### PR TITLE
Refactor database usage to use one Connection per task or request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "stdext",
  "tempfile",
  "tftp_client",
  "tokio",
@@ -2351,6 +2352,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stdext"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af28eeb7c18ac2dbdb255d40bee63f203120e1db6b0024b177746ebec7049c1"
 
 [[package]]
 name = "strsim"

--- a/rack-director/Cargo.toml
+++ b/rack-director/Cargo.toml
@@ -21,12 +21,13 @@ rusqlite = { workspace = true, features = ["uuid"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 env_logger = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 uuid = { version = "1.20.0", features = ["serde"] }
 object_store = { version = "0.13.1", features = ["aws"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["json"] }
+stdext = "0.3.3"
 tempfile = { workspace = true }
 tftp_client = "0.1"
 tokio-test = { workspace = true }

--- a/rack-director/src/database/connection.rs
+++ b/rack-director/src/database/connection.rs
@@ -241,25 +241,55 @@ impl Connection {
 }
 
 /// Represents a Transaction on the connection. Must be closed with commit() or rollback().
+///
+/// If dropped without calling `commit()` or `rollback()`, a best-effort ROLLBACK
+/// is issued via `try_send` so that the connection remains usable for subsequent
+/// operations. The rollback is best-effort: if the channel is full the ROLLBACK
+/// may not be sent, but in practice the channel capacity is 1 and the background
+/// thread is never blocked between operations.
 #[must_use]
 pub struct Transaction<'conn> {
     conn: &'conn mut Connection,
+    /// Set to true once commit() or rollback() has been called so that the
+    /// Drop impl does not issue a redundant ROLLBACK.
+    done: bool,
 }
 
 impl<'conn> Transaction<'conn> {
     async fn new(conn: &'conn mut Connection) -> rusqlite::Result<Self> {
         conn.execute("BEGIN ", ()).await?;
-        Ok(Self { conn })
+        Ok(Self { conn, done: false })
     }
 
     /// Commit the transaction to the database.
-    pub async fn commit(self) -> rusqlite::Result<()> {
+    pub async fn commit(mut self) -> rusqlite::Result<()> {
+        self.done = true;
         self.conn.execute("COMMIT", ()).await.map(|_| ())
     }
 
     /// Rollback the transaction.
-    pub async fn rollback(self) -> rusqlite::Result<()> {
+    pub async fn rollback(mut self) -> rusqlite::Result<()> {
+        self.done = true;
         self.conn.execute("ROLLBACK", ()).await.map(|_| ())
+    }
+}
+
+impl<'conn> Drop for Transaction<'conn> {
+    fn drop(&mut self) {
+        if !self.done {
+            // Issue a best-effort ROLLBACK so the connection is not left inside
+            // an open transaction. We use try_send rather than blocking_send
+            // because blocking_send must not be called from within a Tokio
+            // async context (it would panic).
+            let (reply_tx, _reply_rx) = oneshot::channel();
+            let request: Box<dyn SqlRequest> = Box::new(RequestWrapper::new(
+                Box::new(|conn: &mut rusqlite::Connection| {
+                    let _ = conn.execute_batch("ROLLBACK");
+                }),
+                reply_tx,
+            ));
+            let _ = self.conn.tx.try_send(ControlMessage::Request(request));
+        }
     }
 }
 
@@ -329,5 +359,41 @@ mod tests {
         conn.execute("INSERT INTO foo(x) VALUES (2)", ())
             .await
             .unwrap();
+    }
+
+    /// Verify that dropping a Transaction without calling commit() issues a
+    /// ROLLBACK and leaves the connection in a reusable state.
+    #[tokio::test]
+    async fn transaction_drop_rolls_back() {
+        let mut conn = Connection::open(test_database_path!()).await.unwrap();
+        conn.execute("CREATE TABLE foo (x INTEGER)", ())
+            .await
+            .unwrap();
+
+        {
+            let tx = conn.transaction().await.unwrap();
+            tx.execute("INSERT INTO foo(x) VALUES (1)", ())
+                .await
+                .unwrap();
+            // Drop tx without calling commit() or rollback().
+            // The Drop impl must issue a best-effort ROLLBACK.
+        }
+
+        // Give the background thread a moment to process the ROLLBACK sent via try_send.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // The inserted row must not be visible.
+        let count: i64 = conn
+            .query_one("SELECT COUNT(*) FROM foo", [], |r| r.get(0))
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "implicit rollback must discard the inserted row");
+
+        // The connection must be reusable — starting a new transaction must succeed.
+        let tx2 = conn
+            .transaction()
+            .await
+            .expect("connection must be reusable after implicit rollback");
+        tx2.commit().await.unwrap();
     }
 }

--- a/rack-director/src/database/connection.rs
+++ b/rack-director/src/database/connection.rs
@@ -1,0 +1,333 @@
+use std::{
+    ops::Deref,
+    path::Path,
+    thread::{self, JoinHandle},
+};
+
+use rusqlite::Params;
+use tokio::sync::{mpsc, oneshot};
+
+/// SqlRequest is the function to be called with the rusqlite Connection on the
+/// remote thread.
+trait SqlRequest: Send {
+    fn handle(self: Box<Self>, conn: &mut rusqlite::Connection);
+}
+
+/// Function on conn that can be sent to the sqlite thread
+type SqlFunction<R> = Box<dyn FnOnce(&mut rusqlite::Connection) -> R + Send + 'static>;
+
+/// RequestWrapper wraps a higher level request to respond over a oneshot channel,
+/// so that results may be returned to the originating thread. It implements
+/// SqlRequest.
+struct RequestWrapper<Response: Send> {
+    action: SqlFunction<Response>,
+    reply: oneshot::Sender<Response>,
+}
+
+impl<Response: Send> RequestWrapper<Response> {
+    fn new(action: SqlFunction<Response>, reply: oneshot::Sender<Response>) -> Self {
+        Self { action, reply }
+    }
+}
+
+impl<Response: Send> SqlRequest for RequestWrapper<Response> {
+    fn handle(self: Box<Self>, conn: &mut rusqlite::Connection) {
+        let response = (self.action)(conn);
+        let _ = self.reply.send(response);
+    }
+}
+
+fn start_with_file<P: AsRef<Path>>(
+    path: P,
+    started: oneshot::Sender<rusqlite::Result<mpsc::Sender<ControlMessage>>>,
+) {
+    let conn = match rusqlite::Connection::open(path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            started
+                .send(Err(e))
+                .expect("caller did not wait for a response on started channel");
+            return;
+        }
+    };
+
+    let (tx, rx) = mpsc::channel(1);
+    started
+        .send(Ok(tx))
+        .expect("caller did not wait for a response on started channel");
+
+    sqlite_loop(conn, rx);
+}
+
+/// Macro to get the path to this test's database. Must be called at the top level of the test.
+#[cfg(test)]
+#[macro_export]
+macro_rules! test_database_path {
+    () => {
+        format!("file:{}?mode=memory&cache=shared", stdext::function_name!())
+    };
+}
+
+/// Launched in a background thread to respond to SqlRequest objects.
+fn sqlite_loop(mut conn: rusqlite::Connection, mut channel: mpsc::Receiver<ControlMessage>) {
+    while let Some(msg) = channel.blocking_recv() {
+        match msg {
+            ControlMessage::Request(sql_request) => sql_request.handle(&mut conn),
+            ControlMessage::Close(sender) => {
+                channel.close();
+
+                let mut closers = vec![sender];
+
+                // Drain the queue. Note that this _really_ shouldn't happen since the design is guarded on &mut.
+                while let Some(msg) = channel.blocking_recv() {
+                    match msg {
+                        ControlMessage::Request(sql_request) => sql_request.handle(&mut conn),
+                        ControlMessage::Close(sender2) => closers.push(sender2),
+                    }
+                }
+
+                // Notify requester when closed.
+                closers.into_iter().for_each(|sender| {
+                    let _ = sender.send(());
+                });
+            }
+        }
+    }
+}
+enum ControlMessage {
+    Request(Box<dyn SqlRequest>),
+    Close(oneshot::Sender<()>),
+}
+
+/// A Connection to a sqlite database. Provides a tokio-compatible async interface to
+/// rusqlite.
+pub struct Connection {
+    handle: JoinHandle<()>,
+    tx: mpsc::Sender<ControlMessage>,
+}
+
+impl Connection {
+    /// Open a database
+    pub async fn open<P: AsRef<Path> + Send + 'static>(path: P) -> anyhow::Result<Self> {
+        let (start_tx, start_rx) = oneshot::channel();
+        let handle = thread::spawn(move || start_with_file(path, start_tx));
+        let tx = start_rx.await??;
+
+        Ok(Self { handle, tx })
+    }
+
+    /// Convenience method to prepare and execute a single SQL statement.
+    ///
+    /// On success, returns the number of rows that were changed or inserted or deleted.
+    pub async fn execute<Sql: AsRef<str> + Send + 'static, P: Params + Send + 'static>(
+        &self,
+        sql: Sql,
+        params: P,
+    ) -> rusqlite::Result<usize> {
+        let action: SqlFunction<_> = Box::new(move |conn| conn.execute(sql.as_ref(), params));
+        self.send_request(action).await
+    }
+
+    /// Convenience method to run multiple SQL statements (that cannot take any parameters).
+    pub async fn execute_batch<Sql: AsRef<str> + Send + 'static>(
+        &self,
+        sql: Sql,
+    ) -> rusqlite::Result<()> {
+        let action: SqlFunction<_> = Box::new(move |conn| conn.execute_batch(sql.as_ref()));
+        self.send_request(action).await
+    }
+
+    /// Convenience method to execute a query that is expected to return exactly one row.
+    ///
+    /// Returns Err(QueryReturnedMoreThanOneRow) if the query returns more than one row.
+    ///
+    /// Returns Err(QueryReturnedNoRows) if no results are returned. If the query truly is optional, you can call .optional() on the result of this to get a Result<Option<T>> (requires that the trait rusqlite::OptionalExtension is imported).
+    pub async fn query_one<
+        R: Send + 'static,
+        Sql: AsRef<str> + Send + 'static,
+        P: Params + Send + 'static,
+        F: (FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<R>) + Send + 'static,
+    >(
+        &self,
+        sql: Sql,
+        params: P,
+        f: F,
+    ) -> rusqlite::Result<R> {
+        let action: SqlFunction<_> = Box::new(move |conn| conn.query_one(sql.as_ref(), params, f));
+        self.send_request(action).await
+    }
+
+    /// Convenience method to execute a query that is expected to return a single row.
+    pub async fn query_row<
+        R: Send + 'static,
+        Sql: AsRef<str> + Send + 'static,
+        P: Params + Send + 'static,
+        F: (FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<R>) + Send + 'static,
+    >(
+        &self,
+        sql: Sql,
+        params: P,
+        f: F,
+    ) -> rusqlite::Result<R> {
+        let action: SqlFunction<_> = Box::new(move |conn| conn.query_row(sql.as_ref(), params, f));
+        self.send_request(action).await
+    }
+
+    /// Query Rows and return the results as a Vec<R>
+    pub async fn query<
+        R: Send + 'static,
+        Sql: AsRef<str> + Send + 'static,
+        P: Params + Send + 'static,
+        F: (FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<R>) + Send + 'static,
+    >(
+        &self,
+        sql: Sql,
+        params: P,
+        f: F,
+    ) -> rusqlite::Result<Vec<R>> {
+        let action: SqlFunction<_> = Box::new(move |conn| {
+            let mut stmt = conn.prepare(sql.as_ref())?;
+            stmt.query_map(params, f)?
+                .collect::<rusqlite::Result<Vec<R>>>()
+        });
+        self.send_request(action).await
+    }
+
+    /// Check if table_name exists.
+    pub async fn table_exists<T: AsRef<str> + Send + 'static>(
+        &self,
+        table: T,
+    ) -> rusqlite::Result<bool> {
+        let action: SqlFunction<_> = Box::new(move |conn| conn.table_exists(None, table.as_ref()));
+        self.send_request(action).await
+    }
+
+    /// Start a new Transaction.
+    pub async fn transaction(&mut self) -> rusqlite::Result<Transaction<'_>> {
+        Transaction::new(self).await
+    }
+
+    /// Returns the rowid of the most recent successful INSERT in this connection.
+    pub async fn last_insert_rowid(&self) -> i64 {
+        let action: SqlFunction<_> = Box::new(move |conn| conn.last_insert_rowid());
+        self.send_request(action).await
+    }
+
+    /// Send a request message to the background thread.
+    async fn send_request<R: Send + 'static>(&self, function: SqlFunction<R>) -> R {
+        let (tx, rx) = oneshot::channel();
+        let request = RequestWrapper::new(function, tx);
+        self.tx
+            .send(ControlMessage::Request(Box::new(request)))
+            .await
+            .expect("couldn't send Request to background thread");
+
+        rx.await
+            .expect("didn't receive result from background thread")
+    }
+
+    /// Closes the connection, consuming self.
+    #[allow(unused)]
+    pub async fn close(self) {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(ControlMessage::Close(tx))
+            .await
+            .expect("couldn't send Close request to background thread");
+        rx.await
+            .expect("didn't receive drained notification from background thread");
+        self.handle.join().expect("couldn't join background thread");
+    }
+}
+
+/// Represents a Transaction on the connection. Must be closed with commit() or rollback().
+#[must_use]
+pub struct Transaction<'conn> {
+    conn: &'conn mut Connection,
+}
+
+impl<'conn> Transaction<'conn> {
+    async fn new(conn: &'conn mut Connection) -> rusqlite::Result<Self> {
+        conn.execute("BEGIN ", ()).await?;
+        Ok(Self { conn })
+    }
+
+    /// Commit the transaction to the database.
+    pub async fn commit(self) -> rusqlite::Result<()> {
+        self.conn.execute("COMMIT", ()).await.map(|_| ())
+    }
+
+    /// Rollback the transaction.
+    pub async fn rollback(self) -> rusqlite::Result<()> {
+        self.conn.execute("ROLLBACK", ()).await.map(|_| ())
+    }
+}
+
+impl<'conn> Deref for Transaction<'conn> {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        self.conn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Connection;
+
+    #[tokio::test]
+    async fn empty_params_tuple() {
+        let conn = Connection::open(test_database_path!()).await.unwrap();
+        let n = conn
+            .execute("CREATE TABLE foo (x INTEGER)", ())
+            .await
+            .unwrap();
+        assert_eq!(n, 0); // DDL statements affect 0 rows
+
+        let n = conn
+            .execute("INSERT INTO foo(x) VALUES (?1)", (1,))
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[tokio::test]
+    async fn query() {
+        let conn = Connection::open(test_database_path!()).await.unwrap();
+        let n = conn
+            .execute("CREATE TABLE foo (x INTEGER)", ())
+            .await
+            .unwrap();
+        assert_eq!(n, 0); // DDL statements affect 0 rows
+
+        let n = conn
+            .execute("INSERT INTO foo(x) VALUES (?1)", (1,))
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+
+        let result: Vec<i64> = conn
+            .query("SELECT * FROM foo WHERE x = ?1", (1,), |row| row.get(0))
+            .await
+            .unwrap();
+        assert_eq!(result, vec![1])
+    }
+
+    #[tokio::test]
+    async fn transaction() {
+        let mut conn = Connection::open(test_database_path!()).await.unwrap();
+        conn.execute("CREATE TABLE foo (x INTEGER)", ())
+            .await
+            .unwrap();
+
+        let tx = conn.transaction().await.expect("start transaction");
+        tx.execute("INSERT INTO foo(x) VALUES (1)", ())
+            .await
+            .unwrap();
+        tx.commit().await.expect("commit transaction");
+
+        conn.execute("INSERT INTO foo(x) VALUES (2)", ())
+            .await
+            .unwrap();
+    }
+}

--- a/rack-director/src/database/migrations/migration_11.rs
+++ b/rack-director/src/database/migrations/migration_11.rs
@@ -4,91 +4,156 @@
 //! The table schemas are created by 11.sql, and this code populates them.
 
 use anyhow::Result;
-use rusqlite::{Connection, params};
 use uuid::Uuid;
+
+use crate::database::Connection;
 
 /// Post-migration hook for migration 11: Convert TEXT UUIDs to BLOB
 /// Reads TEXT UUIDs from old tables and inserts as BLOB into new tables
-pub fn convert_uuids(conn: &Connection) -> Result<()> {
+pub async fn convert_uuids(conn: &Connection) -> Result<()> {
     log::info!("Converting TEXT UUIDs to BLOB format...");
 
-    // Convert each table
-    convert_devices_table(conn)?;
-    convert_plans_table(conn)?;
-    convert_lifecycle_transitions_table(conn)?;
-    convert_dhcp_leases_table(conn)?;
-    convert_pending_devices_table(conn)?;
+    convert_devices_table(conn).await?;
+    convert_plans_table(conn).await?;
+    convert_lifecycle_transitions_table(conn).await?;
+    convert_dhcp_leases_table(conn).await?;
+    convert_pending_devices_table(conn).await?;
 
-    // Replace old tables with new tables
-    finalize_migration(conn)?;
+    finalize_migration(conn).await?;
 
     log::info!("UUID conversion complete");
     Ok(())
 }
 
-fn convert_devices_table(conn: &Connection) -> Result<()> {
+/// Parse a TEXT UUID string into its 16-byte BLOB representation.
+fn parse_uuid_bytes(uuid_str: &str, context: &str) -> Result<Vec<u8>> {
+    let uuid = Uuid::parse_str(uuid_str).map_err(|e| {
+        anyhow::anyhow!("Failed to parse UUID '{}' in {}: {}", uuid_str, context, e)
+    })?;
+    Ok(uuid.into_bytes().to_vec())
+}
+
+/// Parse an optional TEXT UUID string into its 16-byte BLOB representation.
+fn parse_optional_uuid_bytes(uuid_str: Option<String>, context: &str) -> Result<Option<Vec<u8>>> {
+    match uuid_str {
+        None => Ok(None),
+        Some(s) => parse_uuid_bytes(&s, context).map(Some),
+    }
+}
+
+async fn convert_devices_table(conn: &Connection) -> Result<()> {
     log::debug!("Converting devices table...");
 
-    let mut stmt = conn.prepare(
-        "SELECT id, uuid, created_at, first_seen_at, last_seen_at, attributes, lifecycle, role_id, architecture FROM devices"
-    )?;
+    type DeviceRow = (
+        i64,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        String,
+        String,
+        Option<i64>,
+        String,
+    );
 
-    let mut rows = stmt.query([])?;
+    let rows: Vec<DeviceRow> = conn
+        .query(
+            "SELECT id, uuid, created_at,
+                NULLIF(first_seen_at, 0),
+                NULLIF(last_seen_at, 0),
+                attributes, lifecycle, role_id, architecture FROM devices",
+            (),
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
+                ))
+            },
+        )
+        .await?;
 
-    while let Some(row) = rows.next()? {
-        let id: i64 = row.get(0)?;
-        let uuid_str: String = row.get(1)?;
-        let created_at: Option<String> = row.get(2).ok();
-        let first_seen_at: Option<String> = row.get(3).ok();
-        let last_seen_at: Option<String> = row.get(4).ok();
-        let attributes: String = row.get(5)?;
-        let lifecycle: String = row.get(6)?;
-        let role_id: Option<i64> = row.get(7)?;
-        let architecture: String = row.get(8)?;
-
-        let uuid = Uuid::parse_str(&uuid_str).map_err(|e| {
-            anyhow::anyhow!("Failed to parse UUID '{}' in devices: {}", uuid_str, e)
-        })?;
-
+    for (
+        id,
+        uuid_str,
+        created_at,
+        first_seen_at,
+        last_seen_at,
+        attributes,
+        lifecycle,
+        role_id,
+        architecture,
+    ) in rows
+    {
+        let uuid_bytes = parse_uuid_bytes(&uuid_str, "devices")?;
         conn.execute(
             "INSERT INTO devices_new (id, uuid, created_at, first_seen_at, last_seen_at, attributes, lifecycle, role_id, architecture)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![id, uuid, created_at, first_seen_at, last_seen_at, attributes, lifecycle, role_id, architecture],
-        )?;
+            (id, uuid_bytes, created_at, first_seen_at, last_seen_at, attributes, lifecycle, role_id, architecture),
+        ).await?;
     }
 
     Ok(())
 }
 
-fn convert_plans_table(conn: &Connection) -> Result<()> {
+async fn convert_plans_table(conn: &Connection) -> Result<()> {
     log::debug!("Converting plans table...");
 
-    let mut stmt = conn.prepare(
-        "SELECT id, device_uuid, status, current_step, total_steps, actions, error_message, created_at, started_at, completed_at FROM plans"
-    )?;
+    type PlanRow = (
+        i64,
+        String,
+        String,
+        i32,
+        i32,
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+        Option<String>,
+    );
 
-    let mut rows = stmt.query([])?;
+    let rows: Vec<PlanRow> = conn.query(
+        "SELECT id, device_uuid, status, current_step, total_steps, actions, error_message, created_at, started_at, completed_at FROM plans",
+        (),
+        |row| Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+            row.get(6)?,
+            row.get(7)?,
+            row.get(8)?,
+            row.get(9)?,
+        )),
+    ).await?;
 
-    while let Some(row) = rows.next()? {
-        let id: i64 = row.get(0)?;
-        let uuid_str: String = row.get(1)?;
-        let status: String = row.get(2)?;
-        let current_step: i32 = row.get(3)?;
-        let total_steps: i32 = row.get(4)?;
-        let actions: String = row.get(5)?;
-        let error_message: Option<String> = row.get(6)?;
-        let created_at: String = row.get(7)?;
-        let started_at: Option<String> = row.get(8)?;
-        let completed_at: Option<String> = row.get(9)?;
-
-        let uuid = Uuid::parse_str(&uuid_str)
-            .map_err(|e| anyhow::anyhow!("Failed to parse UUID '{}' in plans: {}", uuid_str, e))?;
-
+    for (
+        id,
+        uuid_str,
+        status,
+        current_step,
+        total_steps,
+        actions,
+        error_message,
+        created_at,
+        started_at,
+        completed_at,
+    ) in rows
+    {
+        let uuid_bytes = parse_uuid_bytes(&uuid_str, "plans")?;
         conn.execute(
             "INSERT INTO plans_new VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            params![
+            (
                 id,
-                uuid,
+                uuid_bytes,
                 status,
                 current_step,
                 total_steps,
@@ -96,91 +161,132 @@ fn convert_plans_table(conn: &Connection) -> Result<()> {
                 error_message,
                 created_at,
                 started_at,
-                completed_at
-            ],
-        )?;
+                completed_at,
+            ),
+        )
+        .await?;
     }
 
     Ok(())
 }
 
-fn convert_lifecycle_transitions_table(conn: &Connection) -> Result<()> {
+async fn convert_lifecycle_transitions_table(conn: &Connection) -> Result<()> {
     log::debug!("Converting lifecycle_transitions table...");
 
-    let mut stmt = conn.prepare(
-        "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message FROM lifecycle_transitions"
-    )?;
+    type TransitionRow = (
+        i64,
+        String,
+        String,
+        String,
+        Option<i64>,
+        String,
+        Option<String>,
+        Option<bool>,
+        Option<String>,
+    );
 
-    let mut rows = stmt.query([])?;
+    let rows: Vec<TransitionRow> = conn.query(
+        "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message FROM lifecycle_transitions",
+        (),
+        |row| Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+            row.get(6)?,
+            row.get(7)?,
+            row.get(8)?,
+        )),
+    ).await?;
 
-    while let Some(row) = rows.next()? {
-        let id: i64 = row.get(0)?;
-        let uuid_str: String = row.get(1)?;
-        let from_state: String = row.get(2)?;
-        let to_state: String = row.get(3)?;
-        let plan_id: Option<i64> = row.get(4)?;
-        let created_at: String = row.get(5)?;
-        let completed_at: Option<String> = row.get(6)?;
-        let success: Option<bool> = row.get(7)?;
-        let error_message: Option<String> = row.get(8)?;
-
-        let uuid = Uuid::parse_str(&uuid_str).map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to parse UUID '{}' in lifecycle_transitions: {}",
-                uuid_str,
-                e
-            )
-        })?;
-
+    for (
+        id,
+        uuid_str,
+        from_state,
+        to_state,
+        plan_id,
+        created_at,
+        completed_at,
+        success,
+        error_message,
+    ) in rows
+    {
+        let uuid_bytes = parse_uuid_bytes(&uuid_str, "lifecycle_transitions")?;
         conn.execute(
             "INSERT INTO lifecycle_transitions_new VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![
+            (
                 id,
-                uuid,
+                uuid_bytes,
                 from_state,
                 to_state,
                 plan_id,
                 created_at,
                 completed_at,
                 success,
-                error_message
-            ],
-        )?;
+                error_message,
+            ),
+        )
+        .await?;
     }
 
     Ok(())
 }
 
-fn convert_dhcp_leases_table(conn: &Connection) -> Result<()> {
+async fn convert_dhcp_leases_table(conn: &Connection) -> Result<()> {
     log::debug!("Converting dhcp_leases table...");
 
-    let mut stmt = conn.prepare(
-        "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, created_at, updated_at, network_id FROM dhcp_leases"
-    )?;
+    type LeaseRow = (
+        i64,
+        String,
+        String,
+        Option<String>,
+        String,
+        String,
+        String,
+        Option<String>,
+        String,
+        String,
+        Option<i64>,
+    );
 
-    let mut rows = stmt.query([])?;
+    let rows: Vec<LeaseRow> = conn.query(
+        "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, created_at, updated_at, network_id FROM dhcp_leases",
+        (),
+        |row| Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+            row.get(6)?,
+            row.get(7)?,
+            row.get(8)?,
+            row.get(9)?,
+            row.get(10)?,
+        )),
+    ).await?;
 
-    while let Some(row) = rows.next()? {
-        let id: i64 = row.get(0)?;
-        let mac_address: String = row.get(1)?;
-        let ip_address: String = row.get(2)?;
-        let uuid_str: Option<String> = row.get(3)?;
-        let lease_start: String = row.get(4)?;
-        let lease_end: String = row.get(5)?;
-        let state: String = row.get(6)?;
-        let hostname: Option<String> = row.get(7)?;
-        let created_at: String = row.get(8)?;
-        let updated_at: String = row.get(9)?;
-        let network_id: Option<i64> = row.get(10)?;
-
-        let device_uuid = uuid_str
-            .map(|s| Uuid::parse_str(&s))
-            .transpose()
-            .map_err(|e| anyhow::anyhow!("Failed to parse UUID in dhcp_leases: {}", e))?;
-
+    for (
+        id,
+        mac_address,
+        ip_address,
+        uuid_str,
+        lease_start,
+        lease_end,
+        state,
+        hostname,
+        created_at,
+        updated_at,
+        network_id,
+    ) in rows
+    {
+        let device_uuid = parse_optional_uuid_bytes(uuid_str, "dhcp_leases")?;
         conn.execute(
             "INSERT INTO dhcp_leases_new VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-            params![
+            (
                 id,
                 mac_address,
                 ip_address,
@@ -191,53 +297,53 @@ fn convert_dhcp_leases_table(conn: &Connection) -> Result<()> {
                 hostname,
                 created_at,
                 updated_at,
-                network_id
-            ],
-        )?;
+                network_id,
+            ),
+        )
+        .await?;
     }
 
     Ok(())
 }
 
-fn convert_pending_devices_table(conn: &Connection) -> Result<()> {
+async fn convert_pending_devices_table(conn: &Connection) -> Result<()> {
     log::debug!("Converting pending_devices table...");
 
-    let mut stmt = conn.prepare(
-        "SELECT id, mac_address, device_uuid, network_id, created_at, completed_at FROM pending_devices"
-    )?;
+    type PendingRow = (i64, String, Option<String>, i64, String, Option<String>);
 
-    let mut rows = stmt.query([])?;
+    let rows: Vec<PendingRow> = conn.query(
+        "SELECT id, mac_address, device_uuid, network_id, created_at, completed_at FROM pending_devices",
+        (),
+        |row| Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+        )),
+    ).await?;
 
-    while let Some(row) = rows.next()? {
-        let id: i64 = row.get(0)?;
-        let mac_address: String = row.get(1)?;
-        let uuid_str: Option<String> = row.get(2)?;
-        let network_id: i64 = row.get(3)?;
-        let created_at: String = row.get(4)?;
-        let completed_at: Option<String> = row.get(5)?;
-
-        let device_uuid = uuid_str
-            .map(|s| Uuid::parse_str(&s))
-            .transpose()
-            .map_err(|e| anyhow::anyhow!("Failed to parse UUID in pending_devices: {}", e))?;
-
+    for (id, mac_address, uuid_str, network_id, created_at, completed_at) in rows {
+        let device_uuid = parse_optional_uuid_bytes(uuid_str, "pending_devices")?;
         conn.execute(
             "INSERT INTO pending_devices_new VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
+            (
                 id,
                 mac_address,
                 device_uuid,
                 network_id,
                 created_at,
-                completed_at
-            ],
-        )?;
+                completed_at,
+            ),
+        )
+        .await?;
     }
 
     Ok(())
 }
 
-fn finalize_migration(conn: &Connection) -> Result<()> {
+async fn finalize_migration(conn: &Connection) -> Result<()> {
     log::debug!("Finalizing migration: replacing old tables with new tables...");
 
     conn.execute_batch(
@@ -284,7 +390,7 @@ fn finalize_migration(conn: &Connection) -> Result<()> {
 
          -- Re-enable foreign keys
          PRAGMA foreign_keys=ON;"
-    )?;
+    ).await?;
 
     Ok(())
 }

--- a/rack-director/src/database/mod.rs
+++ b/rack-director/src/database/mod.rs
@@ -17,8 +17,10 @@ pub trait ConnectionFactory: Send + Sync {
 
 /// A `ConnectionFactory` backed by a filesystem path to a SQLite database.
 ///
-/// Each call to `open` runs the full migration sequence and returns an
-/// independent connection with no shared state.
+/// Each call to `open` returns an independent connection with no shared state.
+/// Migrations are NOT run on each open call — callers must invoke
+/// `database::run_migrations` once at startup before opening connections
+/// for normal use.
 pub struct DatabaseConnectionFactory {
     path: std::path::PathBuf,
 }

--- a/rack-director/src/database/mod.rs
+++ b/rack-director/src/database/mod.rs
@@ -1,10 +1,56 @@
 mod connection;
 mod migrations;
 
-use std::path::Path;
-
 use anyhow::Result;
 pub use connection::Connection;
+
+/// A factory for opening database connections.
+///
+/// Implementors produce independent `Connection` instances on demand,
+/// allowing callers to open a fresh connection per request or operation
+/// without sharing a single connection across concurrent tasks.
+#[async_trait::async_trait]
+pub trait ConnectionFactory: Send + Sync {
+    /// Open a new database connection.
+    async fn open(&self) -> Result<Connection>;
+}
+
+/// A `ConnectionFactory` backed by a filesystem path to a SQLite database.
+///
+/// Each call to `open` runs the full migration sequence and returns an
+/// independent connection with no shared state.
+pub struct DatabaseConnectionFactory {
+    path: std::path::PathBuf,
+}
+
+impl DatabaseConnectionFactory {
+    /// Create a new factory that opens connections to the SQLite database at `path`.
+    pub fn new(path: std::path::PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionFactory for DatabaseConnectionFactory {
+    async fn open(&self) -> Result<Connection> {
+        Connection::open(self.path.clone()).await
+    }
+}
+
+/// Macro to create a `DatabaseConnectionFactory` pointing at this test's in-memory database.
+///
+/// Must be called at the top level of the test (same scoping rules as `test_database_path!`).
+/// Call `database::run_migrations(&factory).await` before opening connections to ensure the
+/// schema is up to date.
+#[cfg(test)]
+#[macro_export]
+macro_rules! test_connection_factory {
+    () => {
+        crate::database::DatabaseConnectionFactory::new(std::path::PathBuf::from(
+            crate::test_database_path!(),
+        ))
+    };
+}
 
 /// Trait for types that can be constructed from a database row.
 /// Provides a standard interface for row-to-struct conversion.
@@ -54,8 +100,18 @@ const POST_MIGRATION_HOOKS: [Option<PostMigrationHook>; LATEST_VERSION] = [
     None,                                                               // Migration 13
 ];
 
-pub async fn open<T: AsRef<Path> + Send + 'static>(path: T) -> Result<Connection> {
-    let mut conn = Connection::open(path).await?;
+/// Run all pending database migrations against the database opened by `factory`.
+///
+/// This function opens a single connection via the factory, applies any SQL migrations that
+/// have not yet been applied, runs any associated post-migration hooks, and performs
+/// a one-time bad-data cleanup. The migrated connection is returned so that callers can
+/// hold it open — this is important for in-memory SQLite databases, which are destroyed
+/// when all connections close.
+///
+/// Callers should invoke this once at startup before opening any other connections so that
+/// the schema is fully initialised before concurrent factory calls begin.
+pub async fn run_migrations(factory: &dyn ConnectionFactory) -> Result<Connection> {
+    let mut conn = factory.open().await?;
     let current_version = get_or_init_current_migration(&mut conn).await?;
     perform_migrations(&mut conn, current_version).await?;
 
@@ -132,15 +188,17 @@ mod tests {
     use tempfile::tempdir;
 
     #[tokio::test]
-    async fn test_open() {
+    async fn test_run_migrations() {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        assert!(open(db_path).await.is_ok());
+        let factory = DatabaseConnectionFactory::new(db_path);
+        assert!(run_migrations(&factory).await.is_ok());
     }
 
     #[tokio::test]
     async fn test_database_schema() {
-        let conn = open(test_database_path!()).await.unwrap();
+        let factory = test_connection_factory!();
+        let conn = run_migrations(&factory).await.unwrap();
 
         // Test that tables exist
         let table_names: Vec<String> = conn
@@ -162,7 +220,8 @@ mod tests {
     async fn test_device_operations() {
         use uuid::Uuid;
 
-        let conn = open(test_database_path!()).await.unwrap();
+        let factory = test_connection_factory!();
+        let conn = run_migrations(&factory).await.unwrap();
 
         // Test creating a device with BLOB UUID
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
@@ -246,7 +305,8 @@ mod tests {
         assert_eq!(uuid_type, "text");
 
         // Run migration 11
-        let conn2 = open(test_database_path!()).await.unwrap();
+        let factory2 = test_connection_factory!();
+        let conn2 = run_migrations(&factory2).await.unwrap();
 
         // Verify UUIDs are now stored as BLOB
         let uuid_type: String = conn2

--- a/rack-director/src/database/mod.rs
+++ b/rack-director/src/database/mod.rs
@@ -1,9 +1,10 @@
+mod connection;
 mod migrations;
 
 use std::path::Path;
 
 use anyhow::Result;
-use rusqlite::{Connection, params};
+pub use connection::Connection;
 
 /// Trait for types that can be constructed from a database row.
 /// Provides a standard interface for row-to-struct conversion.
@@ -15,46 +16,8 @@ pub trait FromRow: Sized {
     fn from_row(row: &rusqlite::Row) -> rusqlite::Result<Self>;
 }
 
-/// Execute a query and map all rows to a Vec<T>.
-///
-/// This is a convenience function for queries that return multiple rows.
-/// Uses the FromRow trait to convert each row to the target type.
-pub fn query_map_all<T: FromRow>(
-    conn: &Connection,
-    sql: &str,
-    params: &[&dyn rusqlite::types::ToSql],
-) -> rusqlite::Result<Vec<T>> {
-    let mut stmt = conn.prepare(sql)?;
-    let rows = stmt.query_map(params, |row| T::from_row(row))?;
-    rows.collect()
-}
-
-/// Execute a query and return the first row as T.
-///
-/// Returns an error if no rows are found (rusqlite::Error::QueryReturnedNoRows).
-pub fn query_one<T: FromRow>(
-    conn: &Connection,
-    sql: &str,
-    params: &[&dyn rusqlite::types::ToSql],
-) -> rusqlite::Result<T> {
-    conn.query_row(sql, params, |row| T::from_row(row))
-}
-
-/// Execute a query and return the first row as Option<T>.
-///
-/// Returns Ok(None) if no rows are found, Ok(Some(T)) if a row exists.
-pub fn query_optional<T: FromRow>(
-    conn: &Connection,
-    sql: &str,
-    params: &[&dyn rusqlite::types::ToSql],
-) -> rusqlite::Result<Option<T>> {
-    use rusqlite::OptionalExtension;
-    conn.query_row(sql, params, |row| T::from_row(row))
-        .optional()
-}
-
-const LATEST_VERSION: i32 = 13;
-const MIGRATIONS: [&str; LATEST_VERSION as usize] = [
+const LATEST_VERSION: usize = 13;
+const MIGRATIONS: [&str; LATEST_VERSION] = [
     include_str!("migrations/1.sql"),
     include_str!("migrations/2.sql"),
     include_str!("migrations/3.sql"),
@@ -70,124 +33,123 @@ const MIGRATIONS: [&str; LATEST_VERSION as usize] = [
     include_str!("migrations/13.sql"),
 ];
 
+use futures::{FutureExt, future::BoxFuture};
+
 /// Post-migration hooks that run Rust code after SQL migrations
 /// Index corresponds to migration version (1-indexed, so POST_MIGRATION_HOOKS[10] runs after migration 11)
-type PostMigrationHook = fn(&Connection) -> Result<()>;
-const POST_MIGRATION_HOOKS: [Option<PostMigrationHook>; LATEST_VERSION as usize] = [
-    None,                                          // Migration 1
-    None,                                          // Migration 2
-    None,                                          // Migration 3
-    None,                                          // Migration 4
-    None,                                          // Migration 5
-    None,                                          // Migration 6
-    None,                                          // Migration 7
-    None,                                          // Migration 8
-    None,                                          // Migration 9
-    None,                                          // Migration 10
-    Some(migrations::migration_11::convert_uuids), // Migration 11
-    None,                                          // Migration 12
-    None,                                          // Migration 13
+type PostMigrationHook = fn(&Connection) -> BoxFuture<Result<()>>;
+const POST_MIGRATION_HOOKS: [Option<PostMigrationHook>; LATEST_VERSION] = [
+    None,                                                               // Migration 1
+    None,                                                               // Migration 2
+    None,                                                               // Migration 3
+    None,                                                               // Migration 4
+    None,                                                               // Migration 5
+    None,                                                               // Migration 6
+    None,                                                               // Migration 7
+    None,                                                               // Migration 8
+    None,                                                               // Migration 9
+    None,                                                               // Migration 10
+    Some(|conn| migrations::migration_11::convert_uuids(conn).boxed()), // Migration 11
+    None,                                                               // Migration 12
+    None,                                                               // Migration 13
 ];
 
-pub fn open<T: AsRef<Path>>(path: T) -> Result<Connection> {
-    let conn = Connection::open(path)?;
-    let current_version = get_or_init_current_migration(&conn)?;
-    perform_migrations(&conn, current_version)?;
+pub async fn open<T: AsRef<Path> + Send + 'static>(path: T) -> Result<Connection> {
+    let mut conn = Connection::open(path).await?;
+    let current_version = get_or_init_current_migration(&mut conn).await?;
+    perform_migrations(&mut conn, current_version).await?;
 
     // Hack for bad data from Bug #1
     // Note: After migration 11, UUIDs are BLOBs
     // The migration should have already removed this bad data, but we keep this as a safeguard
-    conn.execute(
-        "DELETE FROM devices WHERE uuid = x'7b757569647d'",
-        params![],
-    )
-    .unwrap();
+    conn.execute("DELETE FROM devices WHERE uuid = x'7b757569647d'", ())
+        .await
+        .unwrap();
 
     Ok(conn)
 }
 
-#[cfg(test)]
-pub fn run_migrations(conn: &Connection) -> Result<()> {
-    let current_version = get_or_init_current_migration(conn)?;
-    perform_migrations(conn, current_version)?;
-    Ok(())
-}
-
-fn get_or_init_current_migration(conn: &Connection) -> Result<i32> {
+async fn get_or_init_current_migration(conn: &mut Connection) -> Result<usize> {
     log::debug!("Checking for migrations");
 
-    if conn.table_exists(None, "migrations")? {
-        let version = conn.query_one("SELECT version FROM migrations", [], |r| r.get(0))?;
+    if conn.table_exists("migrations").await? {
+        let version = conn
+            .query_one("SELECT version FROM migrations", [], |r| r.get(0))
+            .await?;
         Ok(version)
     } else {
         conn.execute_batch(
             "CREATE TABLE migrations (version INTEGER);
                   INSERT INTO migrations (version) VALUES (0)",
-        )?;
+        )
+        .await?;
         Ok(0)
     }
 }
 
-fn perform_migrations(conn: &Connection, current_version: i32) -> Result<()> {
+async fn perform_migrations(conn: &mut Connection, current_version: usize) -> Result<()> {
     let mut version = current_version;
     while version < LATEST_VERSION {
         version += 1;
-        perform_migration(conn, version)?;
+
+        let tx = conn.transaction().await?;
+
+        if let Err(e) = perform_migration(&tx, version).await {
+            tx.rollback().await?;
+            return Err(e);
+        }
+
+        tx.commit().await?;
     }
 
     Ok(())
 }
 
-fn perform_migration(conn: &Connection, version: i32) -> Result<()> {
-    // Wrap entire migration in a transaction for atomicity
-    let tx = conn.unchecked_transaction()?;
-
+async fn perform_migration(conn: &Connection, version: usize) -> Result<()> {
     // Run SQL migration
-    if let Err(e) = tx.execute_batch(MIGRATIONS[version as usize - 1]) {
+    if let Err(e) = conn.execute_batch(MIGRATIONS[version - 1]).await {
         log::error!("Couldn't update database. {e}");
         return Err(e.into());
     }
 
     // Run post-migration hook if it exists
-    if let Some(hook) = POST_MIGRATION_HOOKS[version as usize - 1] {
+    if let Some(ref hook) = POST_MIGRATION_HOOKS[version - 1] {
         log::debug!("Running post-migration hook for version {}", version);
-        hook(&tx)?;
+        hook(conn).await?;
     }
 
-    tx.execute("UPDATE migrations SET version = ?1 ", [version])?;
-
-    // Commit the transaction
-    tx.commit()?;
+    conn.execute("UPDATE migrations SET version = ?1 ", [version])
+        .await?;
 
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::test_database_path;
+
     use super::*;
     use tempfile::tempdir;
 
-    #[test]
-    fn test_open() {
+    #[tokio::test]
+    async fn test_open() {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        assert!(open(db_path).is_ok());
+        assert!(open(db_path).await.is_ok());
     }
 
-    #[test]
-    fn test_database_schema() {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let conn = open(db_path).unwrap();
+    #[tokio::test]
+    async fn test_database_schema() {
+        let conn = open(test_database_path!()).await.unwrap();
 
         // Test that tables exist
-        let mut stmt = conn
-            .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-            .unwrap();
-        let table_names: Vec<String> = stmt
-            .query_map([], |row| row.get::<_, String>(0))
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
+        let table_names: Vec<String> = conn
+            .query(
+                "SELECT name FROM sqlite_master WHERE type='table'",
+                (),
+                |row| row.get(0),
+            )
+            .await
             .unwrap();
 
         assert!(table_names.contains(&"devices".to_string()));
@@ -196,53 +158,54 @@ mod tests {
         assert!(table_names.contains(&"migrations".to_string()));
     }
 
-    #[test]
-    fn test_device_operations() {
+    #[tokio::test]
+    async fn test_device_operations() {
         use uuid::Uuid;
 
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let conn = open(db_path).unwrap();
+        let conn = open(test_database_path!()).await.unwrap();
 
         // Test creating a device with BLOB UUID
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
 
         conn.execute(
             "INSERT INTO devices (uuid, lifecycle) VALUES (?1, 'new')",
-            params![test_uuid],
+            (test_uuid,),
         )
+        .await
         .unwrap();
 
         // Test querying the device
-        let mut stmt = conn
-            .prepare("SELECT uuid FROM devices WHERE uuid = ?1")
-            .unwrap();
-        let retrieved_uuid: Uuid = stmt
-            .query_row(params![test_uuid], |row| row.get(0))
+        let retrieved_uuid: Uuid = conn
+            .query_one(
+                "SELECT uuid FROM devices WHERE uuid = ?1",
+                (test_uuid,),
+                |row| row.get(0),
+            )
+            .await
             .unwrap();
 
         assert_eq!(retrieved_uuid, test_uuid);
     }
 
-    #[test]
-    fn test_migration_11_uuid_conversion() {
+    #[tokio::test]
+    async fn test_migration_11_uuid_conversion() {
         use uuid::Uuid;
 
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test_migration.db");
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = Connection::open(test_database_path!()).await.unwrap();
 
         // Set up database to migration 10 (before UUID BLOB migration)
         conn.execute_batch(
             "CREATE TABLE migrations (version INTEGER);
              INSERT INTO migrations (version) VALUES (0)",
         )
+        .await
         .unwrap();
 
         // Run migrations 1-10
         for version in 1..=10 {
-            conn.execute_batch(MIGRATIONS[version - 1]).unwrap();
+            conn.execute_batch(MIGRATIONS[version - 1]).await.unwrap();
             conn.execute("UPDATE migrations SET version = ?1", [version])
+                .await
                 .unwrap();
         }
 
@@ -252,53 +215,54 @@ mod tests {
 
         conn.execute(
             "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', 'x86-64')",
-            params![test_uuid1.to_string()],
+            (test_uuid1.to_string(),),
         )
+        .await
         .unwrap();
 
         conn.execute(
             "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', 'x86-64')",
-            params![test_uuid2.to_string()],
+            (test_uuid2.to_string(),),
         )
+        .await
         .unwrap();
 
         // Insert plan with TEXT device_uuid
         conn.execute(
             "INSERT INTO plans (device_uuid, status, total_steps, actions) VALUES (?1, 'pending', 1, '[]')",
-            params![test_uuid1.to_string()],
-        )
+            (test_uuid1.to_string(),),
+        ).await
         .unwrap();
 
         // Verify UUIDs are stored as TEXT before migration
         let uuid_type: String = conn
             .query_row(
                 "SELECT typeof(uuid) FROM devices WHERE uuid = ?1",
-                params![test_uuid1.to_string()],
+                (test_uuid1.to_string(),),
                 |row| row.get(0),
             )
+            .await
             .unwrap();
         assert_eq!(uuid_type, "text");
 
         // Run migration 11
-        drop(conn);
-        let conn = open(&db_path).unwrap();
+        let conn2 = open(test_database_path!()).await.unwrap();
 
         // Verify UUIDs are now stored as BLOB
-        let uuid_type: String = conn
+        let uuid_type: String = conn2
             .query_row("SELECT typeof(uuid) FROM devices LIMIT 1", [], |row| {
                 row.get(0)
             })
+            .await
             .unwrap();
         assert_eq!(uuid_type, "blob");
 
         // Verify we can read UUIDs as Uuid type
-        let mut stmt = conn
-            .prepare("SELECT uuid FROM devices ORDER BY uuid")
-            .unwrap();
-        let uuids: Vec<Uuid> = stmt
-            .query_map([], |row| row.get(0))
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
+        let uuids: Vec<Uuid> = conn2
+            .query("SELECT uuid FROM devices ORDER BY uuid", (), |row| {
+                row.get(0)
+            })
+            .await
             .unwrap();
 
         assert_eq!(uuids.len(), 2);
@@ -306,8 +270,9 @@ mod tests {
         assert!(uuids.contains(&test_uuid2));
 
         // Verify plan device_uuid was also converted
-        let plan_uuid: Uuid = conn
+        let plan_uuid: Uuid = conn2
             .query_row("SELECT device_uuid FROM plans", [], |row| row.get(0))
+            .await
             .unwrap();
         assert_eq!(plan_uuid, test_uuid1);
     }

--- a/rack-director/src/dhcp/allocator.rs
+++ b/rack-director/src/dhcp/allocator.rs
@@ -159,13 +159,11 @@ mod tests {
     use crate::dhcp::store::LeaseState;
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
 
     async fn create_test_allocator() -> (IpAllocator, i64, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let conn = database::open(db_path).unwrap();
-        let db = Arc::new(Mutex::new(conn));
+        let db = Arc::new(database::open(db_path).await.unwrap());
         let store = DhcpStore::new(db.clone());
 
         // Create test network

--- a/rack-director/src/dhcp/allocator.rs
+++ b/rack-director/src/dhcp/allocator.rs
@@ -3,142 +3,129 @@ use std::collections::HashSet;
 use std::net::Ipv4Addr;
 use uuid::Uuid;
 
-use super::store::DhcpStore;
+use crate::database::Connection;
 
-#[derive(Clone)]
-pub struct IpAllocator {
-    store: DhcpStore,
+use super::store;
+
+/// Allocate IP for a known device (MAC -> UUID mapping exists) within a specific network
+pub async fn allocate_for_device_in_network(
+    conn: &Connection,
+    mac: &str,
+    uuid: &Uuid,
+    network_id: i64,
+) -> Result<Ipv4Addr> {
+    // 1. Check static reservation in this network
+    if let Some(reservation) = store::get_static_reservation(conn, network_id, mac).await? {
+        log::debug!(
+            "Device {} has static reservation {} in network {}",
+            uuid,
+            reservation.ip_address,
+            network_id
+        );
+        return Ok(reservation.ip_address.parse()?);
+    }
+
+    // 2. Check existing lease in this network
+    if let Some(lease) = store::get_lease_by_mac(conn, mac).await?
+        && !lease.is_expired()
+        && lease.network_id == Some(network_id)
+    {
+        log::debug!(
+            "Reusing existing lease for MAC {} in network {}: {}",
+            mac,
+            network_id,
+            lease.ip_address
+        );
+        return Ok(lease.ip_address.parse()?);
+    }
+
+    // 3. Allocate from pools in this network
+    allocate_from_pools(conn, network_id, mac).await
 }
 
-impl IpAllocator {
-    pub fn new(store: DhcpStore) -> Self {
-        Self { store }
+/// Allocate IP for unknown device (no UUID mapping) within a specific network
+pub async fn allocate_for_mac_in_network(
+    conn: &Connection,
+    mac: &str,
+    network_id: i64,
+) -> Result<Ipv4Addr> {
+    // 1. Check static reservation in this network
+    if let Some(reservation) = store::get_static_reservation(conn, network_id, mac).await? {
+        log::debug!(
+            "MAC {} has static reservation {} in network {}",
+            mac,
+            reservation.ip_address,
+            network_id
+        );
+        return Ok(reservation.ip_address.parse()?);
     }
 
-    /// Allocate IP for a known device (MAC -> UUID mapping exists) within a specific network
-    pub async fn allocate_for_device_in_network(
-        &self,
-        mac: &str,
-        uuid: &Uuid,
-        network_id: i64,
-    ) -> Result<Ipv4Addr> {
-        // 1. Check static reservation in this network
-        if let Some(reservation) = self.store.get_static_reservation(network_id, mac).await? {
-            log::debug!(
-                "Device {} has static reservation {} in network {}",
-                uuid,
-                reservation.ip_address,
-                network_id
-            );
-            return Ok(reservation.ip_address.parse()?);
-        }
-
-        // 2. Check existing lease in this network
-        if let Some(lease) = self.store.get_lease_by_mac(mac).await?
-            && !lease.is_expired()
-            && lease.network_id == Some(network_id)
-        {
-            log::debug!(
-                "Reusing existing lease for MAC {} in network {}: {}",
-                mac,
-                network_id,
-                lease.ip_address
-            );
-            return Ok(lease.ip_address.parse()?);
-        }
-
-        // 3. Allocate from pools in this network
-        self.allocate_from_pools(network_id, mac).await
+    // 2. Check existing lease in this network
+    if let Some(lease) = store::get_lease_by_mac(conn, mac).await?
+        && !lease.is_expired()
+        && lease.network_id == Some(network_id)
+    {
+        log::debug!(
+            "Reusing existing lease for MAC {} in network {}: {}",
+            mac,
+            network_id,
+            lease.ip_address
+        );
+        return Ok(lease.ip_address.parse()?);
     }
 
-    /// Allocate IP for unknown device (no UUID mapping) within a specific network
-    pub async fn allocate_for_mac_in_network(
-        &self,
-        mac: &str,
-        network_id: i64,
-    ) -> Result<Ipv4Addr> {
-        // 1. Check static reservation in this network
-        if let Some(reservation) = self.store.get_static_reservation(network_id, mac).await? {
-            log::debug!(
-                "MAC {} has static reservation {} in network {}",
-                mac,
-                reservation.ip_address,
-                network_id
-            );
-            return Ok(reservation.ip_address.parse()?);
-        }
+    // 3. Allocate from pools in this network
+    allocate_from_pools(conn, network_id, mac).await
+}
 
-        // 2. Check existing lease in this network
-        if let Some(lease) = self.store.get_lease_by_mac(mac).await?
-            && !lease.is_expired()
-            && lease.network_id == Some(network_id)
-        {
-            log::debug!(
-                "Reusing existing lease for MAC {} in network {}: {}",
-                mac,
-                network_id,
-                lease.ip_address
-            );
-            return Ok(lease.ip_address.parse()?);
-        }
+/// Allocate from pools within a network (try each pool until success)
+async fn allocate_from_pools(conn: &Connection, network_id: i64, mac: &str) -> Result<Ipv4Addr> {
+    let pools = store::list_pools_for_network(conn, network_id).await?;
 
-        // 3. Allocate from pools in this network
-        self.allocate_from_pools(network_id, mac).await
+    if pools.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No pools configured for network {}",
+            network_id
+        ));
     }
 
-    /// Allocate from pools within a network (try each pool until success)
-    async fn allocate_from_pools(&self, network_id: i64, mac: &str) -> Result<Ipv4Addr> {
-        let pools = self.store.list_pools_for_network(network_id).await?;
+    // Get all active IPs in this network
+    let active_ips: HashSet<Ipv4Addr> = store::get_leases_by_network(conn, network_id)
+        .await?
+        .into_iter()
+        .filter(|l| !l.is_expired())
+        .filter_map(|l| l.ip_address.parse().ok())
+        .collect();
 
-        if pools.is_empty() {
-            return Err(anyhow::anyhow!(
-                "No pools configured for network {}",
-                network_id
-            ));
-        }
+    // Get all statically reserved IPs in this network
+    let reserved_ips: HashSet<Ipv4Addr> = store::list_static_reservations(conn, network_id)
+        .await?
+        .into_iter()
+        .filter_map(|r| r.ip_address.parse().ok())
+        .collect();
 
-        // Get all active IPs in this network
-        let active_ips: HashSet<Ipv4Addr> = self
-            .store
-            .get_leases_by_network(network_id)
-            .await?
-            .into_iter()
-            .filter(|l| !l.is_expired())
-            .filter_map(|l| l.ip_address.parse().ok())
-            .collect();
+    // Try each pool until allocation succeeds
+    for pool in pools {
+        let range = parse_ip_range(&pool.range_start, &pool.range_end)?;
 
-        // Get all statically reserved IPs in this network
-        let reserved_ips: HashSet<Ipv4Addr> = self
-            .store
-            .list_static_reservations(network_id)
-            .await?
-            .into_iter()
-            .filter_map(|r| r.ip_address.parse().ok())
-            .collect();
-
-        // Try each pool until allocation succeeds
-        for pool in pools {
-            let range = parse_ip_range(&pool.range_start, &pool.range_end)?;
-
-            for ip in range {
-                if !active_ips.contains(&ip) && !reserved_ips.contains(&ip) {
-                    log::info!(
-                        "Allocated {} from pool '{}' (network {}) for MAC {}",
-                        ip,
-                        pool.name,
-                        network_id,
-                        mac
-                    );
-                    return Ok(ip);
-                }
+        for ip in range {
+            if !active_ips.contains(&ip) && !reserved_ips.contains(&ip) {
+                log::info!(
+                    "Allocated {} from pool '{}' (network {}) for MAC {}",
+                    ip,
+                    pool.name,
+                    network_id,
+                    mac
+                );
+                return Ok(ip);
             }
         }
-
-        Err(anyhow::anyhow!(
-            "All pools exhausted for network {}",
-            network_id
-        ))
     }
+
+    Err(anyhow::anyhow!(
+        "All pools exhausted for network {}",
+        network_id
+    ))
 }
 
 /// Parse IP range from start and end addresses
@@ -155,48 +142,45 @@ fn parse_ip_range(start: &str, end: &str) -> Result<impl Iterator<Item = Ipv4Add
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
+    use crate::database::{self, DatabaseConnectionFactory};
     use crate::dhcp::store::LeaseState;
+    use crate::test_connection_factory;
     use std::sync::Arc;
-    use tempfile::tempdir;
 
-    async fn create_test_allocator() -> (IpAllocator, i64, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-        let store = DhcpStore::new(db.clone());
+    async fn create_test_db(
+        factory: DatabaseConnectionFactory,
+    ) -> (Arc<crate::database::Connection>, i64) {
+        let db = Arc::new(database::run_migrations(&factory).await.unwrap());
 
         // Create test network
-        let network = store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+        let network = store::create_network(
+            &db,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Create test pool
-        store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        store::create_pool(&db, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
-        (IpAllocator::new(store), network.id, temp_dir)
+        (db, network.id)
     }
 
     #[tokio::test]
     async fn test_allocate_for_mac_in_network() {
-        let (allocator, network_id, _temp_dir) = create_test_allocator().await;
+        let (db, network_id) = create_test_db(test_connection_factory!()).await;
         let mac = "aa:bb:cc:dd:ee:ff";
 
         // Allocate IP in test network
-        let ip = allocator
-            .allocate_for_mac_in_network(mac, network_id)
+        let ip = allocate_for_mac_in_network(&db, mac, network_id)
             .await
             .unwrap();
         assert_eq!(ip.to_string(), "10.0.0.100"); // First IP in test range
@@ -204,32 +188,29 @@ mod tests {
 
     #[tokio::test]
     async fn test_allocate_reuses_existing_lease() {
-        let (allocator, network_id, _temp_dir) = create_test_allocator().await;
+        let (db, network_id) = create_test_db(test_connection_factory!()).await;
         let mac = "aa:bb:cc:dd:ee:ff";
 
         // First allocation
-        let ip1 = allocator
-            .allocate_for_mac_in_network(mac, network_id)
+        let ip1 = allocate_for_mac_in_network(&db, mac, network_id)
             .await
             .unwrap();
 
         // Create lease
-        allocator
-            .store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip1,
-                None,
-                LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &db,
+            mac,
+            &ip1,
+            None,
+            LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Second allocation should return same IP
-        let ip2 = allocator
-            .allocate_for_mac_in_network(mac, network_id)
+        let ip2 = allocate_for_mac_in_network(&db, mac, network_id)
             .await
             .unwrap();
         assert_eq!(ip1, ip2);
@@ -237,29 +218,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_allocate_different_ips_for_different_macs() {
-        let (allocator, network_id, _temp_dir) = create_test_allocator().await;
+        let (db, network_id) = create_test_db(test_connection_factory!()).await;
         let mac1 = "aa:bb:cc:dd:ee:ff";
         let mac2 = "11:22:33:44:55:66";
 
-        let ip1 = allocator
-            .allocate_for_mac_in_network(mac1, network_id)
+        let ip1 = allocate_for_mac_in_network(&db, mac1, network_id)
             .await
             .unwrap();
-        allocator
-            .store
-            .create_or_update_lease_with_network(
-                mac1,
-                &ip1,
-                None,
-                LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &db,
+            mac1,
+            &ip1,
+            None,
+            LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
-        let ip2 = allocator
-            .allocate_for_mac_in_network(mac2, network_id)
+        let ip2 = allocate_for_mac_in_network(&db, mac2, network_id)
             .await
             .unwrap();
 
@@ -270,20 +248,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_reservation_takes_priority() {
-        let (allocator, network_id, _temp_dir) = create_test_allocator().await;
+        let (db, network_id) = create_test_db(test_connection_factory!()).await;
         let mac = "aa:bb:cc:dd:ee:ff";
         let static_ip = "10.0.0.50";
 
         // Create static reservation
-        allocator
-            .store
-            .create_static_reservation(network_id, mac, static_ip, None)
+        store::create_static_reservation(&db, network_id, mac, static_ip, None)
             .await
             .unwrap();
 
         // Allocation should return the static IP
-        let ip = allocator
-            .allocate_for_mac_in_network(mac, network_id)
+        let ip = allocate_for_mac_in_network(&db, mac, network_id)
             .await
             .unwrap();
         assert_eq!(ip.to_string(), static_ip);
@@ -291,41 +266,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_reservation_overrides_existing_lease() {
-        let (allocator, network_id, _temp_dir) = create_test_allocator().await;
+        let (db, network_id) = create_test_db(test_connection_factory!()).await;
         let mac = "aa:bb:cc:dd:ee:ff";
 
         // First, allocate IP from pool
-        let ip1 = allocator
-            .allocate_for_mac_in_network(mac, network_id)
+        let ip1 = allocate_for_mac_in_network(&db, mac, network_id)
             .await
             .unwrap();
         assert_eq!(ip1.to_string(), "10.0.0.100"); // First IP in pool
 
         // Create an active lease for this IP
-        allocator
-            .store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip1,
-                None,
-                LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &db,
+            mac,
+            &ip1,
+            None,
+            LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Admin creates a static reservation for a different IP
         let static_ip = "10.0.0.50";
-        allocator
-            .store
-            .create_static_reservation(network_id, mac, static_ip, None)
+        store::create_static_reservation(&db, network_id, mac, static_ip, None)
             .await
             .unwrap();
 
         // Next allocation should return the static IP, not the existing lease IP
-        let ip2 = allocator
-            .allocate_for_mac_in_network(mac, network_id)
+        let ip2 = allocate_for_mac_in_network(&db, mac, network_id)
             .await
             .unwrap();
         assert_eq!(

--- a/rack-director/src/dhcp/device_resolution.rs
+++ b/rack-director/src/dhcp/device_resolution.rs
@@ -96,13 +96,11 @@ mod tests {
     use crate::database;
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
 
     async fn create_test_resolver() -> DirectorDeviceResolver {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let conn = database::open(db_path).unwrap();
-        let db = Arc::new(Mutex::new(conn));
+        let db = Arc::new(database::open(db_path).await.unwrap());
         let director = Director::new(db.clone());
         DirectorDeviceResolver::new(director)
     }
@@ -126,7 +124,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_returns_not_pending_for_unknown() {
         let resolver = create_test_resolver().await;
-        let ctx = resolver.resolve("11:22:33:44:55:66", None).await.unwrap();
+        let _ctx = resolver.resolve("11:22:33:44:55:66", None).await.unwrap();
     }
 
     #[tokio::test]

--- a/rack-director/src/dhcp/device_resolution.rs
+++ b/rack-director/src/dhcp/device_resolution.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use uuid::Uuid;
 
+use crate::database::Connection;
 use crate::director::Director;
 
 /// Pre-resolved device context for DHCP handling.
@@ -19,29 +20,55 @@ pub trait DeviceResolver: Send + Sync {
     /// Resolution priority:
     /// 1. If GUID is provided and matches a known device, use that device
     /// 2. Otherwise, fall back to MAC-based resolution
-    async fn resolve(&self, mac: &str, guid: Option<&Uuid>) -> Result<DeviceContext>;
+    async fn resolve(
+        &self,
+        conn: &Connection,
+        mac: &str,
+        guid: Option<&Uuid>,
+    ) -> Result<DeviceContext>;
 
     /// Notify that a lease has been activated for a device.
-    async fn on_lease_activated(&self, uuid: &Uuid, ip: &str, mac: &str) -> Result<()>;
+    async fn on_lease_activated(
+        &self,
+        conn: &Connection,
+        uuid: &Uuid,
+        ip: &str,
+        mac: &str,
+    ) -> Result<()>;
 }
 
-/// DeviceResolver implementation backed by the Director service.
-pub struct DirectorDeviceResolver {
-    director: Director,
-}
+/// Stateless DeviceResolver implementation backed by the Director service.
+///
+/// Each call constructs a short-lived `Director` from the provided connection, so no
+/// connection is stored here. This keeps `DirectorDeviceResolver` cheaply cloneable
+/// and `Send + Sync`.
+pub struct DirectorDeviceResolver;
 
 impl DirectorDeviceResolver {
-    pub fn new(director: Director) -> Self {
-        Self { director }
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DirectorDeviceResolver {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 #[async_trait]
 impl DeviceResolver for DirectorDeviceResolver {
-    async fn resolve(&self, mac: &str, guid: Option<&Uuid>) -> Result<DeviceContext> {
+    async fn resolve(
+        &self,
+        conn: &Connection,
+        mac: &str,
+        guid: Option<&Uuid>,
+    ) -> Result<DeviceContext> {
+        let director = Director::new(conn);
+
         // Try GUID-based resolution first if GUID is provided
         let mut device_uuid = if let Some(guid) = guid {
-            if self.director.device_exists(guid).await? {
+            if director.device_exists(guid).await? {
                 log::debug!("Resolved device {} via GUID", guid);
                 Some(*guid)
             } else {
@@ -53,9 +80,9 @@ impl DeviceResolver for DirectorDeviceResolver {
 
         // Fall back to MAC-based resolution if GUID didn't match
         if device_uuid.is_none() {
-            device_uuid = self.director.find_device_by_mac(mac).await?;
+            device_uuid = director.find_device_by_mac(mac).await?;
             if device_uuid.is_none()
-                && let Some(bmc_uuid) = self.director.find_device_by_bmc_mac(mac).await?
+                && let Some(bmc_uuid) = director.find_device_by_bmc_mac(mac).await?
             {
                 log::info!("MAC {} is a BMC for device {}", mac, bmc_uuid);
                 device_uuid = Some(bmc_uuid);
@@ -64,7 +91,7 @@ impl DeviceResolver for DirectorDeviceResolver {
 
         // Check if interface is disabled
         let (is_disabled, disable_reason) = if let Some(uuid) = &device_uuid {
-            let interfaces = self.director.get_network_interfaces(uuid).await?;
+            let interfaces = director.get_network_interfaces(uuid).await?;
             if let Some(iface) = interfaces.iter().find(|i| i.mac_address == mac) {
                 if iface.disabled {
                     (true, iface.warning_label.clone())
@@ -85,30 +112,36 @@ impl DeviceResolver for DirectorDeviceResolver {
         })
     }
 
-    async fn on_lease_activated(&self, uuid: &Uuid, ip: &str, mac: &str) -> Result<()> {
-        self.director.set_device_ip_address(uuid, ip, mac).await
+    async fn on_lease_activated(
+        &self,
+        conn: &Connection,
+        uuid: &Uuid,
+        ip: &str,
+        mac: &str,
+    ) -> Result<()> {
+        let director = Director::new(conn);
+        director.set_device_ip_address(uuid, ip, mac).await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
-    use std::sync::Arc;
-    use tempfile::tempdir;
+    use crate::database::{self, DatabaseConnectionFactory};
+    use crate::test_connection_factory;
 
-    async fn create_test_resolver() -> DirectorDeviceResolver {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-        let director = Director::new(db.clone());
-        DirectorDeviceResolver::new(director)
+    async fn create_test_db(factory: DatabaseConnectionFactory) -> database::Connection {
+        database::run_migrations(&factory).await.unwrap()
     }
 
     #[tokio::test]
     async fn test_resolve_unknown_mac() {
-        let resolver = create_test_resolver().await;
-        let ctx = resolver.resolve("aa:bb:cc:dd:ee:ff", None).await.unwrap();
+        let conn = create_test_db(test_connection_factory!()).await;
+        let resolver = DirectorDeviceResolver::new();
+        let ctx = resolver
+            .resolve(&conn, "aa:bb:cc:dd:ee:ff", None)
+            .await
+            .unwrap();
         assert!(ctx.device_uuid.is_none());
         assert!(!ctx.is_disabled);
         assert!(ctx.disable_reason.is_none());
@@ -116,27 +149,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_returns_not_disabled_for_unknown() {
-        let resolver = create_test_resolver().await;
-        let ctx = resolver.resolve("11:22:33:44:55:66", None).await.unwrap();
+        let conn = create_test_db(test_connection_factory!()).await;
+        let resolver = DirectorDeviceResolver::new();
+        let ctx = resolver
+            .resolve(&conn, "11:22:33:44:55:66", None)
+            .await
+            .unwrap();
         assert!(!ctx.is_disabled);
     }
 
     #[tokio::test]
     async fn test_resolve_returns_not_pending_for_unknown() {
-        let resolver = create_test_resolver().await;
-        let _ctx = resolver.resolve("11:22:33:44:55:66", None).await.unwrap();
+        let conn = create_test_db(test_connection_factory!()).await;
+        let resolver = DirectorDeviceResolver::new();
+        let _ctx = resolver
+            .resolve(&conn, "11:22:33:44:55:66", None)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn test_resolve_with_guid_no_match() {
-        let resolver = create_test_resolver().await;
+        let conn = create_test_db(test_connection_factory!()).await;
+        let resolver = DirectorDeviceResolver::new();
 
         // Use a GUID that doesn't exist in the database
         let non_existent_guid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
 
         // Resolve with non-matching GUID should return None for device_uuid
         let ctx = resolver
-            .resolve("aa:bb:cc:dd:ee:ff", Some(&non_existent_guid))
+            .resolve(&conn, "aa:bb:cc:dd:ee:ff", Some(&non_existent_guid))
             .await
             .unwrap();
         assert_eq!(ctx.device_uuid, None);
@@ -144,10 +186,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_without_guid() {
-        let resolver = create_test_resolver().await;
+        let conn = create_test_db(test_connection_factory!()).await;
+        let resolver = DirectorDeviceResolver::new();
 
         // Resolve without GUID should use MAC-based resolution (returns None for unknown MAC)
-        let ctx = resolver.resolve("aa:bb:cc:dd:ee:ff", None).await.unwrap();
+        let ctx = resolver
+            .resolve(&conn, "aa:bb:cc:dd:ee:ff", None)
+            .await
+            .unwrap();
         assert_eq!(ctx.device_uuid, None);
     }
 }

--- a/rack-director/src/dhcp/handler.rs
+++ b/rack-director/src/dhcp/handler.rs
@@ -10,12 +10,13 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use tokio::net::UdpSocket;
 
-use super::allocator::IpAllocator;
+use super::allocator;
 use super::boot_config::BootConfigProvider;
 use super::device_resolution::{DeviceContext, DeviceResolver};
 use super::message_builder;
 use super::request::{RequestContext, extract_server_identifier};
-use super::store::{DhcpNetwork, DhcpStore, LeaseState, format_mac};
+use super::store::{self, DhcpNetwork, LeaseState, format_mac};
+use crate::database::{Connection, ConnectionFactory};
 
 /// Determines the appropriate vendor class identifier (Option 60) based on client architecture.
 ///
@@ -54,25 +55,22 @@ fn determine_vendor_class_identifier(client_arch: Option<Architecture>) -> &'sta
 
 #[derive(Clone)]
 pub struct DhcpHandler {
-    store: DhcpStore,
+    db: Arc<dyn ConnectionFactory>,
     device_resolver: Arc<dyn DeviceResolver>,
-    allocator: IpAllocator,
     boot_config: BootConfigProvider,
     server_identifier: Ipv4Addr,
 }
 
 impl DhcpHandler {
     pub fn new(
-        store: DhcpStore,
+        db: Arc<dyn ConnectionFactory>,
         device_resolver: Arc<dyn DeviceResolver>,
-        allocator: IpAllocator,
         boot_config: BootConfigProvider,
         server_identifier: Ipv4Addr,
     ) -> Self {
         Self {
-            store,
+            db,
             device_resolver,
-            allocator,
             boot_config,
             server_identifier,
         }
@@ -95,6 +93,9 @@ impl DhcpHandler {
 
         trace!("DHCP: Received packet {:?}", msg);
 
+        // Open one connection per packet to avoid shared-connection contention
+        let conn = self.db.open().await?;
+
         // Extract relay agent address (giaddr)
         let relay_agent = if msg.giaddr() != Ipv4Addr::UNSPECIFIED {
             Some(msg.giaddr())
@@ -103,7 +104,7 @@ impl DhcpHandler {
         };
 
         // Match to network based on relay agent
-        let network = match self.store.get_network_by_relay(relay_agent).await? {
+        let network = match store::get_network_by_relay(&conn, relay_agent).await? {
             Some(network) => network,
             None => {
                 log::warn!("No network found for relay agent {:?}", relay_agent);
@@ -117,14 +118,14 @@ impl DhcpHandler {
         );
 
         let response = match msg.opts().msg_type() {
-            Some(MessageType::Discover) => self.handle_discover(&msg, &network).await?,
-            Some(MessageType::Request) => self.handle_request(&msg, &network).await?,
+            Some(MessageType::Discover) => self.handle_discover(&conn, &msg, &network).await?,
+            Some(MessageType::Request) => self.handle_request(&conn, &msg, &network).await?,
             Some(MessageType::Release) => {
-                self.handle_release(&msg).await?;
+                self.handle_release(&conn, &msg).await?;
                 None
             }
             Some(MessageType::Decline) => {
-                self.handle_decline(&msg).await?;
+                self.handle_decline(&conn, &msg).await?;
                 None
             }
             _ => {
@@ -174,6 +175,7 @@ impl DhcpHandler {
 
     async fn handle_discover(
         &self,
+        conn: &Connection,
         msg: &Message,
         network: &DhcpNetwork,
     ) -> Result<Option<Message>> {
@@ -191,7 +193,7 @@ impl DhcpHandler {
 
         let dev_ctx = self
             .device_resolver
-            .resolve(&req_ctx.mac, req_ctx.guid.as_ref())
+            .resolve(conn, &req_ctx.mac, req_ctx.guid.as_ref())
             .await?;
 
         if dev_ctx.is_disabled {
@@ -211,30 +213,26 @@ impl DhcpHandler {
         // Allocate or retrieve existing IP in this network
         let ip = if let Some(uuid) = &dev_ctx.device_uuid {
             debug!("Device UUID {} found for MAC {}", uuid, req_ctx.mac);
-            self.allocator
-                .allocate_for_device_in_network(&req_ctx.mac, uuid, network.id)
-                .await?
+            allocator::allocate_for_device_in_network(conn, &req_ctx.mac, uuid, network.id).await?
         } else {
             debug!(
                 "No device UUID found for MAC {}, allocating from pool",
                 req_ctx.mac
             );
-            self.allocator
-                .allocate_for_mac_in_network(&req_ctx.mac, network.id)
-                .await?
+            allocator::allocate_for_mac_in_network(conn, &req_ctx.mac, network.id).await?
         };
 
         // Create lease in 'offered' state
-        self.store
-            .create_or_update_lease_with_network(
-                &req_ctx.mac,
-                &ip,
-                dev_ctx.device_uuid.as_ref(),
-                LeaseState::Offered,
-                network.lease_duration,
-                network.id,
-            )
-            .await?;
+        store::create_or_update_lease_with_network(
+            conn,
+            &req_ctx.mac,
+            &ip,
+            dev_ctx.device_uuid.as_ref(),
+            LeaseState::Offered,
+            network.lease_duration,
+            network.id,
+        )
+        .await?;
 
         let offer = self
             .build_offer(msg, ip, network, &req_ctx, &dev_ctx)
@@ -249,6 +247,7 @@ impl DhcpHandler {
 
     async fn handle_request(
         &self,
+        conn: &Connection,
         msg: &Message,
         network: &DhcpNetwork,
     ) -> Result<Option<Message>> {
@@ -281,7 +280,7 @@ impl DhcpHandler {
 
         let dev_ctx = self
             .device_resolver
-            .resolve(&req_ctx.mac, req_ctx.guid.as_ref())
+            .resolve(conn, &req_ctx.mac, req_ctx.guid.as_ref())
             .await?;
 
         if dev_ctx.is_disabled {
@@ -311,10 +310,8 @@ impl DhcpHandler {
         debug!("Requested IP: {}", requested_ip);
 
         // Check for static reservation - takes priority over everything
-        let static_reservation = self
-            .store
-            .get_static_reservation(network.id, &req_ctx.mac)
-            .await?;
+        let static_reservation =
+            store::get_static_reservation(conn, network.id, &req_ctx.mac).await?;
 
         if let Some(reservation) = &static_reservation {
             let reserved_ip: Ipv4Addr = reservation.ip_address.parse()?;
@@ -329,20 +326,20 @@ impl DhcpHandler {
             }
 
             // Static reservation matches requested IP - update or create lease
-            self.store
-                .create_or_update_lease_with_network(
-                    &req_ctx.mac,
-                    &reserved_ip,
-                    dev_ctx.device_uuid.as_ref(),
-                    LeaseState::Active,
-                    network.lease_duration,
-                    network.id,
-                )
-                .await?;
+            store::create_or_update_lease_with_network(
+                conn,
+                &req_ctx.mac,
+                &reserved_ip,
+                dev_ctx.device_uuid.as_ref(),
+                LeaseState::Active,
+                network.lease_duration,
+                network.id,
+            )
+            .await?;
 
             if let Some(uuid) = &dev_ctx.device_uuid {
                 self.device_resolver
-                    .on_lease_activated(uuid, &reserved_ip.to_string(), &req_ctx.mac)
+                    .on_lease_activated(conn, uuid, &reserved_ip.to_string(), &req_ctx.mac)
                     .await?;
             }
 
@@ -358,7 +355,7 @@ impl DhcpHandler {
         }
 
         // No static reservation - validate request matches our offer
-        let lease = self.store.get_lease_by_mac(&req_ctx.mac).await?;
+        let lease = store::get_lease_by_mac(conn, &req_ctx.mac).await?;
         if let Some(lease) = lease {
             let lease_ip: Ipv4Addr = lease.ip_address.parse()?;
             if lease_ip != requested_ip {
@@ -370,10 +367,10 @@ impl DhcpHandler {
             }
 
             // Update lease to 'active'
-            self.store.activate_lease(&req_ctx.mac).await?;
+            store::activate_lease(conn, &req_ctx.mac).await?;
             if let Some(uuid) = &dev_ctx.device_uuid {
                 self.device_resolver
-                    .on_lease_activated(uuid, &lease_ip.to_string(), &req_ctx.mac)
+                    .on_lease_activated(conn, uuid, &lease_ip.to_string(), &req_ctx.mac)
                     .await?;
             }
 
@@ -392,25 +389,25 @@ impl DhcpHandler {
         }
     }
 
-    async fn handle_release(&self, msg: &Message) -> Result<()> {
+    async fn handle_release(&self, conn: &Connection, msg: &Message) -> Result<()> {
         let mac = msg.chaddr();
         let mac_str = format_mac(mac);
 
         info!("DHCP RELEASE from MAC {}", mac_str);
 
-        self.store.release_lease(&mac_str).await?;
+        store::release_lease(conn, &mac_str).await?;
 
         Ok(())
     }
 
-    async fn handle_decline(&self, msg: &Message) -> Result<()> {
+    async fn handle_decline(&self, conn: &Connection, msg: &Message) -> Result<()> {
         let mac = msg.chaddr();
         let mac_str = format_mac(mac);
 
         warn!("DHCP DECLINE from MAC {}", mac_str);
 
         // Mark lease as released to prevent reuse
-        self.store.release_lease(&mac_str).await?;
+        store::release_lease(conn, &mac_str).await?;
 
         Ok(())
     }
@@ -473,10 +470,12 @@ mod tests {
     use dhcproto::v4::Opcode;
 
     use super::*;
+    use crate::test_connection_factory;
 
     #[tokio::test]
     async fn test_server_identifier_in_offer() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a minimal DISCOVER message
         let mut discover = Message::default();
@@ -488,7 +487,7 @@ mod tests {
             .insert(v4::DhcpOption::MessageType(MessageType::Discover));
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Create contexts
         let req_ctx = RequestContext::from_message(&discover);
@@ -531,7 +530,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_identifier_in_nak() {
-        let handler = create_test_handler().await;
+        let handler = create_test_handler(test_connection_factory!()).await;
 
         // Create a minimal REQUEST message
         let mut request = Message::default();
@@ -568,40 +567,38 @@ mod tests {
     async fn test_custom_server_identifier() {
         use super::super::device_resolution::DirectorDeviceResolver;
         use crate::boot_files::FilesystemBootFileProvider;
-        use crate::database;
-        use crate::director::Director;
+        use crate::database::DatabaseConnectionFactory;
         use std::sync::Arc;
         use tempfile::tempdir;
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-        let store = DhcpStore::new(db.clone());
+        let factory: Arc<dyn crate::database::ConnectionFactory> =
+            Arc::new(DatabaseConnectionFactory::new(db_path));
+        let conn = crate::database::run_migrations(factory.as_ref())
+            .await
+            .unwrap();
 
         // Create test network
-        let network = store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+        let network = store::create_network(
+            &conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Create test pool
-        store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        store::create_pool(&conn, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
-        let director = Director::new(db.clone());
-
-        let device_resolver = Arc::new(DirectorDeviceResolver::new(director));
-        let allocator = IpAllocator::new(store.clone());
+        let device_resolver = Arc::new(DirectorDeviceResolver::new());
 
         // Create a temporary boot files directory for testing
         let boot_files_dir = temp_dir.path().join("boot_files");
@@ -617,13 +614,7 @@ mod tests {
 
         // Use a custom server identifier different from gateway
         let custom_server_id: Ipv4Addr = "192.168.1.50".parse().unwrap();
-        let handler = DhcpHandler::new(
-            store.clone(),
-            device_resolver,
-            allocator,
-            boot_config,
-            custom_server_id,
-        );
+        let handler = DhcpHandler::new(factory, device_resolver, boot_config, custom_server_id);
 
         // Verify the handler stores the custom value
         assert_eq!(
@@ -632,7 +623,7 @@ mod tests {
         );
 
         // Get the test network we just created
-        let network = store.get_network(network.id).await.unwrap();
+        let network = store::get_network(&conn, network.id).await.unwrap();
 
         // Build an OFFER and verify it uses the custom identifier
         let mut discover = Message::default();
@@ -680,45 +671,47 @@ mod tests {
         );
     }
 
-    async fn create_test_handler_with_store() -> (DhcpHandler, DhcpStore, i64, tempfile::TempDir) {
+    async fn create_test_handler_with_store(
+        factory: crate::database::DatabaseConnectionFactory,
+    ) -> (
+        DhcpHandler,
+        crate::database::Connection,
+        i64,
+        tempfile::TempDir,
+    ) {
         use super::super::device_resolution::DirectorDeviceResolver;
         use crate::boot_files::FilesystemBootFileProvider;
         use crate::database;
-        use crate::director::Director;
         use std::sync::Arc;
         use tempfile::tempdir;
 
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-        let store = DhcpStore::new(db.clone());
+        let factory: Arc<dyn crate::database::ConnectionFactory> = Arc::new(factory);
+        // Run migrations and get connection for setup and test assertions
+        let conn = database::run_migrations(factory.as_ref()).await.unwrap();
 
         // Create test network
-        let network = store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+        let network = store::create_network(
+            &conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Create test pool
-        store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        store::create_pool(&conn, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
-        let director = Director::new(db.clone());
-
-        let device_resolver = Arc::new(DirectorDeviceResolver::new(director));
-        let allocator = IpAllocator::new(store.clone());
+        let device_resolver = Arc::new(DirectorDeviceResolver::new());
 
         // Create a temporary boot files directory for testing
+        let temp_dir = tempdir().unwrap();
         let boot_files_dir = temp_dir.path().join("boot_files");
         std::fs::create_dir_all(&boot_files_dir).unwrap();
         let boot_file_provider =
@@ -731,24 +724,20 @@ mod tests {
         );
         let server_identifier = "10.0.0.1".parse().unwrap();
 
-        let handler = DhcpHandler::new(
-            store.clone(),
-            device_resolver,
-            allocator,
-            boot_config,
-            server_identifier,
-        );
-        (handler, store, network.id, temp_dir)
+        let handler = DhcpHandler::new(factory, device_resolver, boot_config, server_identifier);
+        (handler, conn, network.id, temp_dir)
     }
 
-    async fn create_test_handler() -> DhcpHandler {
-        let (handler, _store, _network_id, _temp_dir) = create_test_handler_with_store().await;
+    async fn create_test_handler(
+        factory: crate::database::DatabaseConnectionFactory,
+    ) -> DhcpHandler {
+        let (handler, _db, _network_id, _temp_dir) = create_test_handler_with_store(factory).await;
         handler
     }
 
     #[tokio::test]
     async fn test_option_60_default_pxe() {
-        let handler = create_test_handler().await;
+        let handler = create_test_handler(test_connection_factory!()).await;
 
         // Create a minimal REQUEST message without architecture
         let mut request = Message::default();
@@ -881,7 +870,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_vendor_class_identifier_in_offer_http_boot() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a DISCOVER message with HTTP boot architecture (14)
         let mut discover = Message::default();
@@ -898,7 +888,7 @@ mod tests {
             ));
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Create contexts
         let req_ctx = RequestContext::from_message(&discover);
@@ -941,7 +931,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_vendor_class_identifier_in_offer_traditional_pxe() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a DISCOVER message with traditional UEFI architecture (7)
         let mut discover = Message::default();
@@ -958,7 +949,7 @@ mod tests {
             ));
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Create contexts
         let req_ctx = RequestContext::from_message(&discover);
@@ -1001,7 +992,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_vendor_class_identifier_in_ack_http_boot() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a REQUEST message with HTTP boot architecture (15)
         let mut request = Message::default();
@@ -1018,7 +1010,7 @@ mod tests {
             ));
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Create contexts
         let req_ctx = RequestContext::from_message(&request);
@@ -1063,22 +1055,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_request_matching_server_id() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a lease first
         let mac = "aa:bb:cc:dd:ee:ff";
         let ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
-        store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip,
-                None,
-                LeaseState::Offered,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &ip,
+            None,
+            LeaseState::Offered,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Create a REQUEST message with matching server ID
         let mut request = Message::default();
@@ -1096,10 +1089,13 @@ mod tests {
             .insert(v4::DhcpOption::ServerIdentifier(handler.server_identifier));
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Handle the request
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should receive an ACK
         assert!(
@@ -1125,22 +1121,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_request_non_matching_server_id() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a lease first
         let mac = "aa:bb:cc:dd:ee:ff";
         let ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
-        store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip,
-                None,
-                LeaseState::Offered,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &ip,
+            None,
+            LeaseState::Offered,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Create a REQUEST message with non-matching server ID
         let wrong_server_id: Ipv4Addr = "192.168.1.99".parse().unwrap();
@@ -1164,10 +1161,13 @@ mod tests {
             .insert(v4::DhcpOption::ServerIdentifier(wrong_server_id));
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Handle the request
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should NOT respond (silently ignore)
         assert!(
@@ -1178,22 +1178,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_request_without_server_id() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a lease first
         let mac = "aa:bb:cc:dd:ee:ff";
         let ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
-        store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip,
-                None,
-                LeaseState::Offered,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &ip,
+            None,
+            LeaseState::Offered,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Create a REQUEST message WITHOUT server ID (RENEWING or INIT-REBOOT)
         let mut request = Message::default();
@@ -1209,10 +1210,13 @@ mod tests {
         // Note: No ServerIdentifier option added
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Handle the request
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should process the request (RENEWING/REBINDING case)
         assert!(
@@ -1238,22 +1242,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_request_init_reboot_without_server_id() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         // Create a lease first
         let mac = "aa:bb:cc:dd:ee:ff";
         let ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
-        store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip,
-                None,
-                LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &ip,
+            None,
+            LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Create an INIT-REBOOT REQUEST (has requested IP, no server ID, no ciaddr)
         let mut request = Message::default();
@@ -1270,10 +1275,13 @@ mod tests {
         // No ServerIdentifier - characteristic of INIT-REBOOT
 
         // Get test network
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
 
         // Handle the request
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should process INIT-REBOOT request
         assert!(
@@ -1305,15 +1313,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_reservation_nak_on_wrong_requested_ip() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         let mac = "aa:bb:cc:dd:ee:ff";
         let reserved_ip: Ipv4Addr = "10.0.0.50".parse().unwrap();
         let requested_ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
 
         // Create static reservation
-        store
-            .create_static_reservation(network_id, mac, &reserved_ip.to_string(), None)
+        store::create_static_reservation(&conn, network_id, mac, &reserved_ip.to_string(), None)
             .await
             .unwrap();
 
@@ -1329,8 +1337,11 @@ mod tests {
             .opts_mut()
             .insert(v4::DhcpOption::RequestedIpAddress(requested_ip));
 
-        let network = store.get_network(network_id).await.unwrap();
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should receive NAK
         assert!(response.is_some(), "Should respond with NAK");
@@ -1357,15 +1368,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_reservation_nak_on_wrong_ciaddr() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         let mac = "aa:bb:cc:dd:ee:ff";
         let reserved_ip: Ipv4Addr = "10.0.0.50".parse().unwrap();
         let ciaddr: Ipv4Addr = "10.0.0.100".parse().unwrap();
 
         // Create static reservation
-        store
-            .create_static_reservation(network_id, mac, &reserved_ip.to_string(), None)
+        store::create_static_reservation(&conn, network_id, mac, &reserved_ip.to_string(), None)
             .await
             .unwrap();
 
@@ -1379,8 +1390,11 @@ mod tests {
             .opts_mut()
             .insert(v4::DhcpOption::MessageType(MessageType::Request));
 
-        let network = store.get_network(network_id).await.unwrap();
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should receive NAK
         assert!(response.is_some(), "Should respond with NAK");
@@ -1407,14 +1421,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_reservation_ack_on_correct_ip() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         let mac = "aa:bb:cc:dd:ee:ff";
         let reserved_ip: Ipv4Addr = "10.0.0.50".parse().unwrap();
 
         // Create static reservation
-        store
-            .create_static_reservation(network_id, mac, &reserved_ip.to_string(), None)
+        store::create_static_reservation(&conn, network_id, mac, &reserved_ip.to_string(), None)
             .await
             .unwrap();
 
@@ -1430,8 +1444,11 @@ mod tests {
             .opts_mut()
             .insert(v4::DhcpOption::RequestedIpAddress(reserved_ip));
 
-        let network = store.get_network(network_id).await.unwrap();
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should receive ACK
         assert!(response.is_some(), "Should respond with ACK");
@@ -1465,28 +1482,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_reservation_overrides_existing_lease() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         let mac = "aa:bb:cc:dd:ee:ff";
         let old_ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
         let reserved_ip: Ipv4Addr = "10.0.0.50".parse().unwrap();
 
         // Create an active lease for the old IP
-        store
-            .create_or_update_lease_with_network(
-                mac,
-                &old_ip,
-                None,
-                LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &old_ip,
+            None,
+            LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Admin creates static reservation for different IP
-        store
-            .create_static_reservation(network_id, mac, &reserved_ip.to_string(), None)
+        store::create_static_reservation(&conn, network_id, mac, &reserved_ip.to_string(), None)
             .await
             .unwrap();
 
@@ -1500,8 +1517,11 @@ mod tests {
             .opts_mut()
             .insert(v4::DhcpOption::MessageType(MessageType::Request));
 
-        let network = store.get_network(network_id).await.unwrap();
-        let response = handler.handle_request(&request, &network).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
+        let response = handler
+            .handle_request(&conn, &request, &network)
+            .await
+            .unwrap();
 
         // Should receive NAK because old IP doesn't match static reservation
         assert!(response.is_some(), "Should respond with NAK");
@@ -1528,28 +1548,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_static_reservation_full_workflow() {
-        let (handler, store, network_id, _temp_dir) = create_test_handler_with_store().await;
+        let (handler, conn, network_id, _temp_dir) =
+            create_test_handler_with_store(test_connection_factory!()).await;
 
         let mac = "aa:bb:cc:dd:ee:ff";
         let old_ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
         let reserved_ip: Ipv4Addr = "10.0.0.50".parse().unwrap();
 
         // Step 1: Client gets IP from pool
-        store
-            .create_or_update_lease_with_network(
-                mac,
-                &old_ip,
-                None,
-                LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &old_ip,
+            None,
+            LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Step 2: Admin creates static reservation for different IP
-        store
-            .create_static_reservation(network_id, mac, &reserved_ip.to_string(), None)
+        store::create_static_reservation(&conn, network_id, mac, &reserved_ip.to_string(), None)
             .await
             .unwrap();
 
@@ -1563,9 +1583,9 @@ mod tests {
             .opts_mut()
             .insert(v4::DhcpOption::MessageType(MessageType::Request));
 
-        let network = store.get_network(network_id).await.unwrap();
+        let network = store::get_network(&conn, network_id).await.unwrap();
         let response = handler
-            .handle_request(&renew_request, &network)
+            .handle_request(&conn, &renew_request, &network)
             .await
             .unwrap();
 
@@ -1590,7 +1610,7 @@ mod tests {
             .insert(v4::DhcpOption::RequestedIpAddress(reserved_ip));
 
         let response = handler
-            .handle_request(&new_request, &network)
+            .handle_request(&conn, &new_request, &network)
             .await
             .unwrap();
 
@@ -1613,7 +1633,7 @@ mod tests {
         );
 
         // Verify lease was updated to new IP
-        let lease = store.get_lease_by_mac(mac).await.unwrap();
+        let lease = store::get_lease_by_mac(&conn, mac).await.unwrap();
         assert!(lease.is_some());
         let lease = lease.unwrap();
         assert_eq!(

--- a/rack-director/src/dhcp/handler.rs
+++ b/rack-director/src/dhcp/handler.rs
@@ -572,12 +572,10 @@ mod tests {
         use crate::director::Director;
         use std::sync::Arc;
         use tempfile::tempdir;
-        use tokio::sync::Mutex;
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let conn = database::open(db_path).unwrap();
-        let db = Arc::new(Mutex::new(conn));
+        let db = Arc::new(database::open(db_path).await.unwrap());
         let store = DhcpStore::new(db.clone());
 
         // Create test network
@@ -689,12 +687,10 @@ mod tests {
         use crate::director::Director;
         use std::sync::Arc;
         use tempfile::tempdir;
-        use tokio::sync::Mutex;
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let conn = database::open(db_path).unwrap();
-        let db = Arc::new(Mutex::new(conn));
+        let db = Arc::new(database::open(db_path).await.unwrap());
         let store = DhcpStore::new(db.clone());
 
         // Create test network

--- a/rack-director/src/dhcp/mod.rs
+++ b/rack-director/src/dhcp/mod.rs
@@ -8,10 +8,8 @@ mod request;
 mod store;
 
 use anyhow::Result;
-use rusqlite::Connection;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tokio::{net::UdpSocket, task::JoinHandle};
 
 use crate::director::Director;
@@ -38,7 +36,7 @@ pub struct StartResult {
 
 impl DhcpServer {
     pub async fn new(
-        db: Arc<Mutex<Connection>>,
+        db: Arc<crate::database::Connection>,
         director: Director,
         tftp_server: String,
         http_server: String,
@@ -142,16 +140,15 @@ pub fn spawn_lease_cleanup_task(store: DhcpStore) -> JoinHandle<()> {
 mod tests {
 
     use super::*;
-    use tempfile::tempdir;
 
     #[tokio::test]
     async fn test_dhcp_server_creation() {
         use crate::boot_files::FilesystemBootFileProvider;
+        use tempfile::tempdir;
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let conn = crate::database::open(db_path).unwrap();
-        let db = Arc::new(Mutex::new(conn));
+        let db = Arc::new(crate::database::open(db_path).await.unwrap());
         let director = Director::new(db.clone());
 
         // Create a temporary boot files directory for testing

--- a/rack-director/src/dhcp/mod.rs
+++ b/rack-director/src/dhcp/mod.rs
@@ -5,19 +5,18 @@ mod handler;
 mod ip_discovery;
 pub mod message_builder;
 mod request;
-mod store;
+pub mod store;
 
 use anyhow::Result;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use tokio::{net::UdpSocket, task::JoinHandle};
 
-use crate::director::Director;
+use crate::database::ConnectionFactory;
 
 pub use ip_discovery::discover_server_identifier;
-pub use store::{DhcpNetwork, DhcpPool, DhcpStore, Lease, LeaseState, StaticReservation};
+pub use store::{DhcpNetwork, DhcpPool, Lease, LeaseState, StaticReservation};
 
-use allocator::IpAllocator;
 use boot_config::BootConfigProvider;
 use device_resolution::DirectorDeviceResolver;
 use handler::DhcpHandler;
@@ -36,23 +35,21 @@ pub struct StartResult {
 
 impl DhcpServer {
     pub async fn new(
-        db: Arc<crate::database::Connection>,
-        director: Director,
+        conn: Arc<dyn ConnectionFactory>,
         tftp_server: String,
         http_server: String,
         boot_file_provider: Arc<dyn BootFileProvider>,
         server_identifier: Ipv4Addr,
         address: Option<SocketAddr>,
     ) -> Result<Self> {
-        let store = DhcpStore::new(db);
-
         log::info!("DHCP server configuration:");
         log::info!("  TFTP Server: {}", tftp_server);
         log::info!("  HTTP Server: {}", http_server);
         log::info!("  Server Identifier: {}", server_identifier);
 
         // List networks at startup for diagnostic purposes
-        let networks = store.list_networks().await?;
+        let startup_db = conn.open().await?;
+        let networks = store::list_networks(&startup_db).await?;
         log::info!("  Configured networks: {}", networks.len());
         for network in &networks {
             log::info!(
@@ -64,16 +61,9 @@ impl DhcpServer {
             );
         }
 
-        let allocator = IpAllocator::new(store.clone());
         let boot_config = BootConfigProvider::new(tftp_server, http_server, boot_file_provider);
-        let device_resolver = Arc::new(DirectorDeviceResolver::new(director));
-        let handler = DhcpHandler::new(
-            store,
-            device_resolver,
-            allocator,
-            boot_config,
-            server_identifier,
-        );
+        let device_resolver = Arc::new(DirectorDeviceResolver::new());
+        let handler = DhcpHandler::new(conn, device_resolver, boot_config, server_identifier);
 
         Ok(Self {
             handler,
@@ -122,12 +112,16 @@ impl DhcpServer {
 }
 
 /// Spawn a background task that periodically deletes expired DHCP leases.
-pub fn spawn_lease_cleanup_task(store: DhcpStore) -> JoinHandle<()> {
+pub fn spawn_lease_cleanup_task(connection_factory: Arc<dyn ConnectionFactory>) -> JoinHandle<()> {
     tokio::spawn(async move {
+        let conn = connection_factory
+            .open()
+            .await
+            .expect("Failed to open database");
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
         loop {
             interval.tick().await;
-            match store.delete_expired_leases().await {
+            match store::delete_expired_leases(&conn).await {
                 Ok(count) if count > 0 => log::info!("Cleaned up {} expired DHCP lease(s)", count),
                 Ok(_) => {}
                 Err(e) => log::error!("Failed to clean up expired DHCP leases: {}", e),
@@ -146,12 +140,14 @@ mod tests {
         use crate::boot_files::FilesystemBootFileProvider;
         use tempfile::tempdir;
 
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(crate::database::open(db_path).await.unwrap());
-        let director = Director::new(db.clone());
+        let conn: Arc<dyn ConnectionFactory> = Arc::new(crate::test_connection_factory!());
+        // Run migrations and keep the connection alive so the in-memory DB persists
+        let _migration_conn = crate::database::run_migrations(conn.as_ref())
+            .await
+            .unwrap();
 
         // Create a temporary boot files directory for testing
+        let temp_dir = tempdir().unwrap();
         let boot_files_dir = temp_dir.path().join("boot_files");
         std::fs::create_dir_all(&boot_files_dir).unwrap();
         let boot_file_provider =
@@ -159,8 +155,7 @@ mod tests {
 
         let server_identifier = "10.0.0.1".parse().unwrap();
         let server = DhcpServer::new(
-            db,
-            director,
+            conn,
             "10.0.0.1:69".to_string(),
             "http://10.0.0.1:3000".to_string(),
             boot_file_provider,

--- a/rack-director/src/dhcp/store.rs
+++ b/rack-director/src/dhcp/store.rs
@@ -3,15 +3,9 @@ use chrono::{DateTime, Duration, Utc};
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
-use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::database::{Connection, FromRow};
-
-#[derive(Clone)]
-pub struct DhcpStore {
-    db: Arc<Connection>,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Lease {
@@ -180,620 +174,572 @@ impl FromRow for StaticReservation {
     }
 }
 
-impl DhcpStore {
-    pub fn new(db: Arc<Connection>) -> Self {
-        Self { db }
-    }
+// ============================================================
+// Standalone functions accepting &Connection
+// ============================================================
 
-    /// Create or update a DHCP lease with network context.
-    pub async fn create_or_update_lease_with_network(
-        &self,
-        mac: &str,
-        ip: &Ipv4Addr,
-        device_uuid: Option<&Uuid>,
-        state: LeaseState,
-        lease_duration: u32,
-        network_id: i64,
-    ) -> Result<()> {
-        let ip_str = ip.to_string();
-        let now = Utc::now();
-        let lease_end = now + Duration::seconds(lease_duration as i64);
-        let state_str = state.to_string();
-        let now_str = now.to_rfc3339();
-        let lease_end_str = lease_end.to_rfc3339();
-        let device_uuid_copy = device_uuid.copied();
-        let mac = mac.to_string();
+/// Create or update a DHCP lease with network context.
+pub async fn create_or_update_lease_with_network(
+    conn: &Connection,
+    mac: &str,
+    ip: &Ipv4Addr,
+    device_uuid: Option<&Uuid>,
+    state: LeaseState,
+    lease_duration: u32,
+    network_id: i64,
+) -> Result<()> {
+    let ip_str = ip.to_string();
+    let now = Utc::now();
+    let lease_end = now + Duration::seconds(lease_duration as i64);
+    let state_str = state.to_string();
+    let now_str = now.to_rfc3339();
+    let lease_end_str = lease_end.to_rfc3339();
+    let device_uuid_copy = device_uuid.copied();
+    let mac = mac.to_string();
 
-        self.db
-            .execute(
-                "INSERT INTO dhcp_leases
-                    (mac_address, ip_address, device_uuid, lease_start, lease_end, state, network_id, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-                 ON CONFLICT(mac_address) DO UPDATE SET
-                    ip_address = ?2,
-                    device_uuid = ?3,
-                    lease_start = ?4,
-                    lease_end = ?5,
-                    state = ?6,
-                    network_id = ?7,
-                    updated_at = ?8",
-                (mac, ip_str, device_uuid_copy, now_str.clone(), lease_end_str, state_str, network_id, now_str),
-            )
-            .await?;
+    conn.execute(
+        "INSERT INTO dhcp_leases
+            (mac_address, ip_address, device_uuid, lease_start, lease_end, state, network_id, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(mac_address) DO UPDATE SET
+            ip_address = ?2,
+            device_uuid = ?3,
+            lease_start = ?4,
+            lease_end = ?5,
+            state = ?6,
+            network_id = ?7,
+            updated_at = ?8",
+        (mac, ip_str, device_uuid_copy, now_str.clone(), lease_end_str, state_str, network_id, now_str),
+    )
+    .await?;
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    /// Get lease by MAC address.
-    pub async fn get_lease_by_mac(&self, mac: &str) -> Result<Option<Lease>> {
-        let lease = self
-            .db
+/// Get lease by MAC address.
+pub async fn get_lease_by_mac(conn: &Connection, mac: &str) -> Result<Option<Lease>> {
+    let lease = conn
+        .query_row(
+            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+             FROM dhcp_leases WHERE mac_address = ?1",
+            (mac.to_string(),),
+            Lease::from_row,
+        )
+        .await
+        .optional()?;
+
+    Ok(lease)
+}
+
+/// Get lease by ID.
+pub async fn get_lease_by_id(conn: &Connection, id: i64) -> Result<Option<Lease>> {
+    let lease = conn
+        .query_row(
+            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+             FROM dhcp_leases WHERE id = ?1",
+            (id,),
+            Lease::from_row,
+        )
+        .await
+        .optional()?;
+
+    Ok(lease)
+}
+
+/// Activate a lease (transition from Offered to Active).
+pub async fn activate_lease(conn: &Connection, mac: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
+        (
+            LeaseState::Active.to_string(),
+            Utc::now().to_rfc3339(),
+            mac.to_string(),
+        ),
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Release a lease (mark as Released).
+pub async fn release_lease(conn: &Connection, mac: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
+        (
+            LeaseState::Released.to_string(),
+            Utc::now().to_rfc3339(),
+            mac.to_string(),
+        ),
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Get all leases (for API/management).
+pub async fn get_all_leases(conn: &Connection) -> Result<Vec<Lease>> {
+    let leases = conn
+        .query(
+            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+             FROM dhcp_leases ORDER BY updated_at DESC",
+            (),
+            Lease::from_row,
+        )
+        .await?;
+
+    Ok(leases)
+}
+
+/// Find lease by device UUID.
+pub async fn find_lease_by_device_uuid(
+    conn: &Connection,
+    device_uuid: &Uuid,
+) -> Result<Option<Lease>> {
+    let lease = conn
+        .query_row(
+            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+             FROM dhcp_leases WHERE device_uuid = ?1 AND state = 'active' ORDER BY lease_end DESC LIMIT 1",
+            (*device_uuid,),
+            Lease::from_row,
+        )
+        .await
+        .optional()?;
+
+    Ok(lease)
+}
+
+// ========== Network CRUD Operations ==========
+
+/// Get a network by ID.
+pub async fn get_network(conn: &Connection, id: i64) -> Result<DhcpNetwork> {
+    let network = conn
+        .query_one(
+            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+             FROM dhcp_networks WHERE id = ?1",
+            (id,),
+            DhcpNetwork::from_row,
+        )
+        .await?;
+
+    Ok(network)
+}
+
+/// Get a network by relay agent address (or None for local L2).
+pub async fn get_network_by_relay(
+    conn: &Connection,
+    relay: Option<Ipv4Addr>,
+) -> Result<Option<DhcpNetwork>> {
+    let relay_str = relay.map(|r| r.to_string());
+
+    let network = conn
+        .query_row(
+            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+             FROM dhcp_networks WHERE relay_agent_address IS ?1 OR (relay_agent_address IS NULL AND ?1 IS NULL)",
+            (relay_str,),
+            DhcpNetwork::from_row,
+        )
+        .await
+        .optional()?;
+
+    Ok(network)
+}
+
+/// Get a network by name.
+pub async fn get_network_by_name(conn: &Connection, name: &str) -> Result<Option<DhcpNetwork>> {
+    let network = conn
+        .query_row(
+            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+             FROM dhcp_networks WHERE name = ?1",
+            (name.to_string(),),
+            DhcpNetwork::from_row,
+        )
+        .await
+        .optional()?;
+
+    Ok(network)
+}
+
+/// Get a network by relay agent address string, checking both NULL and empty string for local L2.
+pub async fn get_network_by_relay_string(
+    conn: &Connection,
+    relay_agent_address: Option<&str>,
+) -> Result<Option<DhcpNetwork>> {
+    let network = match relay_agent_address {
+        None | Some("") => conn
             .query_row(
-                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-                 FROM dhcp_leases WHERE mac_address = ?1",
-                (mac.to_string(),),
-                Lease::from_row,
-            )
-            .await
-            .optional()?;
-
-        Ok(lease)
-    }
-
-    /// Get lease by ID.
-    pub async fn get_lease_by_id(&self, id: i64) -> Result<Option<Lease>> {
-        let lease = self
-            .db
-            .query_row(
-                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-                 FROM dhcp_leases WHERE id = ?1",
-                (id,),
-                Lease::from_row,
-            )
-            .await
-            .optional()?;
-
-        Ok(lease)
-    }
-
-    /// Activate a lease (transition from Offered to Active).
-    pub async fn activate_lease(&self, mac: &str) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
-                (
-                    LeaseState::Active.to_string(),
-                    Utc::now().to_rfc3339(),
-                    mac.to_string(),
-                ),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    /// Release a lease (mark as Released).
-    pub async fn release_lease(&self, mac: &str) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
-                (
-                    LeaseState::Released.to_string(),
-                    Utc::now().to_rfc3339(),
-                    mac.to_string(),
-                ),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    /// Get all leases (for API/management).
-    pub async fn get_all_leases(&self) -> Result<Vec<Lease>> {
-        let leases = self
-            .db
-            .query(
-                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-                 FROM dhcp_leases ORDER BY updated_at DESC",
-                (),
-                Lease::from_row,
-            )
-            .await?;
-
-        Ok(leases)
-    }
-
-    /// Find lease by device UUID (async version).
-    pub async fn find_lease_by_device_uuid(&self, device_uuid: &Uuid) -> Result<Option<Lease>> {
-        let lease = self
-            .db
-            .query_row(
-                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-                 FROM dhcp_leases WHERE device_uuid = ?1 AND state = 'active' ORDER BY lease_end DESC LIMIT 1",
-                (*device_uuid,),
-                Lease::from_row,
-            )
-            .await
-            .optional()?;
-
-        Ok(lease)
-    }
-
-    // ========== Network CRUD Operations ==========
-
-    /// Get a network by ID.
-    pub async fn get_network(&self, id: i64) -> Result<DhcpNetwork> {
-        let network = self
-            .db
-            .query_one(
                 "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                 FROM dhcp_networks WHERE id = ?1",
-                (id,),
-                DhcpNetwork::from_row,
-            )
-            .await?;
-
-        Ok(network)
-    }
-
-    /// Get a network by relay agent address (or None for local L2).
-    pub async fn get_network_by_relay(
-        &self,
-        relay: Option<Ipv4Addr>,
-    ) -> Result<Option<DhcpNetwork>> {
-        let relay_str = relay.map(|r| r.to_string());
-
-        let network = self
-            .db
-            .query_row(
-                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                 FROM dhcp_networks WHERE relay_agent_address IS ?1 OR (relay_agent_address IS NULL AND ?1 IS NULL)",
-                (relay_str,),
-                DhcpNetwork::from_row,
-            )
-            .await
-            .optional()?;
-
-        Ok(network)
-    }
-
-    /// Get a network by name.
-    pub async fn get_network_by_name(&self, name: &str) -> Result<Option<DhcpNetwork>> {
-        let network = self
-            .db
-            .query_row(
-                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                 FROM dhcp_networks WHERE name = ?1",
-                (name.to_string(),),
-                DhcpNetwork::from_row,
-            )
-            .await
-            .optional()?;
-
-        Ok(network)
-    }
-
-    /// Get a network by relay agent address string, checking both NULL and empty string for local L2.
-    pub async fn get_network_by_relay_string(
-        &self,
-        relay_agent_address: Option<&str>,
-    ) -> Result<Option<DhcpNetwork>> {
-        // Handle the three cases:
-        // 1. None or Some("") - Local L2 network (NULL or empty string)
-        // 2. Some(address) - Specific relay agent address
-        let network = match relay_agent_address {
-            None | Some("") => self
-                .db
-                .query_row(
-                    "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                     FROM dhcp_networks WHERE relay_agent_address IS NULL OR relay_agent_address = ''",
-                    (),
-                    DhcpNetwork::from_row,
-                )
-                .await
-                .optional()?,
-            Some(addr) => self
-                .db
-                .query_row(
-                    "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                     FROM dhcp_networks WHERE relay_agent_address = ?1",
-                    (addr.to_string(),),
-                    DhcpNetwork::from_row,
-                )
-                .await
-                .optional()?,
-        };
-
-        Ok(network)
-    }
-
-    /// List all networks.
-    pub async fn list_networks(&self) -> Result<Vec<DhcpNetwork>> {
-        let networks = self
-            .db
-            .query(
-                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                 FROM dhcp_networks ORDER BY name",
+                 FROM dhcp_networks WHERE relay_agent_address IS NULL OR relay_agent_address = ''",
                 (),
                 DhcpNetwork::from_row,
             )
-            .await?;
+            .await
+            .optional()?,
+        Some(addr) => conn
+            .query_row(
+                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+                 FROM dhcp_networks WHERE relay_agent_address = ?1",
+                (addr.to_string(),),
+                DhcpNetwork::from_row,
+            )
+            .await
+            .optional()?,
+    };
 
-        Ok(networks)
+    Ok(network)
+}
+
+/// List all networks.
+pub async fn list_networks(conn: &Connection) -> Result<Vec<DhcpNetwork>> {
+    let networks = conn
+        .query(
+            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+             FROM dhcp_networks ORDER BY name",
+            (),
+            DhcpNetwork::from_row,
+        )
+        .await?;
+
+    Ok(networks)
+}
+
+/// Create a new network.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_network(
+    conn: &Connection,
+    name: &str,
+    subnet: &str,
+    gateway: &str,
+    dns_servers: &[String],
+    lease_duration: u32,
+    relay_agent_address: Option<&str>,
+    enable_autodiscovery: bool,
+) -> Result<DhcpNetwork> {
+    let dns_servers_json = serde_json::to_string(dns_servers)?;
+    let now = Utc::now().to_rfc3339();
+    let relay = relay_agent_address.map(|s| s.to_string());
+
+    conn.execute(
+        "INSERT INTO dhcp_networks (name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        (name.to_string(), subnet.to_string(), gateway.to_string(), dns_servers_json, lease_duration, relay, enable_autodiscovery, now.clone(), now),
+    )
+    .await?;
+
+    let id = conn.last_insert_rowid().await;
+    get_network(conn, id).await
+}
+
+/// Update a network.
+#[allow(clippy::too_many_arguments)]
+pub async fn update_network(
+    conn: &Connection,
+    id: i64,
+    name: Option<&str>,
+    subnet: Option<&str>,
+    gateway: Option<&str>,
+    dns_servers: Option<&[String]>,
+    lease_duration: Option<u32>,
+    relay_agent_address: Option<Option<&str>>,
+    enable_autodiscovery: Option<bool>,
+) -> Result<DhcpNetwork> {
+    let now = Utc::now().to_rfc3339();
+
+    if let Some(name) = name {
+        conn.execute(
+            "UPDATE dhcp_networks SET name = ?1, updated_at = ?2 WHERE id = ?3",
+            (name.to_string(), now.clone(), id),
+        )
+        .await?;
     }
-
-    /// Create a new network.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn create_network(
-        &self,
-        name: &str,
-        subnet: &str,
-        gateway: &str,
-        dns_servers: &[String],
-        lease_duration: u32,
-        relay_agent_address: Option<&str>,
-        enable_autodiscovery: bool,
-    ) -> Result<DhcpNetwork> {
+    if let Some(subnet) = subnet {
+        conn.execute(
+            "UPDATE dhcp_networks SET subnet = ?1, updated_at = ?2 WHERE id = ?3",
+            (subnet.to_string(), now.clone(), id),
+        )
+        .await?;
+    }
+    if let Some(gateway) = gateway {
+        conn.execute(
+            "UPDATE dhcp_networks SET gateway = ?1, updated_at = ?2 WHERE id = ?3",
+            (gateway.to_string(), now.clone(), id),
+        )
+        .await?;
+    }
+    if let Some(dns_servers) = dns_servers {
         let dns_servers_json = serde_json::to_string(dns_servers)?;
-        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE dhcp_networks SET dns_servers = ?1, updated_at = ?2 WHERE id = ?3",
+            (dns_servers_json, now.clone(), id),
+        )
+        .await?;
+    }
+    if let Some(lease_duration) = lease_duration {
+        conn.execute(
+            "UPDATE dhcp_networks SET lease_duration = ?1, updated_at = ?2 WHERE id = ?3",
+            (lease_duration, now.clone(), id),
+        )
+        .await?;
+    }
+    if let Some(relay_agent_address) = relay_agent_address {
         let relay = relay_agent_address.map(|s| s.to_string());
-
-        self.db
-            .execute(
-                "INSERT INTO dhcp_networks (name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-                (name.to_string(), subnet.to_string(), gateway.to_string(), dns_servers_json, lease_duration, relay, enable_autodiscovery, now.clone(), now),
-            )
-            .await?;
-
-        let id = self.db.last_insert_rowid().await;
-        self.get_network(id).await
+        conn.execute(
+            "UPDATE dhcp_networks SET relay_agent_address = ?1, updated_at = ?2 WHERE id = ?3",
+            (relay, now.clone(), id),
+        )
+        .await?;
+    }
+    if let Some(enable_autodiscovery) = enable_autodiscovery {
+        conn.execute(
+            "UPDATE dhcp_networks SET enable_autodiscovery = ?1, updated_at = ?2 WHERE id = ?3",
+            (enable_autodiscovery, now, id),
+        )
+        .await?;
     }
 
-    /// Update a network.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn update_network(
-        &self,
-        id: i64,
-        name: Option<&str>,
-        subnet: Option<&str>,
-        gateway: Option<&str>,
-        dns_servers: Option<&[String]>,
-        lease_duration: Option<u32>,
-        relay_agent_address: Option<Option<&str>>,
-        enable_autodiscovery: Option<bool>,
-    ) -> Result<DhcpNetwork> {
-        let now = Utc::now().to_rfc3339();
+    get_network(conn, id).await
+}
 
-        if let Some(name) = name {
-            self.db
-                .execute(
-                    "UPDATE dhcp_networks SET name = ?1, updated_at = ?2 WHERE id = ?3",
-                    (name.to_string(), now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(subnet) = subnet {
-            self.db
-                .execute(
-                    "UPDATE dhcp_networks SET subnet = ?1, updated_at = ?2 WHERE id = ?3",
-                    (subnet.to_string(), now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(gateway) = gateway {
-            self.db
-                .execute(
-                    "UPDATE dhcp_networks SET gateway = ?1, updated_at = ?2 WHERE id = ?3",
-                    (gateway.to_string(), now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(dns_servers) = dns_servers {
-            let dns_servers_json = serde_json::to_string(dns_servers)?;
-            self.db
-                .execute(
-                    "UPDATE dhcp_networks SET dns_servers = ?1, updated_at = ?2 WHERE id = ?3",
-                    (dns_servers_json, now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(lease_duration) = lease_duration {
-            self.db
-                .execute(
-                    "UPDATE dhcp_networks SET lease_duration = ?1, updated_at = ?2 WHERE id = ?3",
-                    (lease_duration, now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(relay_agent_address) = relay_agent_address {
-            let relay = relay_agent_address.map(|s| s.to_string());
-            self.db
-                .execute(
-                    "UPDATE dhcp_networks SET relay_agent_address = ?1, updated_at = ?2 WHERE id = ?3",
-                    (relay, now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(enable_autodiscovery) = enable_autodiscovery {
-            self.db
-                .execute(
-                    "UPDATE dhcp_networks SET enable_autodiscovery = ?1, updated_at = ?2 WHERE id = ?3",
-                    (enable_autodiscovery, now, id),
-                )
-                .await?;
-        }
+/// Delete a network.
+pub async fn delete_network(conn: &Connection, id: i64) -> Result<()> {
+    conn.execute("DELETE FROM dhcp_networks WHERE id = ?1", (id,))
+        .await?;
+    Ok(())
+}
 
-        self.get_network(id).await
+// ========== Pool CRUD Operations ==========
+
+/// Get a pool by ID.
+pub async fn get_pool(conn: &Connection, id: i64) -> Result<DhcpPool> {
+    let pool = conn
+        .query_one(
+            "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
+             FROM dhcp_pools WHERE id = ?1",
+            (id,),
+            DhcpPool::from_row,
+        )
+        .await?;
+
+    Ok(pool)
+}
+
+/// List all pools for a network.
+pub async fn list_pools_for_network(conn: &Connection, network_id: i64) -> Result<Vec<DhcpPool>> {
+    let pools = conn
+        .query(
+            "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
+             FROM dhcp_pools WHERE network_id = ?1 ORDER BY name",
+            (network_id,),
+            DhcpPool::from_row,
+        )
+        .await?;
+
+    Ok(pools)
+}
+
+/// Create a new pool.
+pub async fn create_pool(
+    conn: &Connection,
+    network_id: i64,
+    name: &str,
+    range_start: &str,
+    range_end: &str,
+) -> Result<DhcpPool> {
+    let now = Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO dhcp_pools (network_id, name, range_start, range_end, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        (
+            network_id,
+            name.to_string(),
+            range_start.to_string(),
+            range_end.to_string(),
+            now.clone(),
+            now,
+        ),
+    )
+    .await?;
+
+    let id = conn.last_insert_rowid().await;
+    get_pool(conn, id).await
+}
+
+/// Update a pool.
+pub async fn update_pool(
+    conn: &Connection,
+    id: i64,
+    name: Option<&str>,
+    range_start: Option<&str>,
+    range_end: Option<&str>,
+) -> Result<DhcpPool> {
+    let now = Utc::now().to_rfc3339();
+
+    if let Some(name) = name {
+        conn.execute(
+            "UPDATE dhcp_pools SET name = ?1, updated_at = ?2 WHERE id = ?3",
+            (name.to_string(), now.clone(), id),
+        )
+        .await?;
+    }
+    if let Some(range_start) = range_start {
+        conn.execute(
+            "UPDATE dhcp_pools SET range_start = ?1, updated_at = ?2 WHERE id = ?3",
+            (range_start.to_string(), now.clone(), id),
+        )
+        .await?;
+    }
+    if let Some(range_end) = range_end {
+        conn.execute(
+            "UPDATE dhcp_pools SET range_end = ?1, updated_at = ?2 WHERE id = ?3",
+            (range_end.to_string(), now, id),
+        )
+        .await?;
     }
 
-    /// Delete a network.
-    pub async fn delete_network(&self, id: i64) -> Result<()> {
-        self.db
-            .execute("DELETE FROM dhcp_networks WHERE id = ?1", (id,))
-            .await?;
-        Ok(())
-    }
+    get_pool(conn, id).await
+}
 
-    // ========== Pool CRUD Operations ==========
+/// Delete a pool.
+pub async fn delete_pool(conn: &Connection, id: i64) -> Result<()> {
+    conn.execute("DELETE FROM dhcp_pools WHERE id = ?1", (id,))
+        .await?;
+    Ok(())
+}
 
-    /// Get a pool by ID.
-    pub async fn get_pool(&self, id: i64) -> Result<DhcpPool> {
-        let pool = self
-            .db
-            .query_one(
-                "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
-                 FROM dhcp_pools WHERE id = ?1",
-                (id,),
-                DhcpPool::from_row,
-            )
-            .await?;
+// ========== Static Reservation CRUD Operations ==========
 
-        Ok(pool)
-    }
+/// Get a static reservation for a MAC address in a network.
+pub async fn get_static_reservation(
+    conn: &Connection,
+    network_id: i64,
+    mac: &str,
+) -> Result<Option<StaticReservation>> {
+    let reservation = conn
+        .query_row(
+            "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
+             FROM dhcp_static_reservations WHERE network_id = ?1 AND mac_address = ?2",
+            (network_id, mac.to_string()),
+            StaticReservation::from_row,
+        )
+        .await
+        .optional()?;
 
-    /// List all pools for a network.
-    pub async fn list_pools_for_network(&self, network_id: i64) -> Result<Vec<DhcpPool>> {
-        let pools = self
-            .db
-            .query(
-                "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
-                 FROM dhcp_pools WHERE network_id = ?1 ORDER BY name",
-                (network_id,),
-                DhcpPool::from_row,
-            )
-            .await?;
+    Ok(reservation)
+}
 
-        Ok(pools)
-    }
+/// List all static reservations for a network.
+pub async fn list_static_reservations(
+    conn: &Connection,
+    network_id: i64,
+) -> Result<Vec<StaticReservation>> {
+    let reservations = conn
+        .query(
+            "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
+             FROM dhcp_static_reservations WHERE network_id = ?1 ORDER BY ip_address",
+            (network_id,),
+            StaticReservation::from_row,
+        )
+        .await?;
 
-    /// Create a new pool.
-    pub async fn create_pool(
-        &self,
-        network_id: i64,
-        name: &str,
-        range_start: &str,
-        range_end: &str,
-    ) -> Result<DhcpPool> {
-        let now = Utc::now().to_rfc3339();
+    Ok(reservations)
+}
 
-        self.db
-            .execute(
-                "INSERT INTO dhcp_pools (network_id, name, range_start, range_end, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                (network_id, name.to_string(), range_start.to_string(), range_end.to_string(), now.clone(), now),
-            )
-            .await?;
+/// Create a static reservation.
+pub async fn create_static_reservation(
+    conn: &Connection,
+    network_id: i64,
+    mac: &str,
+    ip: &str,
+    hostname: Option<&str>,
+) -> Result<StaticReservation> {
+    let now = Utc::now().to_rfc3339();
+    let hostname_owned = hostname.map(|s| s.to_string());
 
-        let id = self.db.last_insert_rowid().await;
-        self.get_pool(id).await
-    }
+    conn.execute(
+        "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        (network_id, mac.to_string(), ip.to_string(), hostname_owned, now.clone(), now),
+    )
+    .await?;
 
-    /// Update a pool.
-    pub async fn update_pool(
-        &self,
-        id: i64,
-        name: Option<&str>,
-        range_start: Option<&str>,
-        range_end: Option<&str>,
-    ) -> Result<DhcpPool> {
-        let now = Utc::now().to_rfc3339();
+    let id = conn.last_insert_rowid().await;
 
-        if let Some(name) = name {
-            self.db
-                .execute(
-                    "UPDATE dhcp_pools SET name = ?1, updated_at = ?2 WHERE id = ?3",
-                    (name.to_string(), now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(range_start) = range_start {
-            self.db
-                .execute(
-                    "UPDATE dhcp_pools SET range_start = ?1, updated_at = ?2 WHERE id = ?3",
-                    (range_start.to_string(), now.clone(), id),
-                )
-                .await?;
-        }
-        if let Some(range_end) = range_end {
-            self.db
-                .execute(
-                    "UPDATE dhcp_pools SET range_end = ?1, updated_at = ?2 WHERE id = ?3",
-                    (range_end.to_string(), now, id),
-                )
-                .await?;
-        }
+    let reservation = conn
+        .query_one(
+            "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
+             FROM dhcp_static_reservations WHERE id = ?1",
+            (id,),
+            StaticReservation::from_row,
+        )
+        .await?;
 
-        self.get_pool(id).await
-    }
+    Ok(reservation)
+}
 
-    /// Delete a pool.
-    pub async fn delete_pool(&self, id: i64) -> Result<()> {
-        self.db
-            .execute("DELETE FROM dhcp_pools WHERE id = ?1", (id,))
-            .await?;
-        Ok(())
-    }
+/// Delete a static reservation.
+pub async fn delete_static_reservation(conn: &Connection, id: i64) -> Result<()> {
+    conn.execute("DELETE FROM dhcp_static_reservations WHERE id = ?1", (id,))
+        .await?;
+    Ok(())
+}
 
-    // ========== Static Reservation CRUD Operations ==========
+/// Create or update a static reservation (upsert).
+pub async fn create_or_update_static_reservation(
+    conn: &Connection,
+    network_id: i64,
+    mac: &str,
+    ip: &str,
+    hostname: Option<&str>,
+) -> Result<()> {
+    let now = Utc::now().to_rfc3339();
+    let hostname_owned = hostname.map(|s| s.to_string());
 
-    /// Get a static reservation for a MAC address in a network.
-    pub async fn get_static_reservation(
-        &self,
-        network_id: i64,
-        mac: &str,
-    ) -> Result<Option<StaticReservation>> {
-        let reservation = self
-            .db
-            .query_row(
-                "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
-                 FROM dhcp_static_reservations WHERE network_id = ?1 AND mac_address = ?2",
-                (network_id, mac.to_string()),
-                StaticReservation::from_row,
-            )
-            .await
-            .optional()?;
+    conn.execute(
+        "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(network_id, mac_address) DO UPDATE SET
+            ip_address = ?3,
+            hostname = ?4,
+            updated_at = ?6",
+        (network_id, mac.to_string(), ip.to_string(), hostname_owned, now.clone(), now),
+    )
+    .await?;
 
-        Ok(reservation)
-    }
+    Ok(())
+}
 
-    /// List all static reservations for a network.
-    pub async fn list_static_reservations(
-        &self,
-        network_id: i64,
-    ) -> Result<Vec<StaticReservation>> {
-        let reservations = self
-            .db
-            .query(
-                "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
-                 FROM dhcp_static_reservations WHERE network_id = ?1 ORDER BY ip_address",
-                (network_id,),
-                StaticReservation::from_row,
-            )
-            .await?;
+/// Delete all static reservations for a MAC address across all networks.
+pub async fn delete_static_reservations_by_mac(conn: &Connection, mac: &str) -> Result<u64> {
+    let deleted = conn
+        .execute(
+            "DELETE FROM dhcp_static_reservations WHERE mac_address = ?1",
+            (mac.to_string(),),
+        )
+        .await?;
+    Ok(deleted as u64)
+}
 
-        Ok(reservations)
-    }
+/// Get leases by network.
+pub async fn get_leases_by_network(conn: &Connection, network_id: i64) -> Result<Vec<Lease>> {
+    let leases = conn
+        .query(
+            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+             FROM dhcp_leases WHERE network_id = ?1 ORDER BY updated_at DESC",
+            (network_id,),
+            Lease::from_row,
+        )
+        .await?;
 
-    /// Create a static reservation.
-    pub async fn create_static_reservation(
-        &self,
-        network_id: i64,
-        mac: &str,
-        ip: &str,
-        hostname: Option<&str>,
-    ) -> Result<StaticReservation> {
-        let now = Utc::now().to_rfc3339();
-        let hostname_owned = hostname.map(|s| s.to_string());
+    Ok(leases)
+}
 
-        self.db
-            .execute(
-                "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                (network_id, mac.to_string(), ip.to_string(), hostname_owned, now.clone(), now),
-            )
-            .await?;
-
-        let id = self.db.last_insert_rowid().await;
-
-        // Fetch and return the created reservation
-        let reservation = self
-            .db
-            .query_one(
-                "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
-                 FROM dhcp_static_reservations WHERE id = ?1",
-                (id,),
-                StaticReservation::from_row,
-            )
-            .await?;
-
-        Ok(reservation)
-    }
-
-    /// Delete a static reservation.
-    pub async fn delete_static_reservation(&self, id: i64) -> Result<()> {
-        self.db
-            .execute("DELETE FROM dhcp_static_reservations WHERE id = ?1", (id,))
-            .await?;
-        Ok(())
-    }
-
-    /// Create or update a static reservation (upsert).
-    ///
-    /// Creates a new static reservation or updates an existing one if the MAC address
-    /// already has a reservation in the specified network. This makes the operation
-    /// idempotent and safe to call multiple times during device registration.
-    ///
-    /// # Errors
-    /// Returns an error if the IP address is already reserved for a different MAC on this network.
-    pub async fn create_or_update_static_reservation(
-        &self,
-        network_id: i64,
-        mac: &str,
-        ip: &str,
-        hostname: Option<&str>,
-    ) -> Result<()> {
-        let now = Utc::now().to_rfc3339();
-        let hostname_owned = hostname.map(|s| s.to_string());
-
-        self.db
-            .execute(
-                "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                 ON CONFLICT(network_id, mac_address) DO UPDATE SET
-                    ip_address = ?3,
-                    hostname = ?4,
-                    updated_at = ?6",
-                (network_id, mac.to_string(), ip.to_string(), hostname_owned, now.clone(), now),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    /// Delete all static reservations for a MAC address across all networks.
-    ///
-    /// This is a bulk deletion operation used when a device is deleted. It removes all
-    /// reservations for the given MAC address regardless of which network they're on.
-    ///
-    /// Returns the number of reservations deleted (0 if the MAC has no reservations).
-    pub async fn delete_static_reservations_by_mac(&self, mac: &str) -> Result<u64> {
-        let deleted = self
-            .db
-            .execute(
-                "DELETE FROM dhcp_static_reservations WHERE mac_address = ?1",
-                (mac.to_string(),),
-            )
-            .await?;
-        Ok(deleted as u64)
-    }
-
-    /// Get leases by network.
-    pub async fn get_leases_by_network(&self, network_id: i64) -> Result<Vec<Lease>> {
-        let leases = self
-            .db
-            .query(
-                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-                 FROM dhcp_leases WHERE network_id = ?1 ORDER BY updated_at DESC",
-                (network_id,),
-                Lease::from_row,
-            )
-            .await?;
-
-        Ok(leases)
-    }
-
-    /// Delete all expired DHCP leases from the database.
-    ///
-    /// Deletes leases in any state where lease_end < now. Returns the number of deleted leases.
-    pub async fn delete_expired_leases(&self) -> Result<u64> {
-        let now = Utc::now().to_rfc3339();
-        let deleted = self
-            .db
-            .execute("DELETE FROM dhcp_leases WHERE lease_end < ?1", (now,))
-            .await?;
-        Ok(deleted as u64)
-    }
+/// Delete all expired DHCP leases from the database.
+pub async fn delete_expired_leases(conn: &Connection) -> Result<u64> {
+    let now = Utc::now().to_rfc3339();
+    let deleted = conn
+        .execute("DELETE FROM dhcp_leases WHERE lease_end < ?1", (now,))
+        .await?;
+    Ok(deleted as u64)
 }
 
 pub fn format_mac(mac: &[u8]) -> String {
@@ -820,41 +766,38 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{database::open, test_database_path};
+    use crate::{database::DatabaseConnectionFactory, test_database_path};
 
     use super::*;
 
-    async fn create_test_store(path: String) -> (DhcpStore, i64) {
-        let db = Arc::new(open(path).await.unwrap());
-        let store = DhcpStore::new(db);
+    async fn setup_db_with_network(path: String) -> (Connection, i64) {
+        let factory = DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        let db = crate::database::run_migrations(&factory).await.unwrap();
 
-        // Create test network
-        let network = store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
-                86400,
-                None,
-                false,
-            )
+        let network = create_network(
+            &db,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string(), "8.8.4.4".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        create_pool(&db, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
-        // Create test pool
-        store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
-            .await
-            .unwrap();
-
-        (store, network.id)
+        (db, network.id)
     }
 
     #[tokio::test]
     async fn test_get_network() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
-        let network = store.get_network(network_id).await.unwrap();
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
+        let network = get_network(&db, network_id).await.unwrap();
         assert_eq!(network.name, "Test Network");
         assert_eq!(network.subnet, "10.0.0.0/24");
         assert_eq!(network.gateway, "10.0.0.1");
@@ -862,40 +805,34 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_by_name() {
-        let (store, _network_id) = create_test_store(test_database_path!()).await;
+        let (db, _network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Test existing network
-        let network = store.get_network_by_name("Test Network").await.unwrap();
+        let network = get_network_by_name(&db, "Test Network").await.unwrap();
         assert!(network.is_some());
-        let network = network.unwrap();
-        assert_eq!(network.name, "Test Network");
+        assert_eq!(network.unwrap().name, "Test Network");
 
-        // Test non-existent network
-        let network = store.get_network_by_name("NonExistent").await.unwrap();
+        let network = get_network_by_name(&db, "NonExistent").await.unwrap();
         assert!(network.is_none());
     }
 
     #[tokio::test]
     async fn test_get_network_by_relay_string() {
-        let (store, _network_id) = create_test_store(test_database_path!()).await;
+        let (db, _network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Create a network with a relay agent
-        store
-            .create_network(
-                "Relay Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        create_network(
+            &db,
+            "Relay Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
-        // Test finding by specific relay agent address
-        let network = store
-            .get_network_by_relay_string(Some("10.0.0.2"))
+        let network = get_network_by_relay_string(&db, Some("10.0.0.2"))
             .await
             .unwrap();
         assert!(network.is_some());
@@ -903,22 +840,15 @@ mod tests {
         assert_eq!(network.name, "Relay Network");
         assert_eq!(network.relay_agent_address, Some("10.0.0.2".to_string()));
 
-        // Test finding local L2 network (None)
-        let network = store.get_network_by_relay_string(None).await.unwrap();
+        let network = get_network_by_relay_string(&db, None).await.unwrap();
         assert!(network.is_some());
-        let network = network.unwrap();
-        assert_eq!(network.name, "Test Network");
-        assert!(network.relay_agent_address.is_none());
+        assert_eq!(network.unwrap().name, "Test Network");
 
-        // Test finding local L2 network (empty string)
-        let network = store.get_network_by_relay_string(Some("")).await.unwrap();
+        let network = get_network_by_relay_string(&db, Some("")).await.unwrap();
         assert!(network.is_some());
-        let network = network.unwrap();
-        assert_eq!(network.name, "Test Network");
+        assert_eq!(network.unwrap().name, "Test Network");
 
-        // Test non-existent relay agent
-        let network = store
-            .get_network_by_relay_string(Some("10.0.0.99"))
+        let network = get_network_by_relay_string(&db, Some("10.0.0.99"))
             .await
             .unwrap();
         assert!(network.is_none());
@@ -932,144 +862,121 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_expired_leases_removes_expired() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Insert a lease that expired 1 hour ago
         let expired_time = (Utc::now() - Duration::hours(1)).to_rfc3339();
-        store.db
-            .execute(
-                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                ("aa:bb:cc:dd:ee:01".to_string(), "10.0.0.101".to_string(), expired_time.clone(), expired_time, "active".to_string(), network_id),
-            )
-            .await
-            .unwrap();
+        db.execute(
+            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            ("aa:bb:cc:dd:ee:01".to_string(), "10.0.0.101".to_string(), expired_time.clone(), expired_time, "active".to_string(), network_id),
+        )
+        .await
+        .unwrap();
 
-        // Delete expired leases
-        let deleted = store.delete_expired_leases().await.unwrap();
+        let deleted = delete_expired_leases(&db).await.unwrap();
         assert_eq!(deleted, 1);
 
-        // Verify the lease is gone
-        let leases = store.get_leases_by_network(network_id).await.unwrap();
+        let leases = get_leases_by_network(&db, network_id).await.unwrap();
         assert_eq!(leases.len(), 0);
     }
 
     #[tokio::test]
     async fn test_delete_expired_leases_preserves_active() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Insert a lease that expires in 1 hour
         let future_time = (Utc::now() + Duration::hours(1)).to_rfc3339();
         let now = Utc::now().to_rfc3339();
-        store.db
-            .execute(
-                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                ("aa:bb:cc:dd:ee:02".to_string(), "10.0.0.102".to_string(), now, future_time, "active".to_string(), network_id),
-            )
-            .await
-            .unwrap();
+        db.execute(
+            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            ("aa:bb:cc:dd:ee:02".to_string(), "10.0.0.102".to_string(), now, future_time, "active".to_string(), network_id),
+        )
+        .await
+        .unwrap();
 
-        // Delete expired leases
-        let deleted = store.delete_expired_leases().await.unwrap();
+        let deleted = delete_expired_leases(&db).await.unwrap();
         assert_eq!(deleted, 0);
 
-        // Verify the lease still exists
-        let leases = store.get_leases_by_network(network_id).await.unwrap();
+        let leases = get_leases_by_network(&db, network_id).await.unwrap();
         assert_eq!(leases.len(), 1);
         assert_eq!(leases[0].mac_address, "aa:bb:cc:dd:ee:02");
     }
 
     #[tokio::test]
     async fn test_delete_expired_leases_mixed() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
         let expired_time = (Utc::now() - Duration::hours(1)).to_rfc3339();
         let future_time = (Utc::now() + Duration::hours(1)).to_rfc3339();
         let now = Utc::now().to_rfc3339();
 
-        // Insert 2 expired leases
-        store.db
-            .execute(
-                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                ("aa:bb:cc:dd:ee:03".to_string(), "10.0.0.103".to_string(), expired_time.clone(), expired_time.clone(), "active".to_string(), network_id),
-            )
-            .await
-            .unwrap();
-        store.db
-            .execute(
-                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                ("aa:bb:cc:dd:ee:04".to_string(), "10.0.0.104".to_string(), expired_time.clone(), expired_time, "offered".to_string(), network_id),
-            )
-            .await
-            .unwrap();
-        // Insert 1 active lease
-        store.db
-            .execute(
-                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                ("aa:bb:cc:dd:ee:05".to_string(), "10.0.0.105".to_string(), now, future_time, "active".to_string(), network_id),
-            )
-            .await
-            .unwrap();
+        db.execute(
+            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            ("aa:bb:cc:dd:ee:03".to_string(), "10.0.0.103".to_string(), expired_time.clone(), expired_time.clone(), "active".to_string(), network_id),
+        )
+        .await
+        .unwrap();
+        db.execute(
+            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            ("aa:bb:cc:dd:ee:04".to_string(), "10.0.0.104".to_string(), expired_time.clone(), expired_time, "offered".to_string(), network_id),
+        )
+        .await
+        .unwrap();
+        db.execute(
+            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            ("aa:bb:cc:dd:ee:05".to_string(), "10.0.0.105".to_string(), now, future_time, "active".to_string(), network_id),
+        )
+        .await
+        .unwrap();
 
-        // Delete expired leases
-        let deleted = store.delete_expired_leases().await.unwrap();
+        let deleted = delete_expired_leases(&db).await.unwrap();
         assert_eq!(deleted, 2);
 
-        // Verify only the active lease remains
-        let leases = store.get_leases_by_network(network_id).await.unwrap();
+        let leases = get_leases_by_network(&db, network_id).await.unwrap();
         assert_eq!(leases.len(), 1);
         assert_eq!(leases[0].mac_address, "aa:bb:cc:dd:ee:05");
     }
 
     #[tokio::test]
     async fn test_delete_expired_leases_no_leases() {
-        let (store, _network_id) = create_test_store(test_database_path!()).await;
+        let (db, _network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Delete expired leases when there are none
-        let deleted = store.delete_expired_leases().await.unwrap();
+        let deleted = delete_expired_leases(&db).await.unwrap();
         assert_eq!(deleted, 0);
     }
 
     #[tokio::test]
     async fn test_delete_expired_leases_released_and_expired() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Insert a released lease that is also expired
         let expired_time = (Utc::now() - Duration::hours(1)).to_rfc3339();
-        store.db
-            .execute(
-                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                ("aa:bb:cc:dd:ee:06".to_string(), "10.0.0.106".to_string(), expired_time.clone(), expired_time, "released".to_string(), network_id),
-            )
-            .await
-            .unwrap();
+        db.execute(
+            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            ("aa:bb:cc:dd:ee:06".to_string(), "10.0.0.106".to_string(), expired_time.clone(), expired_time, "released".to_string(), network_id),
+        )
+        .await
+        .unwrap();
 
-        // Delete expired leases
-        let deleted = store.delete_expired_leases().await.unwrap();
+        let deleted = delete_expired_leases(&db).await.unwrap();
         assert_eq!(deleted, 1);
 
-        // Verify the lease is gone
-        let leases = store.get_leases_by_network(network_id).await.unwrap();
+        let leases = get_leases_by_network(&db, network_id).await.unwrap();
         assert_eq!(leases.len(), 0);
     }
 
     #[tokio::test]
     async fn test_create_or_update_static_reservation_insert() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Create a new reservation
-        store
-            .create_or_update_static_reservation(
-                network_id,
-                "aa:bb:cc:dd:ee:01",
-                "10.0.0.50",
-                Some("test-host"),
-            )
-            .await
-            .unwrap();
+        create_or_update_static_reservation(
+            &db,
+            network_id,
+            "aa:bb:cc:dd:ee:01",
+            "10.0.0.50",
+            Some("test-host"),
+        )
+        .await
+        .unwrap();
 
-        // Verify it was created
-        let reservation = store
-            .get_static_reservation(network_id, "aa:bb:cc:dd:ee:01")
+        let reservation = get_static_reservation(&db, network_id, "aa:bb:cc:dd:ee:01")
             .await
             .unwrap();
         assert!(reservation.is_some());
@@ -1081,32 +988,29 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_or_update_static_reservation_update() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Create initial reservation
-        store
-            .create_or_update_static_reservation(
-                network_id,
-                "aa:bb:cc:dd:ee:02",
-                "10.0.0.51",
-                Some("initial-host"),
-            )
-            .await
-            .unwrap();
+        create_or_update_static_reservation(
+            &db,
+            network_id,
+            "aa:bb:cc:dd:ee:02",
+            "10.0.0.51",
+            Some("initial-host"),
+        )
+        .await
+        .unwrap();
 
-        // Update with different IP and hostname
-        store
-            .create_or_update_static_reservation(
-                network_id,
-                "aa:bb:cc:dd:ee:02",
-                "10.0.0.52",
-                Some("updated-host"),
-            )
-            .await
-            .unwrap();
+        create_or_update_static_reservation(
+            &db,
+            network_id,
+            "aa:bb:cc:dd:ee:02",
+            "10.0.0.52",
+            Some("updated-host"),
+        )
+        .await
+        .unwrap();
 
-        // Verify it was updated, not duplicated
-        let reservations = store.list_static_reservations(network_id).await.unwrap();
+        let reservations = list_static_reservations(&db, network_id).await.unwrap();
         let matching: Vec<_> = reservations
             .iter()
             .filter(|r| r.mac_address == "aa:bb:cc:dd:ee:02")
@@ -1118,43 +1022,49 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_or_update_static_reservation_ip_conflict() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Create reservation for first MAC
-        store
-            .create_or_update_static_reservation(network_id, "aa:bb:cc:dd:ee:03", "10.0.0.53", None)
-            .await
-            .unwrap();
+        create_or_update_static_reservation(
+            &db,
+            network_id,
+            "aa:bb:cc:dd:ee:03",
+            "10.0.0.53",
+            None,
+        )
+        .await
+        .unwrap();
 
-        // Try to create reservation for different MAC with same IP
-        let result = store
-            .create_or_update_static_reservation(network_id, "aa:bb:cc:dd:ee:04", "10.0.0.53", None)
-            .await;
-
-        // Should fail due to UNIQUE constraint on (network_id, ip_address)
+        let result = create_or_update_static_reservation(
+            &db,
+            network_id,
+            "aa:bb:cc:dd:ee:04",
+            "10.0.0.53",
+            None,
+        )
+        .await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_delete_static_reservations_by_mac_single_network() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Create reservation
-        store
-            .create_or_update_static_reservation(network_id, "aa:bb:cc:dd:ee:05", "10.0.0.54", None)
-            .await
-            .unwrap();
+        create_or_update_static_reservation(
+            &db,
+            network_id,
+            "aa:bb:cc:dd:ee:05",
+            "10.0.0.54",
+            None,
+        )
+        .await
+        .unwrap();
 
-        // Delete by MAC
-        let deleted = store
-            .delete_static_reservations_by_mac("aa:bb:cc:dd:ee:05")
+        let deleted = delete_static_reservations_by_mac(&db, "aa:bb:cc:dd:ee:05")
             .await
             .unwrap();
         assert_eq!(deleted, 1);
 
-        // Verify it's gone
-        let reservation = store
-            .get_static_reservation(network_id, "aa:bb:cc:dd:ee:05")
+        let reservation = get_static_reservation(&db, network_id, "aa:bb:cc:dd:ee:05")
             .await
             .unwrap();
         assert!(reservation.is_none());
@@ -1162,64 +1072,64 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_static_reservations_by_mac_multiple_networks() {
-        let (store, network_id) = create_test_store(test_database_path!()).await;
+        let (db, network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Create second network
-        let network2 = store
-            .create_network(
-                "Second Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+        let network2 = create_network(
+            &db,
+            "Second Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
-        // Create reservations on both networks for same MAC
-        store
-            .create_or_update_static_reservation(network_id, "aa:bb:cc:dd:ee:06", "10.0.0.55", None)
-            .await
-            .unwrap();
-        store
-            .create_or_update_static_reservation(
-                network2.id,
-                "aa:bb:cc:dd:ee:06",
-                "192.168.1.55",
-                None,
-            )
-            .await
-            .unwrap();
+        create_or_update_static_reservation(
+            &db,
+            network_id,
+            "aa:bb:cc:dd:ee:06",
+            "10.0.0.55",
+            None,
+        )
+        .await
+        .unwrap();
+        create_or_update_static_reservation(
+            &db,
+            network2.id,
+            "aa:bb:cc:dd:ee:06",
+            "192.168.1.55",
+            None,
+        )
+        .await
+        .unwrap();
 
-        // Delete by MAC - should remove from both networks
-        let deleted = store
-            .delete_static_reservations_by_mac("aa:bb:cc:dd:ee:06")
+        let deleted = delete_static_reservations_by_mac(&db, "aa:bb:cc:dd:ee:06")
             .await
             .unwrap();
         assert_eq!(deleted, 2);
 
-        // Verify both are gone
-        let r1 = store
-            .get_static_reservation(network_id, "aa:bb:cc:dd:ee:06")
-            .await
-            .unwrap();
-        assert!(r1.is_none());
-        let r2 = store
-            .get_static_reservation(network2.id, "aa:bb:cc:dd:ee:06")
-            .await
-            .unwrap();
-        assert!(r2.is_none());
+        assert!(
+            get_static_reservation(&db, network_id, "aa:bb:cc:dd:ee:06")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            get_static_reservation(&db, network2.id, "aa:bb:cc:dd:ee:06")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
     async fn test_delete_static_reservations_by_mac_nonexistent() {
-        let (store, _network_id) = create_test_store(test_database_path!()).await;
+        let (db, _network_id) = setup_db_with_network(test_database_path!()).await;
 
-        // Delete nonexistent MAC - should return 0, not error
-        let deleted = store
-            .delete_static_reservations_by_mac("aa:bb:cc:dd:ee:99")
+        let deleted = delete_static_reservations_by_mac(&db, "aa:bb:cc:dd:ee:99")
             .await
             .unwrap();
         assert_eq!(deleted, 0);

--- a/rack-director/src/dhcp/store.rs
+++ b/rack-director/src/dhcp/store.rs
@@ -430,9 +430,12 @@ pub async fn create_network(
 }
 
 /// Update a network.
+///
+/// All field updates are wrapped in a single transaction so that a partial
+/// failure cannot leave the network in an inconsistent state.
 #[allow(clippy::too_many_arguments)]
 pub async fn update_network(
-    conn: &Connection,
+    conn: &mut Connection,
     id: i64,
     name: Option<&str>,
     subnet: Option<&str>,
@@ -444,22 +447,24 @@ pub async fn update_network(
 ) -> Result<DhcpNetwork> {
     let now = Utc::now().to_rfc3339();
 
+    let tx = conn.transaction().await?;
+
     if let Some(name) = name {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_networks SET name = ?1, updated_at = ?2 WHERE id = ?3",
             (name.to_string(), now.clone(), id),
         )
         .await?;
     }
     if let Some(subnet) = subnet {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_networks SET subnet = ?1, updated_at = ?2 WHERE id = ?3",
             (subnet.to_string(), now.clone(), id),
         )
         .await?;
     }
     if let Some(gateway) = gateway {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_networks SET gateway = ?1, updated_at = ?2 WHERE id = ?3",
             (gateway.to_string(), now.clone(), id),
         )
@@ -467,14 +472,14 @@ pub async fn update_network(
     }
     if let Some(dns_servers) = dns_servers {
         let dns_servers_json = serde_json::to_string(dns_servers)?;
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_networks SET dns_servers = ?1, updated_at = ?2 WHERE id = ?3",
             (dns_servers_json, now.clone(), id),
         )
         .await?;
     }
     if let Some(lease_duration) = lease_duration {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_networks SET lease_duration = ?1, updated_at = ?2 WHERE id = ?3",
             (lease_duration, now.clone(), id),
         )
@@ -482,20 +487,21 @@ pub async fn update_network(
     }
     if let Some(relay_agent_address) = relay_agent_address {
         let relay = relay_agent_address.map(|s| s.to_string());
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_networks SET relay_agent_address = ?1, updated_at = ?2 WHERE id = ?3",
             (relay, now.clone(), id),
         )
         .await?;
     }
     if let Some(enable_autodiscovery) = enable_autodiscovery {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_networks SET enable_autodiscovery = ?1, updated_at = ?2 WHERE id = ?3",
             (enable_autodiscovery, now, id),
         )
         .await?;
     }
 
+    tx.commit().await?;
     get_network(conn, id).await
 }
 
@@ -565,8 +571,11 @@ pub async fn create_pool(
 }
 
 /// Update a pool.
+///
+/// All field updates are wrapped in a single transaction so that a partial
+/// failure cannot leave the pool in an inconsistent state.
 pub async fn update_pool(
-    conn: &Connection,
+    conn: &mut Connection,
     id: i64,
     name: Option<&str>,
     range_start: Option<&str>,
@@ -574,28 +583,31 @@ pub async fn update_pool(
 ) -> Result<DhcpPool> {
     let now = Utc::now().to_rfc3339();
 
+    let tx = conn.transaction().await?;
+
     if let Some(name) = name {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_pools SET name = ?1, updated_at = ?2 WHERE id = ?3",
             (name.to_string(), now.clone(), id),
         )
         .await?;
     }
     if let Some(range_start) = range_start {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_pools SET range_start = ?1, updated_at = ?2 WHERE id = ?3",
             (range_start.to_string(), now.clone(), id),
         )
         .await?;
     }
     if let Some(range_end) = range_end {
-        conn.execute(
+        tx.execute(
             "UPDATE dhcp_pools SET range_end = ?1, updated_at = ?2 WHERE id = ?3",
             (range_end.to_string(), now, id),
         )
         .await?;
     }
 
+    tx.commit().await?;
     get_pool(conn, id).await
 }
 

--- a/rack-director/src/dhcp/store.rs
+++ b/rack-director/src/dhcp/store.rs
@@ -1,17 +1,16 @@
 use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::database::FromRow;
+use crate::database::{Connection, FromRow};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DhcpStore {
-    db: Arc<Mutex<Connection>>,
+    db: Arc<Connection>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -182,11 +181,11 @@ impl FromRow for StaticReservation {
 }
 
 impl DhcpStore {
-    pub fn new(db: Arc<Mutex<Connection>>) -> Self {
+    pub fn new(db: Arc<Connection>) -> Self {
         Self { db }
     }
 
-    /// Create or update a DHCP lease with network context
+    /// Create or update a DHCP lease with network context.
     pub async fn create_or_update_lease_with_network(
         &self,
         mac: &str,
@@ -199,217 +198,231 @@ impl DhcpStore {
         let ip_str = ip.to_string();
         let now = Utc::now();
         let lease_end = now + Duration::seconds(lease_duration as i64);
+        let state_str = state.to_string();
+        let now_str = now.to_rfc3339();
+        let lease_end_str = lease_end.to_rfc3339();
+        let device_uuid_copy = device_uuid.copied();
+        let mac = mac.to_string();
 
-        let db = self.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_leases
-                (mac_address, ip_address, device_uuid, lease_start, lease_end, state, network_id, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-             ON CONFLICT(mac_address) DO UPDATE SET
-                ip_address = ?2,
-                device_uuid = ?3,
-                lease_start = ?4,
-                lease_end = ?5,
-                state = ?6,
-                network_id = ?7,
-                updated_at = ?8",
-            params![
-                mac,
-                ip_str,
-                device_uuid,
-                now.to_rfc3339(),
-                lease_end.to_rfc3339(),
-                state.to_string(),
-                network_id,
-                now.to_rfc3339(),
-            ],
-        )?;
+        self.db
+            .execute(
+                "INSERT INTO dhcp_leases
+                    (mac_address, ip_address, device_uuid, lease_start, lease_end, state, network_id, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(mac_address) DO UPDATE SET
+                    ip_address = ?2,
+                    device_uuid = ?3,
+                    lease_start = ?4,
+                    lease_end = ?5,
+                    state = ?6,
+                    network_id = ?7,
+                    updated_at = ?8",
+                (mac, ip_str, device_uuid_copy, now_str.clone(), lease_end_str, state_str, network_id, now_str),
+            )
+            .await?;
 
         Ok(())
     }
 
-    /// Get lease by MAC address
+    /// Get lease by MAC address.
     pub async fn get_lease_by_mac(&self, mac: &str) -> Result<Option<Lease>> {
-        let db = self.db.lock().await;
-
-        let lease = crate::database::query_optional::<Lease>(
-            &db,
-            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-             FROM dhcp_leases WHERE mac_address = ?",
-            &[&mac],
-        )?;
+        let lease = self
+            .db
+            .query_row(
+                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+                 FROM dhcp_leases WHERE mac_address = ?1",
+                (mac.to_string(),),
+                Lease::from_row,
+            )
+            .await
+            .optional()?;
 
         Ok(lease)
     }
 
-    /// Get lease by ID
+    /// Get lease by ID.
     pub async fn get_lease_by_id(&self, id: i64) -> Result<Option<Lease>> {
-        let db = self.db.lock().await;
-
-        let lease = crate::database::query_optional::<Lease>(
-            &db,
-            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-             FROM dhcp_leases WHERE id = ?",
-            &[&id],
-        )?;
+        let lease = self
+            .db
+            .query_row(
+                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+                 FROM dhcp_leases WHERE id = ?1",
+                (id,),
+                Lease::from_row,
+            )
+            .await
+            .optional()?;
 
         Ok(lease)
     }
 
-    /// Activate a lease (transition from Offered to Active)
+    /// Activate a lease (transition from Offered to Active).
     pub async fn activate_lease(&self, mac: &str) -> Result<()> {
-        let db = self.db.lock().await;
-
-        db.execute(
-            "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
-            params![LeaseState::Active.to_string(), Utc::now().to_rfc3339(), mac],
-        )?;
+        self.db
+            .execute(
+                "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
+                (
+                    LeaseState::Active.to_string(),
+                    Utc::now().to_rfc3339(),
+                    mac.to_string(),
+                ),
+            )
+            .await?;
 
         Ok(())
     }
 
-    /// Release a lease (mark as Released)
+    /// Release a lease (mark as Released).
     pub async fn release_lease(&self, mac: &str) -> Result<()> {
-        let db = self.db.lock().await;
-
-        db.execute(
-            "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
-            params![
-                LeaseState::Released.to_string(),
-                Utc::now().to_rfc3339(),
-                mac
-            ],
-        )?;
+        self.db
+            .execute(
+                "UPDATE dhcp_leases SET state = ?1, updated_at = ?2 WHERE mac_address = ?3",
+                (
+                    LeaseState::Released.to_string(),
+                    Utc::now().to_rfc3339(),
+                    mac.to_string(),
+                ),
+            )
+            .await?;
 
         Ok(())
     }
 
-    /// Get all leases (for API/management)
+    /// Get all leases (for API/management).
     pub async fn get_all_leases(&self) -> Result<Vec<Lease>> {
-        let db = self.db.lock().await;
-
-        let leases = crate::database::query_map_all::<Lease>(
-            &db,
-            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-             FROM dhcp_leases ORDER BY updated_at DESC",
-            &[],
-        )?;
+        let leases = self
+            .db
+            .query(
+                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+                 FROM dhcp_leases ORDER BY updated_at DESC",
+                (),
+                Lease::from_row,
+            )
+            .await?;
 
         Ok(leases)
     }
 
-    /// Find lease by device UUID (synchronous for use in non-async contexts)
-    pub fn find_lease_by_device_uuid(&self, device_uuid: &Uuid) -> Result<Option<Lease>> {
-        // Get the db without using async
-        let db = self
+    /// Find lease by device UUID (async version).
+    pub async fn find_lease_by_device_uuid(&self, device_uuid: &Uuid) -> Result<Option<Lease>> {
+        let lease = self
             .db
-            .try_lock()
-            .map_err(|_| anyhow::anyhow!("Could not lock database"))?;
-
-        let lease = crate::database::query_optional::<Lease>(
-            &db,
-            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-             FROM dhcp_leases WHERE device_uuid = ? AND state = 'active' ORDER BY lease_end DESC LIMIT 1",
-            &[device_uuid],
-        )?;
+            .query_row(
+                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+                 FROM dhcp_leases WHERE device_uuid = ?1 AND state = 'active' ORDER BY lease_end DESC LIMIT 1",
+                (*device_uuid,),
+                Lease::from_row,
+            )
+            .await
+            .optional()?;
 
         Ok(lease)
     }
 
     // ========== Network CRUD Operations ==========
 
-    /// Get a network by ID
+    /// Get a network by ID.
     pub async fn get_network(&self, id: i64) -> Result<DhcpNetwork> {
-        let db = self.db.lock().await;
-
-        let network = crate::database::query_one::<DhcpNetwork>(
-            &db,
-            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-             FROM dhcp_networks WHERE id = ?",
-            &[&id],
-        )?;
+        let network = self
+            .db
+            .query_one(
+                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+                 FROM dhcp_networks WHERE id = ?1",
+                (id,),
+                DhcpNetwork::from_row,
+            )
+            .await?;
 
         Ok(network)
     }
 
-    /// Get a network by relay agent address (or None for local L2)
+    /// Get a network by relay agent address (or None for local L2).
     pub async fn get_network_by_relay(
         &self,
         relay: Option<Ipv4Addr>,
     ) -> Result<Option<DhcpNetwork>> {
-        let db = self.db.lock().await;
         let relay_str = relay.map(|r| r.to_string());
 
-        let network = crate::database::query_optional::<DhcpNetwork>(
-            &db,
-            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-             FROM dhcp_networks WHERE relay_agent_address IS ? OR (relay_agent_address IS NULL AND ? IS NULL)",
-            &[&relay_str, &relay_str],
-        )?;
+        let network = self
+            .db
+            .query_row(
+                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+                 FROM dhcp_networks WHERE relay_agent_address IS ?1 OR (relay_agent_address IS NULL AND ?1 IS NULL)",
+                (relay_str,),
+                DhcpNetwork::from_row,
+            )
+            .await
+            .optional()?;
 
         Ok(network)
     }
 
-    /// Get a network by name
+    /// Get a network by name.
     pub async fn get_network_by_name(&self, name: &str) -> Result<Option<DhcpNetwork>> {
-        let db = self.db.lock().await;
-
-        let network = crate::database::query_optional::<DhcpNetwork>(
-            &db,
-            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-             FROM dhcp_networks WHERE name = ?",
-            &[&name],
-        )?;
+        let network = self
+            .db
+            .query_row(
+                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+                 FROM dhcp_networks WHERE name = ?1",
+                (name.to_string(),),
+                DhcpNetwork::from_row,
+            )
+            .await
+            .optional()?;
 
         Ok(network)
     }
 
-    /// Get a network by relay agent address string (checking both NULL and empty string for local L2)
+    /// Get a network by relay agent address string, checking both NULL and empty string for local L2.
     pub async fn get_network_by_relay_string(
         &self,
         relay_agent_address: Option<&str>,
     ) -> Result<Option<DhcpNetwork>> {
-        let db = self.db.lock().await;
-
         // Handle the three cases:
         // 1. None or Some("") - Local L2 network (NULL or empty string)
         // 2. Some(address) - Specific relay agent address
         let network = match relay_agent_address {
-            None | Some("") => crate::database::query_optional::<DhcpNetwork>(
-                &db,
-                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                 FROM dhcp_networks WHERE relay_agent_address IS NULL OR relay_agent_address = ''",
-                &[],
-            )?,
-            Some(addr) => {
-                let addr_string = addr.to_string();
-                crate::database::query_optional::<DhcpNetwork>(
-                    &db,
+            None | Some("") => self
+                .db
+                .query_row(
                     "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-                     FROM dhcp_networks WHERE relay_agent_address = ?",
-                    &[&addr_string],
-                )?
-            }
+                     FROM dhcp_networks WHERE relay_agent_address IS NULL OR relay_agent_address = ''",
+                    (),
+                    DhcpNetwork::from_row,
+                )
+                .await
+                .optional()?,
+            Some(addr) => self
+                .db
+                .query_row(
+                    "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+                     FROM dhcp_networks WHERE relay_agent_address = ?1",
+                    (addr.to_string(),),
+                    DhcpNetwork::from_row,
+                )
+                .await
+                .optional()?,
         };
 
         Ok(network)
     }
 
-    /// List all networks
+    /// List all networks.
     pub async fn list_networks(&self) -> Result<Vec<DhcpNetwork>> {
-        let db = self.db.lock().await;
-
-        let networks = crate::database::query_map_all::<DhcpNetwork>(
-            &db,
-            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
-             FROM dhcp_networks ORDER BY name",
-            &[],
-        )?;
+        let networks = self
+            .db
+            .query(
+                "SELECT id, name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at
+                 FROM dhcp_networks ORDER BY name",
+                (),
+                DhcpNetwork::from_row,
+            )
+            .await?;
 
         Ok(networks)
     }
 
-    /// Create a new network
+    /// Create a new network.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_network(
         &self,
@@ -423,21 +436,21 @@ impl DhcpStore {
     ) -> Result<DhcpNetwork> {
         let dns_servers_json = serde_json::to_string(dns_servers)?;
         let now = Utc::now().to_rfc3339();
+        let relay = relay_agent_address.map(|s| s.to_string());
 
-        let db = self.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_networks (name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![name, subnet, gateway, dns_servers_json, lease_duration, relay_agent_address, enable_autodiscovery, now, now],
-        )?;
+        self.db
+            .execute(
+                "INSERT INTO dhcp_networks (name, subnet, gateway, dns_servers, lease_duration, relay_agent_address, enable_autodiscovery, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                (name.to_string(), subnet.to_string(), gateway.to_string(), dns_servers_json, lease_duration, relay, enable_autodiscovery, now.clone(), now),
+            )
+            .await?;
 
-        let id = db.last_insert_rowid();
-        drop(db);
-
+        let id = self.db.last_insert_rowid().await;
         self.get_network(id).await
     }
 
-    /// Update a network
+    /// Update a network.
     #[allow(clippy::too_many_arguments)]
     pub async fn update_network(
         &self,
@@ -451,94 +464,110 @@ impl DhcpStore {
         enable_autodiscovery: Option<bool>,
     ) -> Result<DhcpNetwork> {
         let now = Utc::now().to_rfc3339();
-        let db = self.db.lock().await;
 
         if let Some(name) = name {
-            db.execute(
-                "UPDATE dhcp_networks SET name = ?, updated_at = ? WHERE id = ?",
-                params![name, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_networks SET name = ?1, updated_at = ?2 WHERE id = ?3",
+                    (name.to_string(), now.clone(), id),
+                )
+                .await?;
         }
         if let Some(subnet) = subnet {
-            db.execute(
-                "UPDATE dhcp_networks SET subnet = ?, updated_at = ? WHERE id = ?",
-                params![subnet, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_networks SET subnet = ?1, updated_at = ?2 WHERE id = ?3",
+                    (subnet.to_string(), now.clone(), id),
+                )
+                .await?;
         }
         if let Some(gateway) = gateway {
-            db.execute(
-                "UPDATE dhcp_networks SET gateway = ?, updated_at = ? WHERE id = ?",
-                params![gateway, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_networks SET gateway = ?1, updated_at = ?2 WHERE id = ?3",
+                    (gateway.to_string(), now.clone(), id),
+                )
+                .await?;
         }
         if let Some(dns_servers) = dns_servers {
             let dns_servers_json = serde_json::to_string(dns_servers)?;
-            db.execute(
-                "UPDATE dhcp_networks SET dns_servers = ?, updated_at = ? WHERE id = ?",
-                params![dns_servers_json, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_networks SET dns_servers = ?1, updated_at = ?2 WHERE id = ?3",
+                    (dns_servers_json, now.clone(), id),
+                )
+                .await?;
         }
         if let Some(lease_duration) = lease_duration {
-            db.execute(
-                "UPDATE dhcp_networks SET lease_duration = ?, updated_at = ? WHERE id = ?",
-                params![lease_duration, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_networks SET lease_duration = ?1, updated_at = ?2 WHERE id = ?3",
+                    (lease_duration, now.clone(), id),
+                )
+                .await?;
         }
         if let Some(relay_agent_address) = relay_agent_address {
-            db.execute(
-                "UPDATE dhcp_networks SET relay_agent_address = ?, updated_at = ? WHERE id = ?",
-                params![relay_agent_address, now, id],
-            )?;
+            let relay = relay_agent_address.map(|s| s.to_string());
+            self.db
+                .execute(
+                    "UPDATE dhcp_networks SET relay_agent_address = ?1, updated_at = ?2 WHERE id = ?3",
+                    (relay, now.clone(), id),
+                )
+                .await?;
         }
         if let Some(enable_autodiscovery) = enable_autodiscovery {
-            db.execute(
-                "UPDATE dhcp_networks SET enable_autodiscovery = ?, updated_at = ? WHERE id = ?",
-                params![enable_autodiscovery, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_networks SET enable_autodiscovery = ?1, updated_at = ?2 WHERE id = ?3",
+                    (enable_autodiscovery, now, id),
+                )
+                .await?;
         }
 
-        drop(db);
         self.get_network(id).await
     }
 
-    /// Delete a network
+    /// Delete a network.
     pub async fn delete_network(&self, id: i64) -> Result<()> {
-        let db = self.db.lock().await;
-        db.execute("DELETE FROM dhcp_networks WHERE id = ?", params![id])?;
+        self.db
+            .execute("DELETE FROM dhcp_networks WHERE id = ?1", (id,))
+            .await?;
         Ok(())
     }
 
     // ========== Pool CRUD Operations ==========
 
-    /// Get a pool by ID
+    /// Get a pool by ID.
     pub async fn get_pool(&self, id: i64) -> Result<DhcpPool> {
-        let db = self.db.lock().await;
-
-        let pool = crate::database::query_one::<DhcpPool>(
-            &db,
-            "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
-             FROM dhcp_pools WHERE id = ?",
-            &[&id],
-        )?;
+        let pool = self
+            .db
+            .query_one(
+                "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
+                 FROM dhcp_pools WHERE id = ?1",
+                (id,),
+                DhcpPool::from_row,
+            )
+            .await?;
 
         Ok(pool)
     }
 
-    /// List all pools for a network
+    /// List all pools for a network.
     pub async fn list_pools_for_network(&self, network_id: i64) -> Result<Vec<DhcpPool>> {
-        let db = self.db.lock().await;
-
-        let pools = crate::database::query_map_all::<DhcpPool>(
-            &db,
-            "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
-             FROM dhcp_pools WHERE network_id = ? ORDER BY name",
-            &[&network_id],
-        )?;
+        let pools = self
+            .db
+            .query(
+                "SELECT id, network_id, name, range_start, range_end, created_at, updated_at
+                 FROM dhcp_pools WHERE network_id = ?1 ORDER BY name",
+                (network_id,),
+                DhcpPool::from_row,
+            )
+            .await?;
 
         Ok(pools)
     }
 
-    /// Create a new pool
+    /// Create a new pool.
     pub async fn create_pool(
         &self,
         network_id: i64,
@@ -548,20 +577,19 @@ impl DhcpStore {
     ) -> Result<DhcpPool> {
         let now = Utc::now().to_rfc3339();
 
-        let db = self.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_pools (network_id, name, range_start, range_end, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![network_id, name, range_start, range_end, now, now],
-        )?;
+        self.db
+            .execute(
+                "INSERT INTO dhcp_pools (network_id, name, range_start, range_end, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                (network_id, name.to_string(), range_start.to_string(), range_end.to_string(), now.clone(), now),
+            )
+            .await?;
 
-        let id = db.last_insert_rowid();
-        drop(db);
-
+        let id = self.db.last_insert_rowid().await;
         self.get_pool(id).await
     }
 
-    /// Update a pool
+    /// Update a pool.
     pub async fn update_pool(
         &self,
         id: i64,
@@ -570,76 +598,84 @@ impl DhcpStore {
         range_end: Option<&str>,
     ) -> Result<DhcpPool> {
         let now = Utc::now().to_rfc3339();
-        let db = self.db.lock().await;
 
         if let Some(name) = name {
-            db.execute(
-                "UPDATE dhcp_pools SET name = ?, updated_at = ? WHERE id = ?",
-                params![name, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_pools SET name = ?1, updated_at = ?2 WHERE id = ?3",
+                    (name.to_string(), now.clone(), id),
+                )
+                .await?;
         }
         if let Some(range_start) = range_start {
-            db.execute(
-                "UPDATE dhcp_pools SET range_start = ?, updated_at = ? WHERE id = ?",
-                params![range_start, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_pools SET range_start = ?1, updated_at = ?2 WHERE id = ?3",
+                    (range_start.to_string(), now.clone(), id),
+                )
+                .await?;
         }
         if let Some(range_end) = range_end {
-            db.execute(
-                "UPDATE dhcp_pools SET range_end = ?, updated_at = ? WHERE id = ?",
-                params![range_end, now, id],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE dhcp_pools SET range_end = ?1, updated_at = ?2 WHERE id = ?3",
+                    (range_end.to_string(), now, id),
+                )
+                .await?;
         }
 
-        drop(db);
         self.get_pool(id).await
     }
 
-    /// Delete a pool
+    /// Delete a pool.
     pub async fn delete_pool(&self, id: i64) -> Result<()> {
-        let db = self.db.lock().await;
-        db.execute("DELETE FROM dhcp_pools WHERE id = ?", params![id])?;
+        self.db
+            .execute("DELETE FROM dhcp_pools WHERE id = ?1", (id,))
+            .await?;
         Ok(())
     }
 
     // ========== Static Reservation CRUD Operations ==========
 
-    /// Get a static reservation for a MAC address in a network
+    /// Get a static reservation for a MAC address in a network.
     pub async fn get_static_reservation(
         &self,
         network_id: i64,
         mac: &str,
     ) -> Result<Option<StaticReservation>> {
-        let db = self.db.lock().await;
-
-        let reservation = crate::database::query_optional::<StaticReservation>(
-            &db,
-            "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
-             FROM dhcp_static_reservations WHERE network_id = ? AND mac_address = ?",
-            &[&network_id, &mac],
-        )?;
+        let reservation = self
+            .db
+            .query_row(
+                "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
+                 FROM dhcp_static_reservations WHERE network_id = ?1 AND mac_address = ?2",
+                (network_id, mac.to_string()),
+                StaticReservation::from_row,
+            )
+            .await
+            .optional()?;
 
         Ok(reservation)
     }
 
-    /// List all static reservations for a network
+    /// List all static reservations for a network.
     pub async fn list_static_reservations(
         &self,
         network_id: i64,
     ) -> Result<Vec<StaticReservation>> {
-        let db = self.db.lock().await;
-
-        let reservations = crate::database::query_map_all::<StaticReservation>(
-            &db,
-            "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
-             FROM dhcp_static_reservations WHERE network_id = ? ORDER BY ip_address",
-            &[&network_id],
-        )?;
+        let reservations = self
+            .db
+            .query(
+                "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
+                 FROM dhcp_static_reservations WHERE network_id = ?1 ORDER BY ip_address",
+                (network_id,),
+                StaticReservation::from_row,
+            )
+            .await?;
 
         Ok(reservations)
     }
 
-    /// Create a static reservation
+    /// Create a static reservation.
     pub async fn create_static_reservation(
         &self,
         network_id: i64,
@@ -648,53 +684,48 @@ impl DhcpStore {
         hostname: Option<&str>,
     ) -> Result<StaticReservation> {
         let now = Utc::now().to_rfc3339();
+        let hostname_owned = hostname.map(|s| s.to_string());
 
-        let db = self.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![network_id, mac, ip, hostname, now, now],
-        )?;
+        self.db
+            .execute(
+                "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                (network_id, mac.to_string(), ip.to_string(), hostname_owned, now.clone(), now),
+            )
+            .await?;
 
-        let id = db.last_insert_rowid();
+        let id = self.db.last_insert_rowid().await;
 
         // Fetch and return the created reservation
-        let reservation = crate::database::query_one::<StaticReservation>(
-            &db,
-            "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
-             FROM dhcp_static_reservations WHERE id = ?",
-            &[&id],
-        )?;
+        let reservation = self
+            .db
+            .query_one(
+                "SELECT id, network_id, mac_address, ip_address, hostname, created_at, updated_at
+                 FROM dhcp_static_reservations WHERE id = ?1",
+                (id,),
+                StaticReservation::from_row,
+            )
+            .await?;
 
         Ok(reservation)
     }
 
-    /// Delete a static reservation
+    /// Delete a static reservation.
     pub async fn delete_static_reservation(&self, id: i64) -> Result<()> {
-        let db = self.db.lock().await;
-        db.execute(
-            "DELETE FROM dhcp_static_reservations WHERE id = ?",
-            params![id],
-        )?;
+        self.db
+            .execute("DELETE FROM dhcp_static_reservations WHERE id = ?1", (id,))
+            .await?;
         Ok(())
     }
 
-    /// Create or update a static reservation (upsert)
+    /// Create or update a static reservation (upsert).
     ///
     /// Creates a new static reservation or updates an existing one if the MAC address
     /// already has a reservation in the specified network. This makes the operation
     /// idempotent and safe to call multiple times during device registration.
     ///
-    /// # Arguments
-    /// * `network_id` - The network ID for the reservation
-    /// * `mac` - The MAC address to reserve
-    /// * `ip` - The IP address to assign
-    /// * `hostname` - Optional hostname for the reservation
-    ///
     /// # Errors
-    /// Returns an error if:
-    /// - The IP address is already reserved for a different MAC on this network
-    /// - Database constraint violation occurs
+    /// Returns an error if the IP address is already reserved for a different MAC on this network.
     pub async fn create_or_update_static_reservation(
         &self,
         network_id: i64,
@@ -703,75 +734,64 @@ impl DhcpStore {
         hostname: Option<&str>,
     ) -> Result<()> {
         let now = Utc::now().to_rfc3339();
+        let hostname_owned = hostname.map(|s| s.to_string());
 
-        let db = self.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(network_id, mac_address) DO UPDATE SET
-                ip_address = ?3,
-                hostname = ?4,
-                updated_at = ?6",
-            params![network_id, mac, ip, hostname, now, now],
-        )?;
+        self.db
+            .execute(
+                "INSERT INTO dhcp_static_reservations (network_id, mac_address, ip_address, hostname, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(network_id, mac_address) DO UPDATE SET
+                    ip_address = ?3,
+                    hostname = ?4,
+                    updated_at = ?6",
+                (network_id, mac.to_string(), ip.to_string(), hostname_owned, now.clone(), now),
+            )
+            .await?;
 
         Ok(())
     }
 
-    /// Delete all static reservations for a MAC address across all networks
+    /// Delete all static reservations for a MAC address across all networks.
     ///
-    /// This is a bulk deletion operation used when a device is deleted.
-    /// It removes all reservations for the given MAC address regardless of which
-    /// network they're on.
+    /// This is a bulk deletion operation used when a device is deleted. It removes all
+    /// reservations for the given MAC address regardless of which network they're on.
     ///
-    /// # Arguments
-    /// * `mac` - The MAC address to delete reservations for
-    ///
-    /// # Returns
-    /// The number of reservations deleted (0 if the MAC has no reservations)
+    /// Returns the number of reservations deleted (0 if the MAC has no reservations).
     pub async fn delete_static_reservations_by_mac(&self, mac: &str) -> Result<u64> {
-        let db = self.db.lock().await;
-        let deleted = db.execute(
-            "DELETE FROM dhcp_static_reservations WHERE mac_address = ?",
-            params![mac],
-        )?;
+        let deleted = self
+            .db
+            .execute(
+                "DELETE FROM dhcp_static_reservations WHERE mac_address = ?1",
+                (mac.to_string(),),
+            )
+            .await?;
         Ok(deleted as u64)
     }
 
-    /// Get leases by network
+    /// Get leases by network.
     pub async fn get_leases_by_network(&self, network_id: i64) -> Result<Vec<Lease>> {
-        let db = self.db.lock().await;
-        let mut stmt = db.prepare(
-            "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
-             FROM dhcp_leases WHERE network_id = ? ORDER BY updated_at DESC",
-        )?;
-
-        let leases = stmt
-            .query_map(params![network_id], |row| {
-                Ok(Lease {
-                    id: row.get(0)?,
-                    mac_address: row.get(1)?,
-                    ip_address: row.get(2)?,
-                    device_uuid: row.get(3)?,
-                    lease_start: row.get::<_, String>(4)?.parse().unwrap(),
-                    lease_end: row.get::<_, String>(5)?.parse().unwrap(),
-                    state: row.get::<_, String>(6)?.parse().unwrap(),
-                    hostname: row.get(7)?,
-                    network_id: row.get(8)?,
-                })
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
+        let leases = self
+            .db
+            .query(
+                "SELECT id, mac_address, ip_address, device_uuid, lease_start, lease_end, state, hostname, network_id
+                 FROM dhcp_leases WHERE network_id = ?1 ORDER BY updated_at DESC",
+                (network_id,),
+                Lease::from_row,
+            )
+            .await?;
 
         Ok(leases)
     }
 
     /// Delete all expired DHCP leases from the database.
-    /// Deletes leases in any state where lease_end < now.
-    /// Returns the number of deleted leases.
+    ///
+    /// Deletes leases in any state where lease_end < now. Returns the number of deleted leases.
     pub async fn delete_expired_leases(&self) -> Result<u64> {
         let now = Utc::now().to_rfc3339();
-        let db = self.db.lock().await;
-        let deleted = db.execute("DELETE FROM dhcp_leases WHERE lease_end < ?1", params![now])?;
+        let deleted = self
+            .db
+            .execute("DELETE FROM dhcp_leases WHERE lease_end < ?1", (now,))
+            .await?;
         Ok(deleted as u64)
     }
 }
@@ -783,7 +803,7 @@ pub fn format_mac(mac: &[u8]) -> String {
         .join(":")
 }
 
-/// Parse datetime from SQLite's CURRENT_TIMESTAMP format or RFC3339
+/// Parse datetime from SQLite's CURRENT_TIMESTAMP format or RFC3339.
 fn parse_datetime(s: &str) -> Result<DateTime<Utc>> {
     // Try RFC3339 first
     if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
@@ -800,14 +820,13 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use tempfile::tempdir;
+    use crate::{database::open, test_database_path};
 
-    async fn create_test_store() -> (DhcpStore, i64, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let conn = crate::database::open(db_path).unwrap();
-        let store = DhcpStore::new(Arc::new(Mutex::new(conn)));
+    use super::*;
+
+    async fn create_test_store(path: String) -> (DhcpStore, i64) {
+        let db = Arc::new(open(path).await.unwrap());
+        let store = DhcpStore::new(db);
 
         // Create test network
         let network = store
@@ -829,12 +848,12 @@ mod tests {
             .await
             .unwrap();
 
-        (store, network.id, temp_dir)
+        (store, network.id)
     }
 
     #[tokio::test]
     async fn test_get_network() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
         let network = store.get_network(network_id).await.unwrap();
         assert_eq!(network.name, "Test Network");
         assert_eq!(network.subnet, "10.0.0.0/24");
@@ -843,7 +862,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_by_name() {
-        let (store, _network_id, _temp_dir) = create_test_store().await;
+        let (store, _network_id) = create_test_store(test_database_path!()).await;
 
         // Test existing network
         let network = store.get_network_by_name("Test Network").await.unwrap();
@@ -858,7 +877,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_by_relay_string() {
-        let (store, _network_id, _temp_dir) = create_test_store().await;
+        let (store, _network_id) = create_test_store(test_database_path!()).await;
 
         // Create a network with a relay agent
         store
@@ -913,16 +932,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_expired_leases_removes_expired() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Insert a lease that expired 1 hour ago
         let expired_time = (Utc::now() - Duration::hours(1)).to_rfc3339();
-        let db = store.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?, ?, ?, ?, ?, ?)",
-            params!["aa:bb:cc:dd:ee:01", "10.0.0.101", expired_time, expired_time, "active", network_id],
-        ).unwrap();
-        drop(db);
+        store.db
+            .execute(
+                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                ("aa:bb:cc:dd:ee:01".to_string(), "10.0.0.101".to_string(), expired_time.clone(), expired_time, "active".to_string(), network_id),
+            )
+            .await
+            .unwrap();
 
         // Delete expired leases
         let deleted = store.delete_expired_leases().await.unwrap();
@@ -935,17 +955,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_expired_leases_preserves_active() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Insert a lease that expires in 1 hour
         let future_time = (Utc::now() + Duration::hours(1)).to_rfc3339();
         let now = Utc::now().to_rfc3339();
-        let db = store.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?, ?, ?, ?, ?, ?)",
-            params!["aa:bb:cc:dd:ee:02", "10.0.0.102", now, future_time, "active", network_id],
-        ).unwrap();
-        drop(db);
+        store.db
+            .execute(
+                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                ("aa:bb:cc:dd:ee:02".to_string(), "10.0.0.102".to_string(), now, future_time, "active".to_string(), network_id),
+            )
+            .await
+            .unwrap();
 
         // Delete expired leases
         let deleted = store.delete_expired_leases().await.unwrap();
@@ -959,28 +980,35 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_expired_leases_mixed() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         let expired_time = (Utc::now() - Duration::hours(1)).to_rfc3339();
         let future_time = (Utc::now() + Duration::hours(1)).to_rfc3339();
         let now = Utc::now().to_rfc3339();
 
-        let db = store.db.lock().await;
         // Insert 2 expired leases
-        db.execute(
-            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?, ?, ?, ?, ?, ?)",
-            params!["aa:bb:cc:dd:ee:03", "10.0.0.103", expired_time, expired_time, "active", network_id],
-        ).unwrap();
-        db.execute(
-            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?, ?, ?, ?, ?, ?)",
-            params!["aa:bb:cc:dd:ee:04", "10.0.0.104", expired_time, expired_time, "offered", network_id],
-        ).unwrap();
+        store.db
+            .execute(
+                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                ("aa:bb:cc:dd:ee:03".to_string(), "10.0.0.103".to_string(), expired_time.clone(), expired_time.clone(), "active".to_string(), network_id),
+            )
+            .await
+            .unwrap();
+        store.db
+            .execute(
+                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                ("aa:bb:cc:dd:ee:04".to_string(), "10.0.0.104".to_string(), expired_time.clone(), expired_time, "offered".to_string(), network_id),
+            )
+            .await
+            .unwrap();
         // Insert 1 active lease
-        db.execute(
-            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?, ?, ?, ?, ?, ?)",
-            params!["aa:bb:cc:dd:ee:05", "10.0.0.105", now, future_time, "active", network_id],
-        ).unwrap();
-        drop(db);
+        store.db
+            .execute(
+                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                ("aa:bb:cc:dd:ee:05".to_string(), "10.0.0.105".to_string(), now, future_time, "active".to_string(), network_id),
+            )
+            .await
+            .unwrap();
 
         // Delete expired leases
         let deleted = store.delete_expired_leases().await.unwrap();
@@ -994,7 +1022,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_expired_leases_no_leases() {
-        let (store, _network_id, _temp_dir) = create_test_store().await;
+        let (store, _network_id) = create_test_store(test_database_path!()).await;
 
         // Delete expired leases when there are none
         let deleted = store.delete_expired_leases().await.unwrap();
@@ -1003,16 +1031,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_expired_leases_released_and_expired() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Insert a released lease that is also expired
         let expired_time = (Utc::now() - Duration::hours(1)).to_rfc3339();
-        let db = store.db.lock().await;
-        db.execute(
-            "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?, ?, ?, ?, ?, ?)",
-            params!["aa:bb:cc:dd:ee:06", "10.0.0.106", expired_time, expired_time, "released", network_id],
-        ).unwrap();
-        drop(db);
+        store.db
+            .execute(
+                "INSERT INTO dhcp_leases (mac_address, ip_address, lease_start, lease_end, state, network_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                ("aa:bb:cc:dd:ee:06".to_string(), "10.0.0.106".to_string(), expired_time.clone(), expired_time, "released".to_string(), network_id),
+            )
+            .await
+            .unwrap();
 
         // Delete expired leases
         let deleted = store.delete_expired_leases().await.unwrap();
@@ -1025,7 +1054,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_or_update_static_reservation_insert() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Create a new reservation
         store
@@ -1052,7 +1081,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_or_update_static_reservation_update() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Create initial reservation
         store
@@ -1089,7 +1118,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_or_update_static_reservation_ip_conflict() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Create reservation for first MAC
         store
@@ -1108,7 +1137,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_static_reservations_by_mac_single_network() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Create reservation
         store
@@ -1133,7 +1162,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_static_reservations_by_mac_multiple_networks() {
-        let (store, network_id, _temp_dir) = create_test_store().await;
+        let (store, network_id) = create_test_store(test_database_path!()).await;
 
         // Create second network
         let network2 = store
@@ -1186,7 +1215,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_static_reservations_by_mac_nonexistent() {
-        let (store, _network_id, _temp_dir) = create_test_store().await;
+        let (store, _network_id) = create_test_store(test_database_path!()).await;
 
         // Delete nonexistent MAC - should return 0, not error
         let deleted = store

--- a/rack-director/src/director/devices/mod.rs
+++ b/rack-director/src/director/devices/mod.rs
@@ -1,0 +1,1 @@
+mod store;

--- a/rack-director/src/director/devices/mod.rs
+++ b/rack-director/src/director/devices/mod.rs
@@ -1,1 +1,0 @@
-mod store;

--- a/rack-director/src/director/devices/store.rs
+++ b/rack-director/src/director/devices/store.rs
@@ -1,0 +1,14 @@
+use uuid::Uuid;
+
+use crate::database::{Connection, FromRow};
+use crate::director::store::Device;
+
+/// Get a device by UUID.
+pub async fn get_device_by_uuid(conn: &Connection, uuid: &Uuid) -> rusqlite::Result<Device> {
+    conn.query_one(
+        "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices WHERE uuid = ?1",
+        (*uuid,),
+        Device::from_row,
+    )
+    .await
+}

--- a/rack-director/src/director/devices/store.rs
+++ b/rack-director/src/director/devices/store.rs
@@ -4,6 +4,7 @@ use crate::database::{Connection, FromRow};
 use crate::director::store::Device;
 
 /// Get a device by UUID.
+#[allow(dead_code)]
 pub async fn get_device_by_uuid(conn: &Connection, uuid: &Uuid) -> rusqlite::Result<Device> {
     conn.query_one(
         "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices WHERE uuid = ?1",

--- a/rack-director/src/director/mod.rs
+++ b/rack-director/src/director/mod.rs
@@ -1,19 +1,12 @@
-use std::sync::Arc;
-
 use uuid::Uuid;
 
 use crate::database::Connection;
-use crate::dhcp::DhcpStore;
-use crate::director::store::DirectorStore;
 use crate::director::store::generate_hostname_from_uuid;
-use crate::lifecycle::{DeviceLifecycle, LifecycleManager, LifecycleStore, LifecycleTransition};
-use crate::operating_systems::{Architecture, OperatingSystemsStore};
+use crate::lifecycle::{DeviceLifecycle, LifecycleManager, LifecycleTransition};
+use crate::operating_systems::Architecture;
 use crate::plans::actions::BootTarget;
-use crate::plans::{Plan, PlanStatus, PlansStore};
-use crate::platforms::PlatformsStore;
-use crate::roles::RolesStore;
+use crate::plans::{Plan, PlanStatus};
 
-mod devices;
 mod ipmi;
 pub(crate) mod store;
 
@@ -21,35 +14,19 @@ pub use common::device_attributes::NetworkInterface;
 pub use store::Device;
 pub use store::PendingDevice;
 
-#[derive(Clone)]
-pub struct Director {
-    store: DirectorStore,
-    plans_store: PlansStore,
-    lifecycle_store: LifecycleStore,
-    os_store: OperatingSystemsStore,
-    roles_store: RolesStore,
-    platforms_store: PlatformsStore,
-    dhcp_store: DhcpStore,
+/// Short-lived handle for executing device management operations against an open database
+/// connection.
+///
+/// `Director<'a>` borrows a `Connection` for its lifetime and uses it directly for all
+/// database access. It is constructed at the start of a request or packet handler and
+/// dropped at the end; it never opens a new connection itself.
+pub struct Director<'a> {
+    conn: &'a Connection,
 }
 
-impl Director {
-    pub fn new(db: Arc<Connection>) -> Self {
-        let store = DirectorStore::new(db.clone());
-        let plans_store = PlansStore::new(db.clone());
-        let lifecycle_store = LifecycleStore::new(db.clone());
-        let os_store = OperatingSystemsStore::new(db.clone());
-        let roles_store = RolesStore::new(db.clone());
-        let platforms_store = PlatformsStore::new(db.clone());
-        let dhcp_store = DhcpStore::new(db);
-        Director {
-            store,
-            plans_store,
-            lifecycle_store,
-            os_store,
-            roles_store,
-            platforms_store,
-            dhcp_store,
-        }
+impl<'a> Director<'a> {
+    pub fn new(conn: &'a Connection) -> Self {
+        Director { conn }
     }
 
     pub async fn register_device(
@@ -58,10 +35,8 @@ impl Director {
         architecture: Architecture,
     ) -> anyhow::Result<()> {
         log::info!("Registering device {uuid}");
-        self.store.register_device(uuid, architecture).await?;
-        self.store
-            .set_hostname(uuid, &generate_hostname_from_uuid(uuid))
-            .await?;
+        store::register_device(self.conn, uuid, architecture).await?;
+        store::set_hostname(self.conn, uuid, &generate_hostname_from_uuid(uuid)).await?;
 
         // Set default BMC config to DHCP
         // Credentials will be auto-generated on first agent fetch
@@ -79,36 +54,34 @@ impl Director {
             "bmc_config".to_string(),
             serde_json::to_value(&default_bmc_config)?,
         );
-        self.store.update_attributes(uuid, attrs).await?;
+        store::update_attributes(self.conn, uuid, attrs).await?;
 
         Ok(())
     }
 
     pub async fn device_exists(&self, uuid: &Uuid) -> anyhow::Result<bool> {
-        let exists = self.store.device_exists(uuid).await?;
-        Ok(exists)
+        store::device_exists(self.conn, uuid).await
     }
 
     /// Get the boot target for this device.
     pub async fn next_boot_target(&self, uuid: &Uuid) -> anyhow::Result<BootTarget> {
         if self.device_exists(uuid).await? {
-            self.store
-                .update_device_last_seen(uuid)
+            store::update_device_last_seen(self.conn, uuid)
                 .await
                 .expect("update device last seen should not fail");
 
             // Check if there's an active plan for this device
-            if let Some(plan) = self.plans_store.get_active_plan_for_device(uuid).await?
+            if let Some(plan) =
+                crate::plans::store::get_active_plan_for_device(self.conn, uuid).await?
                 && let Some(current_action) = plan.get_current_action()
             {
                 // Get device for ActionContext
-                let device = self.get_device(uuid).await?;
+                let device = store::get_device(self.conn, uuid).await?;
 
                 // Create ActionContext for the action
                 let ctx = crate::plans::actions::ActionContext {
                     device: &device,
-                    os_store: &self.os_store,
-                    roles_store: &self.roles_store,
+                    conn: self.conn,
                     director: None, // Director not needed for boot target resolution
                 };
 
@@ -133,7 +106,7 @@ impl Director {
             || attributes.contains_key("network_interfaces");
 
         // Update the attributes
-        self.store.update_attributes(uuid, attributes).await?;
+        store::update_attributes(self.conn, uuid, attributes).await?;
 
         // Auto-detect platform after hardware discovery data is received
         if contains_hardware_info && let Err(e) = self.auto_detect_platform(uuid).await {
@@ -150,8 +123,9 @@ impl Director {
         Ok(())
     }
 
+    #[cfg(test)]
     pub async fn create_plan(&self, plan: &Plan) -> anyhow::Result<i64> {
-        self.plans_store.create_plan(plan).await
+        crate::plans::store::create_plan(self.conn, plan).await
     }
 
     #[cfg(test)]
@@ -159,9 +133,7 @@ impl Director {
         &self,
         device_uuid: &Uuid,
     ) -> anyhow::Result<Option<Plan>> {
-        self.plans_store
-            .get_active_plan_for_device(device_uuid)
-            .await
+        crate::plans::store::get_active_plan_for_device(self.conn, device_uuid).await
     }
 
     /// Handle device boot event
@@ -171,18 +143,15 @@ impl Director {
     /// This is used for actions like RebootDevice that complete when the device boots.
     pub async fn on_boot(&self, device_uuid: &Uuid) -> anyhow::Result<()> {
         // Get the current active plan
-        let mut plan = match self
-            .plans_store
-            .get_active_plan_for_device(device_uuid)
-            .await?
-        {
-            Some(plan) => plan,
-            None => {
-                // No active plan - this is normal for devices that have completed their lifecycle
-                log::debug!("No active plan for device {} on boot", device_uuid);
-                return Ok(());
-            }
-        };
+        let mut plan =
+            match crate::plans::store::get_active_plan_for_device(self.conn, device_uuid).await? {
+                Some(plan) => plan,
+                None => {
+                    // No active plan - this is normal for devices that have completed their lifecycle
+                    log::debug!("No active plan for device {} on boot", device_uuid);
+                    return Ok(());
+                }
+            };
 
         // Start the plan if it's pending
         let plan_was_pending = plan.status == PlanStatus::Pending;
@@ -216,14 +185,14 @@ impl Director {
 
         // Update the plan in the database if it was started or advanced
         if plan_was_pending || should_advance {
-            self.plans_store
-                .update_plan_status(
-                    plan.id.unwrap(),
-                    plan.status.clone(),
-                    plan.current_step,
-                    plan.error_message.as_deref(),
-                )
-                .await?;
+            crate::plans::store::update_plan_status(
+                self.conn,
+                plan.id.unwrap(),
+                plan.status.clone(),
+                plan.current_step,
+                plan.error_message.as_deref(),
+            )
+            .await?;
 
             // Handle lifecycle transition if plan is complete
             if plan.status == PlanStatus::Success {
@@ -237,19 +206,16 @@ impl Director {
 
     pub async fn mark_action_success(&self, device_uuid: &Uuid) -> anyhow::Result<()> {
         // Get the current active plan
-        let mut plan = match self
-            .plans_store
-            .get_active_plan_for_device(device_uuid)
-            .await?
-        {
-            Some(plan) => plan,
-            None => {
-                return Err(anyhow::anyhow!(
-                    "No active plan found for device {}",
-                    device_uuid
-                ));
-            }
-        };
+        let mut plan =
+            match crate::plans::store::get_active_plan_for_device(self.conn, device_uuid).await? {
+                Some(plan) => plan,
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "No active plan found for device {}",
+                        device_uuid
+                    ));
+                }
+            };
 
         // Start the plan if it's pending
         if plan.status == PlanStatus::Pending {
@@ -260,14 +226,14 @@ impl Director {
         let _result = plan.mark_action_success();
 
         // Update the plan in the database
-        self.plans_store
-            .update_plan_status(
-                plan.id.unwrap(),
-                plan.status.clone(),
-                plan.current_step,
-                plan.error_message.as_deref(),
-            )
-            .await?;
+        crate::plans::store::update_plan_status(
+            self.conn,
+            plan.id.unwrap(),
+            plan.status.clone(),
+            plan.current_step,
+            plan.error_message.as_deref(),
+        )
+        .await?;
 
         // Handle lifecycle transition if plan is complete
         if plan.status == PlanStatus::Success {
@@ -284,32 +250,29 @@ impl Director {
         error_message: &str,
     ) -> anyhow::Result<()> {
         // Get the current active plan
-        let mut plan = match self
-            .plans_store
-            .get_active_plan_for_device(device_uuid)
-            .await?
-        {
-            Some(plan) => plan,
-            None => {
-                return Err(anyhow::anyhow!(
-                    "No active plan found for device {}",
-                    device_uuid
-                ));
-            }
-        };
+        let mut plan =
+            match crate::plans::store::get_active_plan_for_device(self.conn, device_uuid).await? {
+                Some(plan) => plan,
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "No active plan found for device {}",
+                        device_uuid
+                    ));
+                }
+            };
 
         // Mark current action as failed
         let _result = plan.mark_action_failed(error_message.to_string());
 
         // Update the plan in the database
-        self.plans_store
-            .update_plan_status(
-                plan.id.unwrap(),
-                plan.status.clone(),
-                plan.current_step,
-                plan.error_message.as_deref(),
-            )
-            .await?;
+        crate::plans::store::update_plan_status(
+            self.conn,
+            plan.id.unwrap(),
+            plan.status.clone(),
+            plan.current_step,
+            plan.error_message.as_deref(),
+        )
+        .await?;
 
         // Handle lifecycle transition if plan failed
         self.handle_plan_completion_failure(plan.id.unwrap(), error_message)
@@ -326,12 +289,12 @@ impl Director {
         log::info!("Auto-detecting platform for device {}", device_uuid);
 
         // Get device attributes
-        let device = self.get_device(device_uuid).await?;
+        let device = store::get_device(self.conn, device_uuid).await?;
         let attrs = &device.attributes;
 
         // Perform platform detection
         let platform_id = crate::platforms::detect_or_create_platform(
-            &self.platforms_store,
+            self.conn,
             &attrs.disks,
             &attrs.network_interfaces,
             &attrs.cpus,
@@ -340,9 +303,7 @@ impl Director {
         .await?;
 
         // Assign platform to device
-        self.store
-            .assign_platform_to_device(device_uuid, platform_id)
-            .await?;
+        store::assign_platform_to_device(self.conn, device_uuid, platform_id).await?;
 
         log::info!(
             "Assigned platform {} to device {}",
@@ -361,7 +322,7 @@ impl Director {
         warning: &str,
     ) -> anyhow::Result<()> {
         // Get current device attributes
-        let device = self.store.get_device(device_uuid).await?;
+        let device = store::get_device(self.conn, device_uuid).await?;
 
         // Append new warning to existing warnings
         let mut warnings = device.attributes.warnings;
@@ -377,7 +338,7 @@ impl Director {
                     .collect(),
             ),
         );
-        self.store.update_attributes(device_uuid, attrs).await
+        store::update_attributes(self.conn, device_uuid, attrs).await
     }
 
     pub async fn start_lifecycle_transition(
@@ -386,11 +347,10 @@ impl Director {
         to_state: DeviceLifecycle,
     ) -> anyhow::Result<i64> {
         // Get current device lifecycle
-        let current_lifecycle = self
-            .lifecycle_store
-            .get_device_lifecycle(device_uuid)
-            .await?
-            .unwrap_or(DeviceLifecycle::New);
+        let current_lifecycle =
+            crate::lifecycle::store::get_device_lifecycle(self.conn, device_uuid)
+                .await?
+                .unwrap_or(DeviceLifecycle::New);
 
         // Check if transition is allowed
         if !LifecycleManager::is_transition_allowed(&current_lifecycle, &to_state) {
@@ -402,10 +362,9 @@ impl Director {
         }
 
         // Check if there's already an active transition
-        if let Some(_active_transition) = self
-            .lifecycle_store
-            .get_active_transition_for_device(device_uuid)
-            .await?
+        if let Some(_active_transition) =
+            crate::lifecycle::store::get_active_transition_for_device(self.conn, device_uuid)
+                .await?
         {
             return Err(anyhow::anyhow!(
                 "Device {} already has an active lifecycle transition",
@@ -420,28 +379,26 @@ impl Director {
         // Create plan for this transition
         let actions = LifecycleManager::get_plan_stub_for_transition(&transition_type);
         let plan = Plan::new(*device_uuid, actions);
-        let plan_id = self.create_plan(&plan).await?;
+        let plan_id = crate::plans::store::create_plan(self.conn, &plan).await?;
 
         // Create lifecycle transition
         let transition =
             LifecycleTransition::new(*device_uuid, current_lifecycle, to_state, Some(plan_id));
 
-        let transition_id = self.lifecycle_store.create_transition(&transition).await?;
+        let transition_id =
+            crate::lifecycle::store::create_transition(self.conn, &transition).await?;
 
         // Get the newly created plan to access its current action
-        let plan = self
-            .plans_store
-            .get_active_plan_for_device(device_uuid)
+        let plan = crate::plans::store::get_active_plan_for_device(self.conn, device_uuid)
             .await?
             .expect("Plan should exist immediately after creation");
 
         // If there's a current action, run its start() hook
         if let Some(action) = plan.get_current_action() {
-            let device = self.get_device(device_uuid).await?;
+            let device = store::get_device(self.conn, device_uuid).await?;
             let ctx = crate::plans::actions::ActionContext {
                 device: &device,
-                os_store: &self.os_store,
-                roles_store: &self.roles_store,
+                conn: self.conn,
                 director: Some(self), // Provide director for actions that need it (e.g., RebootDevice)
             };
 
@@ -463,16 +420,14 @@ impl Director {
         &self,
         device_uuid: &Uuid,
     ) -> anyhow::Result<Option<DeviceLifecycle>> {
-        self.lifecycle_store.get_device_lifecycle(device_uuid).await
+        crate::lifecycle::store::get_device_lifecycle(self.conn, device_uuid).await
     }
 
     pub async fn get_active_transition_for_device(
         &self,
         device_uuid: &Uuid,
     ) -> anyhow::Result<Option<LifecycleTransition>> {
-        self.lifecycle_store
-            .get_active_transition_for_device(device_uuid)
-            .await
+        crate::lifecycle::store::get_active_transition_for_device(self.conn, device_uuid).await
     }
 
     pub async fn get_device_transitions(
@@ -480,27 +435,35 @@ impl Director {
         device_uuid: &Uuid,
         include_completed: bool,
     ) -> anyhow::Result<Vec<LifecycleTransition>> {
-        self.lifecycle_store
-            .get_transitions_for_device(device_uuid, include_completed)
-            .await
+        crate::lifecycle::store::get_transitions_for_device(
+            self.conn,
+            device_uuid,
+            include_completed,
+        )
+        .await
     }
 
     async fn handle_plan_completion_success(&self, plan_id: i64) -> anyhow::Result<()> {
         // Find the lifecycle transition associated with this plan
-        if let Some(transition) = self
-            .lifecycle_store
-            .get_transition_by_plan_id(plan_id)
-            .await?
+        if let Some(transition) =
+            crate::lifecycle::store::get_transition_by_plan_id(self.conn, plan_id).await?
         {
             // Update device lifecycle to the target state
-            self.lifecycle_store
-                .update_device_lifecycle(&transition.device_uuid, transition.to_state.clone())
-                .await?;
+            crate::lifecycle::store::update_device_lifecycle(
+                self.conn,
+                &transition.device_uuid,
+                transition.to_state.clone(),
+            )
+            .await?;
 
             // Complete the transition successfully
-            self.lifecycle_store
-                .complete_transition(transition.id.unwrap(), true, None)
-                .await?;
+            crate::lifecycle::store::complete_transition(
+                self.conn,
+                transition.id.unwrap(),
+                true,
+                None,
+            )
+            .await?;
         }
 
         Ok(())
@@ -512,39 +475,44 @@ impl Director {
         error_message: &str,
     ) -> anyhow::Result<()> {
         // Find the lifecycle transition associated with this plan
-        if let Some(transition) = self
-            .lifecycle_store
-            .get_transition_by_plan_id(plan_id)
-            .await?
+        if let Some(transition) =
+            crate::lifecycle::store::get_transition_by_plan_id(self.conn, plan_id).await?
         {
             // Move device to broken state on failure
-            self.lifecycle_store
-                .update_device_lifecycle(&transition.device_uuid, DeviceLifecycle::Broken)
-                .await?;
+            crate::lifecycle::store::update_device_lifecycle(
+                self.conn,
+                &transition.device_uuid,
+                DeviceLifecycle::Broken,
+            )
+            .await?;
 
             // Complete the transition with failure
-            self.lifecycle_store
-                .complete_transition(transition.id.unwrap(), false, Some(error_message))
-                .await?;
+            crate::lifecycle::store::complete_transition(
+                self.conn,
+                transition.id.unwrap(),
+                false,
+                Some(error_message),
+            )
+            .await?;
         }
 
         Ok(())
     }
 
     pub async fn get_device(&self, uuid: &Uuid) -> anyhow::Result<Device> {
-        self.store.get_device(uuid).await
+        store::get_device(self.conn, uuid).await
     }
 
     pub async fn get_all_devices(&self) -> anyhow::Result<Vec<Device>> {
-        self.store.get_all_devices().await
+        store::get_all_devices(self.conn).await
     }
 
     pub async fn find_device_by_mac(&self, mac: &str) -> anyhow::Result<Option<Uuid>> {
-        self.store.find_device_by_mac(mac).await
+        store::find_device_by_mac(self.conn, mac).await
     }
 
     pub async fn set_device_mac_address(&self, uuid: &Uuid, mac: &str) -> anyhow::Result<()> {
-        self.store.set_mac_address(uuid, mac).await
+        store::set_mac_address(self.conn, uuid, mac).await
     }
 
     pub async fn set_device_ip_address(
@@ -553,14 +521,14 @@ impl Director {
         ip: &str,
         mac: &str,
     ) -> anyhow::Result<()> {
-        self.store.set_ip_address(uuid, ip, mac).await
+        store::set_ip_address(self.conn, uuid, ip, mac).await
     }
 
     pub async fn get_network_interfaces(
         &self,
         uuid: &Uuid,
     ) -> anyhow::Result<Vec<NetworkInterface>> {
-        self.store.get_network_interfaces(uuid).await
+        store::get_network_interfaces(self.conn, uuid).await
     }
 
     pub async fn set_network_interfaces(
@@ -568,18 +536,7 @@ impl Director {
         uuid: &Uuid,
         interfaces: &[NetworkInterface],
     ) -> anyhow::Result<()> {
-        self.store.set_network_interfaces(uuid, interfaces).await
-    }
-
-    pub async fn find_duplicate_macs_on_network(
-        &self,
-        mac: &str,
-        network_id: i64,
-        exclude_device: &Uuid,
-    ) -> anyhow::Result<Vec<(Uuid, String)>> {
-        self.store
-            .find_duplicate_macs_on_network(mac, network_id, exclude_device)
-            .await
+        store::set_network_interfaces(self.conn, uuid, interfaces).await
     }
 
     // Platform assignment methods
@@ -589,17 +546,16 @@ impl Director {
         device_uuid: &Uuid,
         platform_id: i64,
     ) -> anyhow::Result<()> {
-        self.store
-            .assign_platform_to_device(device_uuid, platform_id)
-            .await
+        store::assign_platform_to_device(self.conn, device_uuid, platform_id).await
     }
 
     pub async fn get_device_platform_id(&self, device_uuid: &Uuid) -> anyhow::Result<Option<i64>> {
-        self.store.get_device_platform_id(device_uuid).await
+        store::get_device_platform_id(self.conn, device_uuid).await
     }
 
+    #[cfg(test)]
     pub async fn list_devices_with_platform(&self, platform_id: i64) -> anyhow::Result<Vec<Uuid>> {
-        self.store.list_devices_with_platform(platform_id).await
+        store::list_devices_with_platform(self.conn, platform_id).await
     }
 
     // Role assignment methods
@@ -609,15 +565,11 @@ impl Director {
         device_uuid: &Uuid,
         role_id: i64,
     ) -> anyhow::Result<()> {
-        self.store.assign_role_to_device(device_uuid, role_id).await
+        store::assign_role_to_device(self.conn, device_uuid, role_id).await
     }
 
     pub async fn get_device_role_id(&self, device_uuid: &Uuid) -> anyhow::Result<Option<i64>> {
-        self.store.get_device_role_id(device_uuid).await
-    }
-
-    pub async fn list_devices_with_role(&self, role_id: i64) -> anyhow::Result<Vec<Uuid>> {
-        self.store.list_devices_with_role(role_id).await
+        store::get_device_role_id(self.conn, device_uuid).await
     }
 
     pub async fn create_pending_device(
@@ -625,16 +577,14 @@ impl Director {
         mac_address: &str,
         network_id: i64,
     ) -> anyhow::Result<i64> {
-        self.store
-            .create_pending_device(mac_address, network_id)
-            .await
+        store::create_pending_device(self.conn, mac_address, network_id).await
     }
 
     pub async fn find_pending_device_by_mac(
         &self,
         mac_address: &str,
     ) -> anyhow::Result<Option<i64>> {
-        self.store.find_pending_device_by_mac(mac_address).await
+        store::find_pending_device_by_mac(self.conn, mac_address).await
     }
 
     pub async fn complete_pending_device(
@@ -642,17 +592,15 @@ impl Director {
         mac_address: &str,
         device_uuid: &Uuid,
     ) -> anyhow::Result<()> {
-        self.store
-            .complete_pending_device(mac_address, device_uuid)
-            .await
+        store::complete_pending_device(self.conn, mac_address, device_uuid).await
     }
 
     pub async fn get_pending_devices(&self) -> anyhow::Result<Vec<PendingDevice>> {
-        self.store.get_pending_devices().await
+        store::get_pending_devices(self.conn).await
     }
 
     pub async fn delete_pending_device(&self, id: i64) -> anyhow::Result<()> {
-        self.store.delete_pending_device(id).await
+        store::delete_pending_device(self.conn, id).await
     }
 
     pub async fn delete_device(&self, uuid: &Uuid) -> anyhow::Result<()> {
@@ -660,15 +608,11 @@ impl Director {
         // (interfaces stored in device JSON, lost after deletion)
 
         // 1. Delete for all discovered interfaces
-        let interfaces = self
-            .store
-            .get_network_interfaces(uuid)
+        let interfaces = store::get_network_interfaces(self.conn, uuid)
             .await
             .unwrap_or_default();
         for nic in &interfaces {
-            match self
-                .dhcp_store
-                .delete_static_reservations_by_mac(&nic.mac_address)
+            match crate::dhcp::store::delete_static_reservations_by_mac(self.conn, &nic.mac_address)
                 .await
             {
                 Ok(count) if count > 0 => {
@@ -691,19 +635,19 @@ impl Director {
         }
 
         // 2. Check legacy mac_address field (backward compatibility)
-        if let Ok(device) = self.store.get_device(uuid).await
+        if let Ok(device) = store::get_device(self.conn, uuid).await
             && let Some(mac) = &device.attributes.mac_address
             && !interfaces.iter().any(|nic| &nic.mac_address == mac)
         {
-            let _ = self.dhcp_store.delete_static_reservations_by_mac(mac).await;
+            let _ = crate::dhcp::store::delete_static_reservations_by_mac(self.conn, mac).await;
         }
 
         // 3. Delete device (cascades to plans, transitions)
-        self.store.delete_device(uuid).await
+        store::delete_device(self.conn, uuid).await
     }
 
     pub async fn find_device_by_bmc_mac(&self, mac: &str) -> anyhow::Result<Option<Uuid>> {
-        self.store.find_device_by_bmc_mac(mac).await
+        store::find_device_by_bmc_mac(self.conn, mac).await
     }
 
     /// Issue an IPMI power reset command to the device's BMC
@@ -755,13 +699,13 @@ impl Director {
 
     /// Get BMC IP address from device attributes
     async fn get_bmc_ip(&self, uuid: &Uuid) -> anyhow::Result<Option<String>> {
-        let device = self.store.get_device(uuid).await?;
+        let device = store::get_device(self.conn, uuid).await?;
         Ok(device.attributes.bmc.and_then(|bmc| bmc.ip_address))
     }
 
     /// Get BMC credentials from device attributes
     async fn get_bmc_credentials(&self, uuid: &Uuid) -> anyhow::Result<Option<(String, String)>> {
-        let device = self.store.get_device(uuid).await?;
+        let device = store::get_device(self.conn, uuid).await?;
         let bmc_config = device.attributes.bmc_config;
 
         match bmc_config {
@@ -777,21 +721,22 @@ impl Director {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{database, plans::PlanStatus};
-    use std::sync::Arc;
-    use tempfile::tempdir;
+    use crate::{
+        database, database::DatabaseConnectionFactory, plans::PlanStatus, test_connection_factory,
+    };
 
-    async fn setup_test_director() -> (Director, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-        let director = Director::new(db);
-        (director, temp_dir)
+    /// Sets up a test database and returns the connection.
+    ///
+    /// Each test constructs `Director::new(&conn)` locally so that the Director
+    /// borrows the connection for the duration of the test.
+    async fn setup_test_db(factory: DatabaseConnectionFactory) -> database::Connection {
+        database::run_migrations(&factory).await.unwrap()
     }
 
     #[tokio::test]
     async fn test_single_active_plan_constraint() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440006").unwrap();
 
         // Register device
@@ -843,7 +788,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_all_devices() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
 
         // Initially should return empty list
         let devices = director.get_all_devices().await.unwrap();
@@ -896,7 +842,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_discovery_transition() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440007").unwrap();
 
         // Register device - it should start in "new" state
@@ -996,7 +943,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reboot_with_bmc_info() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440020").unwrap();
 
         // Register device
@@ -1035,7 +983,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reboot_without_bmc_ip() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440021").unwrap();
 
         // Register device without BMC info
@@ -1051,7 +1000,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reboot_without_bmc_credentials() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440022").unwrap();
 
         // Register device
@@ -1081,7 +1031,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_on_boot_advances_reboot_action() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440023").unwrap();
 
         // Register device
@@ -1124,7 +1075,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_on_boot_does_not_advance_other_actions() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440024").unwrap();
 
         // Register device
@@ -1162,7 +1114,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_on_boot_without_active_plan() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440025").unwrap();
 
         // Register device without a plan
@@ -1178,7 +1131,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bmc_ip_with_valid_bmc() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440026").unwrap();
 
         // Register device
@@ -1208,7 +1162,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bmc_ip_without_bmc() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440027").unwrap();
 
         // Register device without BMC
@@ -1224,7 +1179,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bmc_credentials_with_valid_config() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440028").unwrap();
 
         // Register device
@@ -1258,7 +1214,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bmc_credentials_without_credentials() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440029").unwrap();
 
         // Register device - will have default BMC config with no credentials
@@ -1274,7 +1231,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_device_sets_default_bmc_config() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440030").unwrap();
 
         // Register device
@@ -1304,7 +1262,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_default_bmc_config_does_not_override_existing() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440031").unwrap();
 
         // Register device (sets default config)
@@ -1345,7 +1304,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_default_bmc_config_preserves_other_attributes() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440032").unwrap();
 
         // Register device
@@ -1390,26 +1350,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_device_removes_static_reservations() {
-        let (director, temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440033").unwrap();
 
-        // Create a DHCP network first
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(crate::database::open(db_path).await.unwrap());
-        let dhcp_store = crate::dhcp::DhcpStore::new(db);
-
-        let network = dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+        // Create a DHCP network using the shared connection
+        let network = crate::dhcp::store::create_network(
+            &conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Register device
         director
@@ -1434,14 +1391,18 @@ mod tests {
             .unwrap();
 
         // Create static reservation
-        dhcp_store
-            .create_or_update_static_reservation(network.id, mac, "10.0.0.100", None)
-            .await
-            .unwrap();
+        crate::dhcp::store::create_or_update_static_reservation(
+            &conn,
+            network.id,
+            mac,
+            "10.0.0.100",
+            None,
+        )
+        .await
+        .unwrap();
 
         // Verify reservation exists
-        let reservation = dhcp_store
-            .get_static_reservation(network.id, mac)
+        let reservation = crate::dhcp::store::get_static_reservation(&conn, network.id, mac)
             .await
             .unwrap();
         assert!(reservation.is_some());
@@ -1450,8 +1411,7 @@ mod tests {
         director.delete_device(&test_uuid).await.unwrap();
 
         // Verify reservation was deleted
-        let reservation = dhcp_store
-            .get_static_reservation(network.id, mac)
+        let reservation = crate::dhcp::store::get_static_reservation(&conn, network.id, mac)
             .await
             .unwrap();
         assert!(reservation.is_none());
@@ -1459,26 +1419,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_device_removes_reservations_for_multiple_nics() {
-        let (director, temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440034").unwrap();
 
-        // Create DHCP network
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(crate::database::open(db_path).await.unwrap());
-        let dhcp_store = crate::dhcp::DhcpStore::new(db);
-
-        let network = dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+        // Create DHCP network using the shared connection
+        let network = crate::dhcp::store::create_network(
+            &conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Register device
         director
@@ -1515,26 +1472,34 @@ mod tests {
             .unwrap();
 
         // Create static reservations for both MACs
-        dhcp_store
-            .create_or_update_static_reservation(network.id, mac1, "10.0.0.101", None)
-            .await
-            .unwrap();
-        dhcp_store
-            .create_or_update_static_reservation(network.id, mac2, "10.0.0.102", None)
-            .await
-            .unwrap();
+        crate::dhcp::store::create_or_update_static_reservation(
+            &conn,
+            network.id,
+            mac1,
+            "10.0.0.101",
+            None,
+        )
+        .await
+        .unwrap();
+        crate::dhcp::store::create_or_update_static_reservation(
+            &conn,
+            network.id,
+            mac2,
+            "10.0.0.102",
+            None,
+        )
+        .await
+        .unwrap();
 
         // Verify both reservations exist
         assert!(
-            dhcp_store
-                .get_static_reservation(network.id, mac1)
+            crate::dhcp::store::get_static_reservation(&conn, network.id, mac1)
                 .await
                 .unwrap()
                 .is_some()
         );
         assert!(
-            dhcp_store
-                .get_static_reservation(network.id, mac2)
+            crate::dhcp::store::get_static_reservation(&conn, network.id, mac2)
                 .await
                 .unwrap()
                 .is_some()
@@ -1545,15 +1510,13 @@ mod tests {
 
         // Verify both reservations were deleted
         assert!(
-            dhcp_store
-                .get_static_reservation(network.id, mac1)
+            crate::dhcp::store::get_static_reservation(&conn, network.id, mac1)
                 .await
                 .unwrap()
                 .is_none()
         );
         assert!(
-            dhcp_store
-                .get_static_reservation(network.id, mac2)
+            crate::dhcp::store::get_static_reservation(&conn, network.id, mac2)
                 .await
                 .unwrap()
                 .is_none()
@@ -1564,7 +1527,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_platform_detection_status_success() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440050").unwrap();
 
         // Register device
@@ -1574,7 +1538,6 @@ mod tests {
             .unwrap();
 
         // Create a platform first
-        let platforms_store = &director.platforms_store;
         let platform_attrs = crate::platforms::PlatformAttributes {
             disks: vec![crate::platforms::PlatformDisk {
                 path: "/dev/sda".to_string(),
@@ -1594,8 +1557,7 @@ mod tests {
             }],
             memory_gib: 32,
         };
-        platforms_store
-            .create("Test Platform", None, &platform_attrs)
+        crate::platforms::store::create(&conn, "Test Platform", None, &platform_attrs)
             .await
             .unwrap();
 
@@ -1646,7 +1608,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_platform_detection_status_failed() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440051").unwrap();
 
         // Register device
@@ -1702,7 +1665,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_platform_detection_status_manual() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440052").unwrap();
 
         // Register device
@@ -1712,17 +1676,16 @@ mod tests {
             .unwrap();
 
         // Create a platform
-        let platforms_store = &director.platforms_store;
         let platform_attrs = crate::platforms::PlatformAttributes {
             disks: vec![],
             nics: vec![],
             cpus: vec![],
             memory_gib: 0,
         };
-        let platform = platforms_store
-            .create("Manual Platform", None, &platform_attrs)
-            .await
-            .unwrap();
+        let platform =
+            crate::platforms::store::create(&conn, "Manual Platform", None, &platform_attrs)
+                .await
+                .unwrap();
 
         // Manually assign platform
         director
@@ -1737,7 +1700,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_platform_detection_status_no_hardware_info() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440053").unwrap();
 
         // Register device
@@ -1762,7 +1726,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_platform_detection_creates_new_platform_on_no_match() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440056").unwrap();
 
         // Register device
@@ -1772,7 +1737,7 @@ mod tests {
             .unwrap();
 
         // Verify no platforms exist initially
-        let platforms = director.platforms_store.list().await.unwrap();
+        let platforms = crate::platforms::store::list(&conn).await.unwrap();
         assert_eq!(
             platforms.len(),
             0,
@@ -1824,7 +1789,7 @@ mod tests {
             .unwrap();
 
         // Verify a new platform was auto-created
-        let platforms = director.platforms_store.list().await.unwrap();
+        let platforms = crate::platforms::store::list(&conn).await.unwrap();
         assert_eq!(
             platforms.len(),
             1,
@@ -1843,9 +1808,7 @@ mod tests {
         );
 
         // Verify the created platform has the correct hardware attributes
-        let platform = director
-            .platforms_store
-            .get(device.platform_id.unwrap())
+        let platform = crate::platforms::store::get(&conn, device.platform_id.unwrap())
             .await
             .unwrap();
         assert_eq!(platform.attributes.disks.len(), 1);
@@ -1856,7 +1819,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_platform_detection_status_partial_hardware_info() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440054").unwrap();
 
         // Register device
@@ -1895,7 +1859,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_platform_detection_status_manual_overrides_auto() {
-        let (director, _temp_dir) = setup_test_director().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
+        let director = Director::new(&conn);
         let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440055").unwrap();
 
         // Register device
@@ -1930,17 +1895,16 @@ mod tests {
         let auto_platform_id = device.platform_id.unwrap();
 
         // Create a different platform and manually assign it
-        let platforms_store = &director.platforms_store;
         let platform_attrs = crate::platforms::PlatformAttributes {
             disks: vec![],
             nics: vec![],
             cpus: vec![],
             memory_gib: 0,
         };
-        let manual_platform = platforms_store
-            .create("Manual Override", None, &platform_attrs)
-            .await
-            .unwrap();
+        let manual_platform =
+            crate::platforms::store::create(&conn, "Manual Override", None, &platform_attrs)
+                .await
+                .unwrap();
 
         director
             .assign_platform_to_device(&test_uuid, manual_platform.id.unwrap())

--- a/rack-director/src/director/mod.rs
+++ b/rack-director/src/director/mod.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
+use crate::database::Connection;
 use crate::dhcp::DhcpStore;
 use crate::director::store::DirectorStore;
 use crate::director::store::generate_hostname_from_uuid;
@@ -13,6 +13,7 @@ use crate::plans::{Plan, PlanStatus, PlansStore};
 use crate::platforms::PlatformsStore;
 use crate::roles::RolesStore;
 
+mod devices;
 mod ipmi;
 pub(crate) mod store;
 
@@ -32,14 +33,14 @@ pub struct Director {
 }
 
 impl Director {
-    pub fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
-        let store = DirectorStore::new(conn.clone());
-        let plans_store = PlansStore::new(conn.clone());
-        let lifecycle_store = LifecycleStore::new(conn.clone());
-        let os_store = OperatingSystemsStore::new(conn.clone());
-        let roles_store = RolesStore::new(conn.clone());
-        let platforms_store = PlatformsStore::new(conn.clone());
-        let dhcp_store = DhcpStore::new(conn);
+    pub fn new(db: Arc<Connection>) -> Self {
+        let store = DirectorStore::new(db.clone());
+        let plans_store = PlansStore::new(db.clone());
+        let lifecycle_store = LifecycleStore::new(db.clone());
+        let os_store = OperatingSystemsStore::new(db.clone());
+        let roles_store = RolesStore::new(db.clone());
+        let platforms_store = PlatformsStore::new(db.clone());
+        let dhcp_store = DhcpStore::new(db);
         Director {
             store,
             plans_store,
@@ -779,13 +780,12 @@ mod tests {
     use crate::{database, plans::PlanStatus};
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
 
     async fn setup_test_director() -> (Director, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = database::open(&db_path).unwrap();
-        let director = Director::new(Arc::new(Mutex::new(db)));
+        let db = Arc::new(database::open(db_path).await.unwrap());
+        let director = Director::new(db);
         (director, temp_dir)
     }
 
@@ -1395,9 +1395,8 @@ mod tests {
 
         // Create a DHCP network first
         let db_path = temp_dir.path().join("test.db");
-        let db = crate::database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(Mutex::new(db));
-        let dhcp_store = crate::dhcp::DhcpStore::new(db_tokio);
+        let db = Arc::new(crate::database::open(db_path).await.unwrap());
+        let dhcp_store = crate::dhcp::DhcpStore::new(db);
 
         let network = dhcp_store
             .create_network(
@@ -1465,9 +1464,8 @@ mod tests {
 
         // Create DHCP network
         let db_path = temp_dir.path().join("test.db");
-        let db = crate::database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(Mutex::new(db));
-        let dhcp_store = crate::dhcp::DhcpStore::new(db_tokio);
+        let db = Arc::new(crate::database::open(db_path).await.unwrap());
+        let dhcp_store = crate::dhcp::DhcpStore::new(db);
 
         let network = dhcp_store
             .create_network(

--- a/rack-director/src/director/store.rs
+++ b/rack-director/src/director/store.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::database::FromRow;
+use crate::database::{Connection, FromRow};
 use crate::lifecycle::DeviceLifecycle;
 use crate::operating_systems::Architecture;
 use common::device_attributes::{DeviceAttributes, NetworkInterface};
@@ -64,6 +63,14 @@ impl FromRow for Device {
     }
 }
 
+impl TryFrom<Row<'_>> for Device {
+    type Error = rusqlite::Error;
+
+    fn try_from(value: Row<'_>) -> std::result::Result<Self, Self::Error> {
+        Self::from_row(&value)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingDevice {
     pub id: i64,
@@ -89,43 +96,44 @@ impl FromRow for PendingDevice {
 
 #[derive(Clone)]
 pub struct DirectorStore {
-    pub conn: Arc<Mutex<rusqlite::Connection>>,
+    db: Arc<Connection>,
 }
 
 impl DirectorStore {
-    pub fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
-        Self { conn }
+    pub fn new(db: Arc<Connection>) -> Self {
+        Self { db }
     }
 
     pub async fn register_device(&self, uuid: &Uuid, architecture: Architecture) -> Result<()> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
-            params![uuid, architecture.as_str()],
-        )?;
+        self.db
+            .execute(
+                "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
+                (*uuid, architecture.as_str().to_string()),
+            )
+            .await
+            .map(|_| ())?;
         Ok(())
     }
 
     pub async fn device_exists(&self, uuid: &Uuid) -> Result<bool> {
-        let conn = self.conn.lock().await;
-        let res = conn
-            .query_one(
-                "SELECT 1 FROM devices WHERE uuid = ?1",
-                params![uuid],
-                |r| r.get(0),
-            )
+        let res = self
+            .db
+            .query_one("SELECT 1 FROM devices WHERE uuid = ?1", (*uuid,), |r| {
+                r.get::<_, i32>(0)
+            })
+            .await
             .optional()
             .map(|op: Option<i32>| op.is_some())?;
         Ok(res)
     }
 
     pub async fn update_device_last_seen(&self, uuid: &Uuid) -> Result<()> {
-        let conn = self.conn.lock().await;
-
-        conn.execute(
-            "UPDATE devices SET last_seen_at = CURRENT_TIMESTAMP WHERE uuid = ?1",
-            params![uuid],
-        )?;
+        self.db
+            .execute(
+                "UPDATE devices SET last_seen_at = CURRENT_TIMESTAMP WHERE uuid = ?1",
+                (*uuid,),
+            )
+            .await?;
         Ok(())
     }
 
@@ -150,140 +158,155 @@ impl DirectorStore {
         let merged: DeviceAttributes = serde_json::from_value(existing_json)?;
 
         // Update with merged attributes
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "UPDATE devices SET attributes = ?1 WHERE uuid = ?2",
-            params![serde_json::to_string(&merged)?, uuid,],
-        )?;
+        self.db
+            .execute(
+                "UPDATE devices SET attributes = ?1 WHERE uuid = ?2",
+                (serde_json::to_string(&merged)?, *uuid),
+            )
+            .await?;
 
         Ok(())
     }
 
     pub async fn get_device(&self, uuid: &Uuid) -> Result<Device> {
-        let conn = self.conn.lock().await;
-
-        let device = crate::database::query_one::<Device>(
-            &conn,
-            "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices WHERE uuid = ?1",
-            &[uuid],
-        )?;
+        let device = self
+            .db
+            .query_one(
+                "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices WHERE uuid = ?1",
+                (*uuid,),
+                Device::from_row,
+            )
+            .await?;
 
         Ok(device)
     }
 
     pub async fn get_all_devices(&self) -> Result<Vec<Device>> {
-        let conn = self.conn.lock().await;
-
-        let devices = crate::database::query_map_all::<Device>(
-            &conn,
-            "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices",
-            &[],
-        )?;
+        let devices = self
+            .db
+            .query(
+                "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices",
+                (),
+                Device::from_row,
+            )
+            .await?;
 
         Ok(devices)
     }
 
-    /// Find device UUID by MAC address from device attributes
-    /// Searches both legacy mac_address field and network_interfaces array
+    /// Find device UUID by MAC address from device attributes.
+    ///
+    /// Searches both legacy mac_address field and network_interfaces array.
     pub async fn find_device_by_mac(&self, mac: &str) -> Result<Option<Uuid>> {
-        let conn = self.conn.lock().await;
-
-        let mut stmt = conn.prepare(
-            "SELECT uuid FROM devices
-             WHERE json_extract(attributes, '$.mac_address') = ?
-                OR EXISTS (
-                  SELECT 1 FROM json_each(attributes, '$.network_interfaces')
-                  WHERE json_extract(value, '$.mac_address') = ?
-                )",
-        )?;
-
-        let result = stmt
-            .query_row(params![mac, mac], |row| row.get(0))
+        let mac = mac.to_string();
+        let result = self
+            .db
+            .query_row(
+                "SELECT uuid FROM devices
+                 WHERE json_extract(attributes, '$.mac_address') = ?1
+                    OR EXISTS (
+                      SELECT 1 FROM json_each(attributes, '$.network_interfaces')
+                      WHERE json_extract(value, '$.mac_address') = ?1
+                    )",
+                (mac,),
+                |row| row.get(0),
+            )
+            .await
             .optional()?;
 
         Ok(result)
     }
 
-    /// Set hostname in device attributes
+    /// Set hostname in device attributes.
     pub async fn set_hostname(&self, uuid: &Uuid, hostname: &str) -> Result<()> {
-        let conn = self.conn.lock().await;
-
-        conn.execute(
-            "UPDATE devices SET attributes = json_set(attributes, '$.hostname', ?) WHERE uuid = ?",
-            params![hostname, uuid],
-        )?;
+        self.db
+            .execute(
+                "UPDATE devices SET attributes = json_set(attributes, '$.hostname', ?1) WHERE uuid = ?2",
+                (hostname.to_string(), *uuid),
+            )
+            .await?;
 
         Ok(())
     }
 
-    /// Set MAC address in device attributes
+    /// Set MAC address in device attributes.
     pub async fn set_mac_address(&self, uuid: &Uuid, mac: &str) -> Result<()> {
-        let conn = self.conn.lock().await;
-
         // First, update the legacy mac_address field
-        conn.execute(
-            "UPDATE devices SET attributes = json_set(attributes, '$.mac_address', ?) WHERE uuid = ?",
-            params![mac, uuid],
-        )?;
+        self.db
+            .execute(
+                "UPDATE devices SET attributes = json_set(attributes, '$.mac_address', ?1) WHERE uuid = ?2",
+                (mac.to_string(), *uuid),
+            )
+            .await?;
 
         // Then, if network_interfaces array exists, update the first NIC's MAC address
-        let has_interfaces: bool = conn
+        let uuid_copy = *uuid;
+        let has_interfaces: bool = self
+            .db
             .query_row(
-                "SELECT json_type(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?",
-                params![uuid],
+                "SELECT json_type(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?1",
+                (*uuid,),
                 |row| {
                     let json_type: Option<String> = row.get(0)?;
                     Ok(json_type == Some("array".to_string()))
                 },
             )
+            .await
             .optional()?
             .unwrap_or(false);
 
         if has_interfaces {
             // Find the index of the first interface
-            let first_index: Option<i64> = conn
+            let first_index: Option<i64> = self
+                .db
                 .query_row(
-                    "SELECT key FROM json_each((SELECT attributes FROM devices WHERE uuid = ?), '$.network_interfaces')
+                    "SELECT key FROM json_each((SELECT attributes FROM devices WHERE uuid = ?1), '$.network_interfaces')
                      LIMIT 1",
-                    params![uuid],
+                    (uuid_copy,),
                     |row| row.get::<_, i64>(0),
                 )
+                .await
                 .optional()?;
 
             if let Some(index) = first_index {
                 let path = format!("$.network_interfaces[{}].mac_address", index);
-                conn.execute(
-                    "UPDATE devices SET attributes = json_set(attributes, ?, ?) WHERE uuid = ?",
-                    params![path, mac, uuid],
-                )?;
+                self.db
+                    .execute(
+                        "UPDATE devices SET attributes = json_set(attributes, ?1, ?2) WHERE uuid = ?3",
+                        (path, mac.to_string(), uuid_copy),
+                    )
+                    .await?;
             }
         }
 
         Ok(())
     }
 
-    /// Set IP address in device attributes (called by DHCP when lease becomes active)
-    /// Updates either BMC IP or network interface IP based on the MAC address
+    /// Set IP address in device attributes (called by DHCP when lease becomes active).
+    ///
+    /// Updates either BMC IP or network interface IP based on the MAC address.
     pub async fn set_ip_address(&self, uuid: &Uuid, ip: &str, mac: &str) -> Result<()> {
         // Check if this MAC belongs to the BMC
-        let is_bmc: bool = {
-            let conn = self.conn.lock().await;
-            conn.query_row(
-                "SELECT COALESCE(json_extract(attributes, '$.bmc.mac_address') = ?, 0) FROM devices WHERE uuid = ?",
-                params![mac, uuid],
+        let mac_str = mac.to_string();
+        let is_bmc: bool = self
+            .db
+            .query_row(
+                "SELECT COALESCE(json_extract(attributes, '$.bmc.mac_address') = ?1, 0) FROM devices WHERE uuid = ?2",
+                (mac_str, *uuid),
                 |row| row.get::<_, bool>(0),
             )
+            .await
             .optional()?
-            .unwrap_or(false)
-        };
+            .unwrap_or(false);
 
         if is_bmc {
             // Update BMC IP address
-            let conn = self.conn.lock().await;
-            conn.execute(
-                "UPDATE devices SET attributes = json_set(attributes, '$.bmc.ip_address', ?) WHERE uuid = ?",
-                params![ip, uuid],
-            )?;
+            self.db
+                .execute(
+                    "UPDATE devices SET attributes = json_set(attributes, '$.bmc.ip_address', ?1) WHERE uuid = ?2",
+                    (ip.to_string(), *uuid),
+                )
+                .await?;
             return Ok(());
         }
 
@@ -314,16 +337,16 @@ impl DirectorStore {
         Ok(())
     }
 
-    /// Get network interfaces from device attributes
+    /// Get network interfaces from device attributes.
     pub async fn get_network_interfaces(&self, uuid: &Uuid) -> Result<Vec<NetworkInterface>> {
-        let conn = self.conn.lock().await;
-
-        let mut stmt = conn.prepare(
-            "SELECT json_extract(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?",
-        )?;
-
-        let result = stmt
-            .query_row(params![uuid], |row| row.get::<_, Option<String>>(0))
+        let result = self
+            .db
+            .query_row(
+                "SELECT json_extract(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?1",
+                (*uuid,),
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .await
             .optional()?;
 
         match result {
@@ -337,287 +360,298 @@ impl DirectorStore {
         }
     }
 
-    /// Set network interfaces in device attributes
+    /// Set network interfaces in device attributes.
     pub async fn set_network_interfaces(
         &self,
         uuid: &Uuid,
         interfaces: &[NetworkInterface],
     ) -> Result<()> {
-        let conn = self.conn.lock().await;
-
         let json_str = serde_json::to_string(interfaces)?;
 
-        conn.execute(
-            "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', json(?)) WHERE uuid = ?",
-            params![json_str, uuid],
-        )?;
+        self.db
+            .execute(
+                "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', json(?1)) WHERE uuid = ?2",
+                (json_str, *uuid),
+            )
+            .await?;
 
         Ok(())
     }
 
-    /// Find device UUID by MAC address in either legacy mac_address field or network_interfaces array
+    /// Find device UUID by MAC address in either legacy mac_address field or network_interfaces array.
     #[cfg(test)]
     pub async fn find_device_by_any_mac(&self, mac: &str) -> Result<Option<Uuid>> {
-        let conn = self.conn.lock().await;
-
-        let mut stmt = conn.prepare(
-            "SELECT uuid FROM devices
-             WHERE json_extract(attributes, '$.mac_address') = ?
-                OR EXISTS (
-                  SELECT 1 FROM json_each(attributes, '$.network_interfaces')
-                  WHERE json_extract(value, '$.mac_address') = ?
-                )",
-        )?;
-
-        let result = stmt
-            .query_row(params![mac, mac], |row| row.get(0))
+        let mac = mac.to_string();
+        let result = self
+            .db
+            .query_row(
+                "SELECT uuid FROM devices
+                 WHERE json_extract(attributes, '$.mac_address') = ?1
+                    OR EXISTS (
+                      SELECT 1 FROM json_each(attributes, '$.network_interfaces')
+                      WHERE json_extract(value, '$.mac_address') = ?1
+                    )",
+                (mac,),
+                |row| row.get(0),
+            )
+            .await
             .optional()?;
 
         Ok(result)
     }
 
-    /// Create a pending device entry for a MAC address
-    /// Returns the ID of the created pending device
-    /// If a pending device already exists for this MAC, does nothing and returns the existing ID
+    /// Create a pending device entry for a MAC address.
+    ///
+    /// Returns the ID of the created pending device. If a pending device already exists
+    /// for this MAC, does nothing and returns the existing ID.
     pub async fn create_pending_device(&self, mac_address: &str, network_id: i64) -> Result<i64> {
-        let conn = self.conn.lock().await;
+        self.db
+            .execute(
+                "INSERT INTO pending_devices (mac_address, network_id) VALUES (?1, ?2)
+                 ON CONFLICT(mac_address) DO NOTHING",
+                (mac_address.to_string(), network_id),
+            )
+            .await?;
 
-        conn.execute(
-            "INSERT INTO pending_devices (mac_address, network_id) VALUES (?1, ?2)
-             ON CONFLICT(mac_address) DO NOTHING",
-            params![mac_address, network_id],
-        )?;
-
-        let id = conn.last_insert_rowid();
+        let id = self.db.last_insert_rowid().await;
 
         // If no rows were inserted (conflict), get the existing ID
         if id == 0 {
-            let existing_id: i64 = conn.query_row(
-                "SELECT id FROM pending_devices WHERE mac_address = ?1",
-                params![mac_address],
-                |row| row.get(0),
-            )?;
+            let existing_id: i64 = self
+                .db
+                .query_one(
+                    "SELECT id FROM pending_devices WHERE mac_address = ?1",
+                    (mac_address.to_string(),),
+                    |row| row.get(0),
+                )
+                .await?;
             Ok(existing_id)
         } else {
             Ok(id)
         }
     }
 
-    /// Find pending device ID by MAC address
-    /// Returns None if no pending device exists or if it's already completed
+    /// Find pending device ID by MAC address.
+    ///
+    /// Returns None if no pending device exists or if it's already completed.
     pub async fn find_pending_device_by_mac(&self, mac_address: &str) -> Result<Option<i64>> {
-        let conn = self.conn.lock().await;
-
-        let result = conn
+        let result = self
+            .db
             .query_row(
                 "SELECT id FROM pending_devices WHERE mac_address = ?1 AND completed_at IS NULL",
-                params![mac_address],
+                (mac_address.to_string(),),
                 |row| row.get::<_, i64>(0),
             )
+            .await
             .optional()?;
 
         Ok(result)
     }
 
-    /// Complete a pending device by linking it to a device UUID
-    /// Marks the pending device as completed
+    /// Complete a pending device by linking it to a device UUID.
+    ///
+    /// Marks the pending device as completed.
     pub async fn complete_pending_device(
         &self,
         mac_address: &str,
         device_uuid: &Uuid,
     ) -> Result<()> {
-        let conn = self.conn.lock().await;
-
-        conn.execute(
-            "UPDATE pending_devices
-             SET device_uuid = ?1, completed_at = CURRENT_TIMESTAMP
-             WHERE mac_address = ?2 AND completed_at IS NULL",
-            params![device_uuid, mac_address],
-        )?;
+        self.db
+            .execute(
+                "UPDATE pending_devices
+                 SET device_uuid = ?1, completed_at = CURRENT_TIMESTAMP
+                 WHERE mac_address = ?2 AND completed_at IS NULL",
+                (*device_uuid, mac_address.to_string()),
+            )
+            .await?;
 
         Ok(())
     }
 
-    /// Get all pending devices that haven't been completed yet
+    /// Get all pending devices that haven't been completed yet.
     pub async fn get_pending_devices(&self) -> Result<Vec<PendingDevice>> {
-        let conn = self.conn.lock().await;
-
-        let devices = crate::database::query_map_all::<PendingDevice>(
-            &conn,
-            "SELECT id, mac_address, device_uuid, network_id, created_at, completed_at
-             FROM pending_devices
-             WHERE completed_at IS NULL
-             ORDER BY created_at DESC",
-            &[],
-        )?;
+        let devices = self
+            .db
+            .query(
+                "SELECT id, mac_address, device_uuid, network_id, created_at, completed_at
+                 FROM pending_devices
+                 WHERE completed_at IS NULL
+                 ORDER BY created_at DESC",
+                (),
+                PendingDevice::from_row,
+            )
+            .await?;
 
         Ok(devices)
     }
 
-    /// Delete a pending device by ID
+    /// Delete a pending device by ID.
     pub async fn delete_pending_device(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().await;
-        conn.execute("DELETE FROM pending_devices WHERE id = ?1", params![id])?;
+        self.db
+            .execute("DELETE FROM pending_devices WHERE id = ?1", (id,))
+            .await?;
         Ok(())
     }
 
-    /// Delete a device by UUID
-    /// Cascades to plans and transitions, sets leases device_uuid to NULL
+    /// Delete a device by UUID.
+    ///
+    /// Cascades to plans and transitions, sets leases device_uuid to NULL.
     pub async fn delete_device(&self, uuid: &Uuid) -> Result<()> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "DELETE FROM pending_devices WHERE device_uuid = ?1",
-            params![uuid],
-        )?;
-        conn.execute("DELETE FROM devices WHERE uuid = ?1", params![uuid])?;
+        self.db
+            .execute(
+                "DELETE FROM pending_devices WHERE device_uuid = ?1",
+                (*uuid,),
+            )
+            .await?;
+        self.db
+            .execute("DELETE FROM devices WHERE uuid = ?1", (*uuid,))
+            .await?;
         Ok(())
     }
 
-    /// Find device UUID by BMC MAC address
+    /// Find device UUID by BMC MAC address.
     ///
     /// Searches all devices for a BMC with the given MAC address in their attributes.
     /// Returns the device UUID if a match is found.
     pub async fn find_device_by_bmc_mac(&self, mac: &str) -> Result<Option<Uuid>> {
-        let conn = self.conn.lock().await;
-
-        let mut stmt = conn.prepare(
-            "SELECT uuid FROM devices
-             WHERE json_extract(attributes, '$.bmc.mac_address') = ?",
-        )?;
-
-        let result = stmt.query_row(params![mac], |row| row.get(0)).optional()?;
+        let result = self
+            .db
+            .query_row(
+                "SELECT uuid FROM devices
+                 WHERE json_extract(attributes, '$.bmc.mac_address') = ?1",
+                (mac.to_string(),),
+                |row| row.get(0),
+            )
+            .await
+            .optional()?;
 
         Ok(result)
     }
 
-    /// Assign a platform to a device
+    /// Assign a platform to a device.
     pub async fn assign_platform_to_device(
         &self,
         device_uuid: &Uuid,
         platform_id: i64,
     ) -> Result<()> {
-        let conn = self.conn.lock().await;
-
-        conn.execute(
-            "UPDATE devices SET platform_id = ?1 WHERE uuid = ?2",
-            params![platform_id, device_uuid],
-        )
-        .context("Failed to assign platform to device")?;
+        self.db
+            .execute(
+                "UPDATE devices SET platform_id = ?1 WHERE uuid = ?2",
+                (platform_id, *device_uuid),
+            )
+            .await
+            .context("Failed to assign platform to device")?;
 
         Ok(())
     }
 
-    /// Get the platform ID assigned to a device
+    /// Get the platform ID assigned to a device.
     pub async fn get_device_platform_id(&self, device_uuid: &Uuid) -> Result<Option<i64>> {
-        let conn = self.conn.lock().await;
-
-        let result = conn
+        let result = self
+            .db
             .query_row(
                 "SELECT platform_id FROM devices WHERE uuid = ?1",
-                params![device_uuid],
+                (*device_uuid,),
                 |row| row.get::<_, Option<i64>>(0),
             )
+            .await
             .optional()?;
 
         Ok(result.flatten())
     }
 
-    /// List all devices with a specific platform
+    /// List all devices with a specific platform.
     pub async fn list_devices_with_platform(&self, platform_id: i64) -> Result<Vec<Uuid>> {
-        let conn = self.conn.lock().await;
-
-        let mut stmt =
-            conn.prepare("SELECT uuid FROM devices WHERE platform_id = ?1 ORDER BY uuid")?;
-
-        let rows = stmt.query_map(params![platform_id], |row| row.get(0))?;
-
-        let mut uuids = Vec::new();
-        for row in rows {
-            uuids.push(row?);
-        }
+        let uuids = self
+            .db
+            .query(
+                "SELECT uuid FROM devices WHERE platform_id = ?1 ORDER BY uuid",
+                (platform_id,),
+                |row| row.get(0),
+            )
+            .await?;
 
         Ok(uuids)
     }
 
-    /// Assign a role to a device
+    /// Assign a role to a device.
     pub async fn assign_role_to_device(&self, device_uuid: &Uuid, role_id: i64) -> Result<()> {
-        let conn = self.conn.lock().await;
-
-        conn.execute(
-            "UPDATE devices SET role_id = ?1 WHERE uuid = ?2",
-            params![role_id, device_uuid],
-        )
-        .context("Failed to assign role to device")?;
+        self.db
+            .execute(
+                "UPDATE devices SET role_id = ?1 WHERE uuid = ?2",
+                (role_id, *device_uuid),
+            )
+            .await
+            .context("Failed to assign role to device")?;
 
         Ok(())
     }
 
-    /// Get the role ID assigned to a device
+    /// Get the role ID assigned to a device.
     pub async fn get_device_role_id(&self, device_uuid: &Uuid) -> Result<Option<i64>> {
-        let conn = self.conn.lock().await;
-
-        let result = conn
+        let result = self
+            .db
             .query_row(
                 "SELECT role_id FROM devices WHERE uuid = ?1",
-                params![device_uuid],
+                (*device_uuid,),
                 |row| row.get::<_, Option<i64>>(0),
             )
+            .await
             .optional()?;
 
         Ok(result.flatten())
     }
 
-    /// List all devices with a specific role
+    /// List all devices with a specific role.
     pub async fn list_devices_with_role(&self, role_id: i64) -> Result<Vec<Uuid>> {
-        let conn = self.conn.lock().await;
-
-        let mut stmt = conn.prepare("SELECT uuid FROM devices WHERE role_id = ?1 ORDER BY uuid")?;
-
-        let rows = stmt.query_map(params![role_id], |row| row.get(0))?;
-
-        let mut uuids = Vec::new();
-        for row in rows {
-            uuids.push(row?);
-        }
+        let uuids = self
+            .db
+            .query(
+                "SELECT uuid FROM devices WHERE role_id = ?1 ORDER BY uuid",
+                (role_id,),
+                |row| row.get(0),
+            )
+            .await?;
 
         Ok(uuids)
     }
 
-    /// Find devices with the same MAC address on the same network
-    /// Returns Vec<(device_uuid, interface_name)>
+    /// Find devices with the same MAC address on the same network.
     ///
-    /// This function searches for duplicate MAC addresses on a specific network,
-    /// excluding a given device UUID. It's used to detect MAC conflicts during
-    /// device registration.
+    /// Returns Vec<(device_uuid, interface_name)>. This function searches for duplicate MAC
+    /// addresses on a specific network, excluding a given device UUID. It's used to detect
+    /// MAC conflicts during device registration.
     pub async fn find_duplicate_macs_on_network(
         &self,
         mac: &str,
         network_id: i64,
         exclude_device: &Uuid,
     ) -> Result<Vec<(Uuid, String)>> {
-        let conn = self.conn.lock().await;
+        let mac = mac.to_string();
+        let exclude = *exclude_device;
 
-        let mut stmt = conn.prepare(
-            "SELECT uuid, attributes FROM devices
-             WHERE uuid != ?1
-             AND EXISTS (
-               SELECT 1 FROM json_each(attributes, '$.network_interfaces') as iface
-               WHERE json_extract(iface.value, '$.mac_address') = ?2
-                 AND json_extract(iface.value, '$.network_id') = ?3
-             )",
-        )?;
-
-        let rows = stmt.query_map(params![exclude_device, mac, network_id], |row| {
-            let uuid = row.get(0)?;
-            let attributes_json: Option<String> = row.get(1)?;
-            Ok((uuid, attributes_json))
-        })?;
+        let rows = self
+            .db
+            .query(
+                "SELECT uuid, attributes FROM devices
+                 WHERE uuid != ?1
+                 AND EXISTS (
+                   SELECT 1 FROM json_each(attributes, '$.network_interfaces') as iface
+                   WHERE json_extract(iface.value, '$.mac_address') = ?2
+                     AND json_extract(iface.value, '$.network_id') = ?3
+                 )",
+                (exclude, mac.clone(), network_id),
+                |row| {
+                    let uuid: Uuid = row.get(0)?;
+                    let attributes_json: Option<String> = row.get(1)?;
+                    Ok((uuid, attributes_json))
+                },
+            )
+            .await?;
 
         let mut duplicates = Vec::new();
 
-        for row in rows {
-            let (uuid, attributes_json) = row?;
-
+        for (uuid, attributes_json) in rows {
             // Parse attributes to find the matching interface name
             if let Some(json_str) = attributes_json
                 && let Ok(attributes) =
@@ -642,7 +676,7 @@ impl DirectorStore {
     }
 }
 
-/// Extract last UUID segment (after final hyphen) for hostname generation
+/// Extract last UUID segment (after final hyphen) for hostname generation.
 pub fn extract_uuid_last_segment(uuid: &Uuid) -> String {
     let uuid_str = uuid.to_string();
     uuid_str
@@ -652,15 +686,16 @@ pub fn extract_uuid_last_segment(uuid: &Uuid) -> String {
         .to_string()
 }
 
-/// Generate hostname from UUID: "node-{last_segment}"
+/// Generate hostname from UUID: "node-{last_segment}".
 pub fn generate_hostname_from_uuid(uuid: &Uuid) -> String {
     format!("node-{}", extract_uuid_last_segment(uuid))
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::test_database_path;
+
     use super::*;
-    use tempfile::tempdir;
     use uuid::Uuid;
 
     fn test_uuid(suffix: u16) -> Uuid {
@@ -668,19 +703,14 @@ mod tests {
             .expect("test UUID should be valid")
     }
 
-    async fn create_test_store() -> (DirectorStore, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let conn = crate::database::open(&db_path).unwrap();
-        let db = Arc::new(Mutex::new(conn));
-
+    async fn create_test_store(path: String) -> DirectorStore {
+        let db = Arc::new(crate::database::open(path).await.unwrap());
         // Note: No default network is created. Tests that need networks should create them explicitly.
-
-        (DirectorStore::new(db), temp_dir)
+        DirectorStore::new(db)
     }
 
-    /// Helper to create a test network and pool for tests that need DHCP functionality
-    async fn create_test_network(db: &Arc<Mutex<rusqlite::Connection>>) -> i64 {
+    /// Helper to create a test network and pool for tests that need DHCP functionality.
+    async fn create_test_network(db: &Arc<crate::database::Connection>) -> i64 {
         let dhcp_store = crate::dhcp::DhcpStore::new(db.clone());
         let network = dhcp_store
             .create_network(
@@ -717,7 +747,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_hostname() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x20);
 
         // Register device
@@ -739,7 +769,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_mac_address() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x21);
 
         // Register device
@@ -764,7 +794,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_ip_address() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x23);
         let mac = "aa:bb:cc:dd:ee:ff";
 
@@ -793,7 +823,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_hostname_generation_on_register() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x22);
 
         // Register device
@@ -816,7 +846,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_attributes_preserves_existing() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x24);
 
         // Register device
@@ -879,7 +909,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_attributes_overwrites_existing_keys() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x25);
 
         // Register device
@@ -934,7 +964,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_attributes_empty_map() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x26);
 
         // Register device
@@ -959,7 +989,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_interfaces_empty() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x30);
 
         // Register device without any NICs
@@ -975,7 +1005,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_interfaces_single() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x31);
 
         // Register device
@@ -1009,7 +1039,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_interfaces_multiple() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x32);
 
         // Register device
@@ -1063,7 +1093,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_network_interfaces_overwrites() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x33);
 
         // Register device
@@ -1116,7 +1146,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_device_by_mac_legacy_field() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x34);
 
         // Register device
@@ -1142,7 +1172,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_device_by_mac_in_interfaces_array() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x35);
 
         // Register device
@@ -1192,7 +1222,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_device_by_any_mac() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x36);
 
         // Register device
@@ -1249,7 +1279,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_mac_address_legacy_only() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x37);
 
         // Register device
@@ -1278,7 +1308,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_mac_address_updates_first_interface() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x38);
 
         // Register device
@@ -1335,7 +1365,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_ip_address_creates_interface_when_missing() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x39);
         let mac = "aa:bb:cc:dd:ee:ff";
 
@@ -1364,7 +1394,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_ip_address_updates_by_mac() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x40);
 
         // Register device
@@ -1424,7 +1454,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_backward_compatibility_legacy_device() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x41);
 
         // Register device and set up as a legacy device (no network_interfaces)
@@ -1465,7 +1495,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_ip_address_for_bmc() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x42);
         let bmc_mac = "aa:bb:cc:dd:ee:aa";
 
@@ -1476,15 +1506,15 @@ mod tests {
             .unwrap();
 
         // Set BMC information in device attributes
-        let conn = store.conn.lock().await;
-        conn.execute(
-            r#"UPDATE devices SET attributes = json_set(attributes, '$.bmc',
+        store.db
+            .execute(
+                r#"UPDATE devices SET attributes = json_set(attributes, '$.bmc',
                json('{"mac_address":"aa:bb:cc:dd:ee:aa","ip_address":null,"ip_address_source":"Unknown"}')
-            ) WHERE uuid = ?"#,
-            params![uuid],
-        )
-        .unwrap();
-        drop(conn);
+            ) WHERE uuid = ?1"#,
+                (uuid,),
+            )
+            .await
+            .unwrap();
 
         // Set IP address for BMC MAC
         store
@@ -1504,7 +1534,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_interfaces_invalid_json() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x42);
 
         // Register device
@@ -1514,12 +1544,13 @@ mod tests {
             .unwrap();
 
         // Manually set invalid JSON in network_interfaces field
-        let conn = store.conn.lock().await;
-        conn.execute(
-            "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', 'invalid') WHERE uuid = ?",
-            params![uuid],
-        ).unwrap();
-        drop(conn);
+        store.db
+            .execute(
+                "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', 'invalid') WHERE uuid = ?1",
+                (uuid,),
+            )
+            .await
+            .unwrap();
 
         // Should return empty vec instead of error
         let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
@@ -1530,7 +1561,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_network_interface_disabled_fields_serialization() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x43);
 
         // Register device
@@ -1568,7 +1599,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_network_interface_backward_compatibility() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid = test_uuid(0x44);
 
         // Register device
@@ -1578,15 +1609,15 @@ mod tests {
             .unwrap();
 
         // Manually set old-style interface without new fields
-        let conn = store.conn.lock().await;
-        conn.execute(
-            r#"UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces',
+        store.db
+            .execute(
+                r#"UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces',
                json('[{"interface_name":"eth0","mac_address":"aa:bb:cc:dd:ee:01","ip_address":"10.0.0.100"}]')
-            ) WHERE uuid = ?"#,
-            params![uuid],
-        )
-        .unwrap();
-        drop(conn);
+            ) WHERE uuid = ?1"#,
+                (uuid,),
+            )
+            .await
+            .unwrap();
 
         // Should deserialize with default values for new fields
         let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
@@ -1598,7 +1629,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_on_network_no_duplicates() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid1 = test_uuid(0x45);
         let uuid2 = test_uuid(0x46);
 
@@ -1652,7 +1683,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_on_network_finds_duplicate() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid1 = test_uuid(0x47);
         let uuid2 = test_uuid(0x48);
 
@@ -1720,7 +1751,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_on_different_networks() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid1 = test_uuid(0x49);
         let uuid2 = test_uuid(0x4A);
 
@@ -1784,7 +1815,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_multiple_duplicates() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid1 = test_uuid(0x51);
         let uuid2 = test_uuid(0x52);
         let uuid3 = test_uuid(0x53);
@@ -1867,7 +1898,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_no_network_id() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
         let uuid1 = test_uuid(0x54);
         let uuid2 = test_uuid(0x55);
 
@@ -1924,8 +1955,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_pending_device() {
-        let (store, _temp) = create_test_store().await;
-        let network_id = create_test_network(&store.conn).await;
+        let store = create_test_store(test_database_path!()).await;
+        let network_id = create_test_network(&store.db).await;
         let mac = "aa:bb:cc:dd:ee:99";
 
         // Create a pending device
@@ -1947,7 +1978,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_nonexistent_pending_device() {
-        let (store, _temp) = create_test_store().await;
+        let store = create_test_store(test_database_path!()).await;
 
         // Deleting a non-existent pending device should not error
         // (SQL DELETE on non-existent row succeeds with 0 rows affected)
@@ -1957,8 +1988,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_device_with_pending() {
-        let (store, _temp) = create_test_store().await;
-        let network_id = create_test_network(&store.conn).await;
+        let store = create_test_store(test_database_path!()).await;
+        let network_id = create_test_network(&store.db).await;
         let uuid = test_uuid(0x54);
         let mac = "aa:bb:cc:dd:ee:99";
 
@@ -1976,13 +2007,18 @@ mod tests {
         store.delete_device(&uuid).await.unwrap();
 
         // Ensure pending entry is removed
-        let exists: Result<bool, rusqlite::Error> = store.conn.lock().await.query_one(
-            "SELECT 1 FROM pending_devices WHERE mac_address = ?1",
-            [mac],
-            |r| r.get(0),
-        );
+        let exists: rusqlite::Result<bool> = store
+            .db
+            .query_one(
+                "SELECT 1 FROM pending_devices WHERE mac_address = ?1",
+                (mac.to_string(),),
+                |r| r.get(0),
+            )
+            .await
+            .optional()
+            .map(|op: Option<bool>| op.is_some());
         assert!(
-            matches!(exists, Err(rusqlite::Error::QueryReturnedNoRows)),
+            matches!(exists, Ok(false)),
             "Deleting a Device must delete pending records. {:?}",
             exists
         );

--- a/rack-director/src/director/store.rs
+++ b/rack-director/src/director/store.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 use rusqlite::{OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
@@ -94,586 +92,519 @@ impl FromRow for PendingDevice {
     }
 }
 
-#[derive(Clone)]
-pub struct DirectorStore {
-    db: Arc<Connection>,
+pub async fn register_device(
+    conn: &Connection,
+    uuid: &Uuid,
+    architecture: Architecture,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
+        (*uuid, architecture.as_str().to_string()),
+    )
+    .await
+    .map(|_| ())?;
+    Ok(())
 }
 
-impl DirectorStore {
-    pub fn new(db: Arc<Connection>) -> Self {
-        Self { db }
+pub async fn device_exists(conn: &Connection, uuid: &Uuid) -> Result<bool> {
+    let res = conn
+        .query_one("SELECT 1 FROM devices WHERE uuid = ?1", (*uuid,), |r| {
+            r.get::<_, i32>(0)
+        })
+        .await
+        .optional()
+        .map(|op: Option<i32>| op.is_some())?;
+    Ok(res)
+}
+
+pub async fn update_device_last_seen(conn: &Connection, uuid: &Uuid) -> Result<()> {
+    conn.execute(
+        "UPDATE devices SET last_seen_at = CURRENT_TIMESTAMP WHERE uuid = ?1",
+        (*uuid,),
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn update_attributes(
+    conn: &Connection,
+    uuid: &Uuid,
+    attributes: serde_json::Map<String, serde_json::Value>,
+) -> Result<()> {
+    let device = get_device(conn, uuid).await?;
+
+    let mut existing_json = serde_json::to_value(&device.attributes)?;
+    let existing_map = existing_json.as_object_mut().unwrap();
+
+    for (key, value) in attributes {
+        existing_map.insert(key, value);
     }
 
-    pub async fn register_device(&self, uuid: &Uuid, architecture: Architecture) -> Result<()> {
-        self.db
-            .execute(
-                "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
-                (*uuid, architecture.as_str().to_string()),
-            )
-            .await
-            .map(|_| ())?;
-        Ok(())
-    }
+    let merged: DeviceAttributes = serde_json::from_value(existing_json)?;
 
-    pub async fn device_exists(&self, uuid: &Uuid) -> Result<bool> {
-        let res = self
-            .db
-            .query_one("SELECT 1 FROM devices WHERE uuid = ?1", (*uuid,), |r| {
-                r.get::<_, i32>(0)
-            })
-            .await
-            .optional()
-            .map(|op: Option<i32>| op.is_some())?;
-        Ok(res)
-    }
+    conn.execute(
+        "UPDATE devices SET attributes = ?1 WHERE uuid = ?2",
+        (serde_json::to_string(&merged)?, *uuid),
+    )
+    .await?;
 
-    pub async fn update_device_last_seen(&self, uuid: &Uuid) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE devices SET last_seen_at = CURRENT_TIMESTAMP WHERE uuid = ?1",
-                (*uuid,),
-            )
-            .await?;
-        Ok(())
-    }
+    Ok(())
+}
 
-    pub async fn update_attributes(
-        &self,
-        uuid: &Uuid,
-        attributes: serde_json::Map<String, serde_json::Value>,
-    ) -> Result<()> {
-        // Get existing attributes
-        let device = self.get_device(uuid).await?;
+pub async fn get_device(conn: &Connection, uuid: &Uuid) -> Result<Device> {
+    let device = conn
+        .query_one(
+            "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices WHERE uuid = ?1",
+            (*uuid,),
+            Device::from_row,
+        )
+        .await?;
 
-        // Convert existing DeviceAttributes to JSON for merging
-        let mut existing_json = serde_json::to_value(&device.attributes)?;
-        let existing_map = existing_json.as_object_mut().unwrap();
+    Ok(device)
+}
 
-        // Merge new attributes (new values overwrite existing keys)
-        for (key, value) in attributes {
-            existing_map.insert(key, value);
-        }
+pub async fn get_all_devices(conn: &Connection) -> Result<Vec<Device>> {
+    let devices = conn
+        .query(
+            "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices",
+            (),
+            Device::from_row,
+        )
+        .await?;
 
-        // Deserialize back to DeviceAttributes to validate structure
-        let merged: DeviceAttributes = serde_json::from_value(existing_json)?;
+    Ok(devices)
+}
 
-        // Update with merged attributes
-        self.db
-            .execute(
-                "UPDATE devices SET attributes = ?1 WHERE uuid = ?2",
-                (serde_json::to_string(&merged)?, *uuid),
-            )
-            .await?;
+/// Find device UUID by MAC address from device attributes.
+///
+/// Searches both legacy mac_address field and network_interfaces array.
+pub async fn find_device_by_mac(conn: &Connection, mac: &str) -> Result<Option<Uuid>> {
+    let mac = mac.to_string();
+    let result = conn
+        .query_row(
+            "SELECT uuid FROM devices
+             WHERE json_extract(attributes, '$.mac_address') = ?1
+                OR EXISTS (
+                  SELECT 1 FROM json_each(attributes, '$.network_interfaces')
+                  WHERE json_extract(value, '$.mac_address') = ?1
+                )",
+            (mac,),
+            |row| row.get(0),
+        )
+        .await
+        .optional()?;
 
-        Ok(())
-    }
+    Ok(result)
+}
 
-    pub async fn get_device(&self, uuid: &Uuid) -> Result<Device> {
-        let device = self
-            .db
-            .query_one(
-                "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices WHERE uuid = ?1",
-                (*uuid,),
-                Device::from_row,
-            )
-            .await?;
+/// Set hostname in device attributes.
+pub async fn set_hostname(conn: &Connection, uuid: &Uuid, hostname: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE devices SET attributes = json_set(attributes, '$.hostname', ?1) WHERE uuid = ?2",
+        (hostname.to_string(), *uuid),
+    )
+    .await?;
 
-        Ok(device)
-    }
+    Ok(())
+}
 
-    pub async fn get_all_devices(&self) -> Result<Vec<Device>> {
-        let devices = self
-            .db
-            .query(
-                "SELECT uuid, architecture, lifecycle, role_id, platform_id, attributes, created_at, first_seen_at, last_seen_at FROM devices",
-                (),
-                Device::from_row,
-            )
-            .await?;
+/// Set MAC address in device attributes.
+pub async fn set_mac_address(conn: &Connection, uuid: &Uuid, mac: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE devices SET attributes = json_set(attributes, '$.mac_address', ?1) WHERE uuid = ?2",
+        (mac.to_string(), *uuid),
+    )
+    .await?;
 
-        Ok(devices)
-    }
+    let uuid_copy = *uuid;
+    let has_interfaces: bool = conn
+        .query_row(
+            "SELECT json_type(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?1",
+            (*uuid,),
+            |row| {
+                let json_type: Option<String> = row.get(0)?;
+                Ok(json_type == Some("array".to_string()))
+            },
+        )
+        .await
+        .optional()?
+        .unwrap_or(false);
 
-    /// Find device UUID by MAC address from device attributes.
-    ///
-    /// Searches both legacy mac_address field and network_interfaces array.
-    pub async fn find_device_by_mac(&self, mac: &str) -> Result<Option<Uuid>> {
-        let mac = mac.to_string();
-        let result = self
-            .db
+    if has_interfaces {
+        let first_index: Option<i64> = conn
             .query_row(
-                "SELECT uuid FROM devices
-                 WHERE json_extract(attributes, '$.mac_address') = ?1
-                    OR EXISTS (
-                      SELECT 1 FROM json_each(attributes, '$.network_interfaces')
-                      WHERE json_extract(value, '$.mac_address') = ?1
-                    )",
-                (mac,),
-                |row| row.get(0),
-            )
-            .await
-            .optional()?;
-
-        Ok(result)
-    }
-
-    /// Set hostname in device attributes.
-    pub async fn set_hostname(&self, uuid: &Uuid, hostname: &str) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE devices SET attributes = json_set(attributes, '$.hostname', ?1) WHERE uuid = ?2",
-                (hostname.to_string(), *uuid),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    /// Set MAC address in device attributes.
-    pub async fn set_mac_address(&self, uuid: &Uuid, mac: &str) -> Result<()> {
-        // First, update the legacy mac_address field
-        self.db
-            .execute(
-                "UPDATE devices SET attributes = json_set(attributes, '$.mac_address', ?1) WHERE uuid = ?2",
-                (mac.to_string(), *uuid),
-            )
-            .await?;
-
-        // Then, if network_interfaces array exists, update the first NIC's MAC address
-        let uuid_copy = *uuid;
-        let has_interfaces: bool = self
-            .db
-            .query_row(
-                "SELECT json_type(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?1",
-                (*uuid,),
-                |row| {
-                    let json_type: Option<String> = row.get(0)?;
-                    Ok(json_type == Some("array".to_string()))
-                },
-            )
-            .await
-            .optional()?
-            .unwrap_or(false);
-
-        if has_interfaces {
-            // Find the index of the first interface
-            let first_index: Option<i64> = self
-                .db
-                .query_row(
-                    "SELECT key FROM json_each((SELECT attributes FROM devices WHERE uuid = ?1), '$.network_interfaces')
-                     LIMIT 1",
-                    (uuid_copy,),
-                    |row| row.get::<_, i64>(0),
-                )
-                .await
-                .optional()?;
-
-            if let Some(index) = first_index {
-                let path = format!("$.network_interfaces[{}].mac_address", index);
-                self.db
-                    .execute(
-                        "UPDATE devices SET attributes = json_set(attributes, ?1, ?2) WHERE uuid = ?3",
-                        (path, mac.to_string(), uuid_copy),
-                    )
-                    .await?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Set IP address in device attributes (called by DHCP when lease becomes active).
-    ///
-    /// Updates either BMC IP or network interface IP based on the MAC address.
-    pub async fn set_ip_address(&self, uuid: &Uuid, ip: &str, mac: &str) -> Result<()> {
-        // Check if this MAC belongs to the BMC
-        let mac_str = mac.to_string();
-        let is_bmc: bool = self
-            .db
-            .query_row(
-                "SELECT COALESCE(json_extract(attributes, '$.bmc.mac_address') = ?1, 0) FROM devices WHERE uuid = ?2",
-                (mac_str, *uuid),
-                |row| row.get::<_, bool>(0),
-            )
-            .await
-            .optional()?
-            .unwrap_or(false);
-
-        if is_bmc {
-            // Update BMC IP address
-            self.db
-                .execute(
-                    "UPDATE devices SET attributes = json_set(attributes, '$.bmc.ip_address', ?1) WHERE uuid = ?2",
-                    (ip.to_string(), *uuid),
-                )
-                .await?;
-            return Ok(());
-        }
-
-        // Not a BMC - update network interface by MAC address
-        // Get current network interfaces
-        let mut interfaces = self.get_network_interfaces(uuid).await?;
-
-        // Find interface with matching MAC
-        if let Some(interface) = interfaces.iter_mut().find(|i| i.mac_address == mac) {
-            // Update existing interface
-            interface.ip_address = Some(ip.to_string());
-        } else {
-            // MAC not found - create new interface
-            interfaces.push(NetworkInterface {
-                interface_name: "unknown".to_string(), // Will be updated by agent
-                mac_address: mac.to_string(),
-                ip_address: Some(ip.to_string()),
-                network_id: None,
-                speed_mbps: None, // Will be updated by agent during hardware scan
-                disabled: false,
-                warning_label: None,
-            });
-        }
-
-        // Save updated interfaces
-        self.set_network_interfaces(uuid, &interfaces).await?;
-
-        Ok(())
-    }
-
-    /// Get network interfaces from device attributes.
-    pub async fn get_network_interfaces(&self, uuid: &Uuid) -> Result<Vec<NetworkInterface>> {
-        let result = self
-            .db
-            .query_row(
-                "SELECT json_extract(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?1",
-                (*uuid,),
-                |row| row.get::<_, Option<String>>(0),
-            )
-            .await
-            .optional()?;
-
-        match result {
-            Some(Some(json_str)) => {
-                // Try to parse the JSON array
-                let interfaces: Vec<NetworkInterface> =
-                    serde_json::from_str(&json_str).unwrap_or_else(|_| Vec::new());
-                Ok(interfaces)
-            }
-            _ => Ok(Vec::new()),
-        }
-    }
-
-    /// Set network interfaces in device attributes.
-    pub async fn set_network_interfaces(
-        &self,
-        uuid: &Uuid,
-        interfaces: &[NetworkInterface],
-    ) -> Result<()> {
-        let json_str = serde_json::to_string(interfaces)?;
-
-        self.db
-            .execute(
-                "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', json(?1)) WHERE uuid = ?2",
-                (json_str, *uuid),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    /// Find device UUID by MAC address in either legacy mac_address field or network_interfaces array.
-    #[cfg(test)]
-    pub async fn find_device_by_any_mac(&self, mac: &str) -> Result<Option<Uuid>> {
-        let mac = mac.to_string();
-        let result = self
-            .db
-            .query_row(
-                "SELECT uuid FROM devices
-                 WHERE json_extract(attributes, '$.mac_address') = ?1
-                    OR EXISTS (
-                      SELECT 1 FROM json_each(attributes, '$.network_interfaces')
-                      WHERE json_extract(value, '$.mac_address') = ?1
-                    )",
-                (mac,),
-                |row| row.get(0),
-            )
-            .await
-            .optional()?;
-
-        Ok(result)
-    }
-
-    /// Create a pending device entry for a MAC address.
-    ///
-    /// Returns the ID of the created pending device. If a pending device already exists
-    /// for this MAC, does nothing and returns the existing ID.
-    pub async fn create_pending_device(&self, mac_address: &str, network_id: i64) -> Result<i64> {
-        self.db
-            .execute(
-                "INSERT INTO pending_devices (mac_address, network_id) VALUES (?1, ?2)
-                 ON CONFLICT(mac_address) DO NOTHING",
-                (mac_address.to_string(), network_id),
-            )
-            .await?;
-
-        let id = self.db.last_insert_rowid().await;
-
-        // If no rows were inserted (conflict), get the existing ID
-        if id == 0 {
-            let existing_id: i64 = self
-                .db
-                .query_one(
-                    "SELECT id FROM pending_devices WHERE mac_address = ?1",
-                    (mac_address.to_string(),),
-                    |row| row.get(0),
-                )
-                .await?;
-            Ok(existing_id)
-        } else {
-            Ok(id)
-        }
-    }
-
-    /// Find pending device ID by MAC address.
-    ///
-    /// Returns None if no pending device exists or if it's already completed.
-    pub async fn find_pending_device_by_mac(&self, mac_address: &str) -> Result<Option<i64>> {
-        let result = self
-            .db
-            .query_row(
-                "SELECT id FROM pending_devices WHERE mac_address = ?1 AND completed_at IS NULL",
-                (mac_address.to_string(),),
+                "SELECT key FROM json_each((SELECT attributes FROM devices WHERE uuid = ?1), '$.network_interfaces')
+                 LIMIT 1",
+                (uuid_copy,),
                 |row| row.get::<_, i64>(0),
             )
             .await
             .optional()?;
 
-        Ok(result)
-    }
-
-    /// Complete a pending device by linking it to a device UUID.
-    ///
-    /// Marks the pending device as completed.
-    pub async fn complete_pending_device(
-        &self,
-        mac_address: &str,
-        device_uuid: &Uuid,
-    ) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE pending_devices
-                 SET device_uuid = ?1, completed_at = CURRENT_TIMESTAMP
-                 WHERE mac_address = ?2 AND completed_at IS NULL",
-                (*device_uuid, mac_address.to_string()),
+        if let Some(index) = first_index {
+            let path = format!("$.network_interfaces[{}].mac_address", index);
+            conn.execute(
+                "UPDATE devices SET attributes = json_set(attributes, ?1, ?2) WHERE uuid = ?3",
+                (path, mac.to_string(), uuid_copy),
             )
             .await?;
-
-        Ok(())
+        }
     }
 
-    /// Get all pending devices that haven't been completed yet.
-    pub async fn get_pending_devices(&self) -> Result<Vec<PendingDevice>> {
-        let devices = self
-            .db
-            .query(
-                "SELECT id, mac_address, device_uuid, network_id, created_at, completed_at
-                 FROM pending_devices
-                 WHERE completed_at IS NULL
-                 ORDER BY created_at DESC",
-                (),
-                PendingDevice::from_row,
-            )
-            .await?;
+    Ok(())
+}
 
-        Ok(devices)
+/// Set IP address in device attributes (called by DHCP when lease becomes active).
+///
+/// Updates either BMC IP or network interface IP based on the MAC address.
+pub async fn set_ip_address(conn: &Connection, uuid: &Uuid, ip: &str, mac: &str) -> Result<()> {
+    let mac_str = mac.to_string();
+    let is_bmc: bool = conn
+        .query_row(
+            "SELECT COALESCE(json_extract(attributes, '$.bmc.mac_address') = ?1, 0) FROM devices WHERE uuid = ?2",
+            (mac_str, *uuid),
+            |row| row.get::<_, bool>(0),
+        )
+        .await
+        .optional()?
+        .unwrap_or(false);
+
+    if is_bmc {
+        conn.execute(
+            "UPDATE devices SET attributes = json_set(attributes, '$.bmc.ip_address', ?1) WHERE uuid = ?2",
+            (ip.to_string(), *uuid),
+        )
+        .await?;
+        return Ok(());
     }
 
-    /// Delete a pending device by ID.
-    pub async fn delete_pending_device(&self, id: i64) -> Result<()> {
-        self.db
-            .execute("DELETE FROM pending_devices WHERE id = ?1", (id,))
-            .await?;
-        Ok(())
+    let mut interfaces = get_network_interfaces(conn, uuid).await?;
+
+    if let Some(interface) = interfaces.iter_mut().find(|i| i.mac_address == mac) {
+        interface.ip_address = Some(ip.to_string());
+    } else {
+        interfaces.push(NetworkInterface {
+            interface_name: "unknown".to_string(),
+            mac_address: mac.to_string(),
+            ip_address: Some(ip.to_string()),
+            network_id: None,
+            speed_mbps: None,
+            disabled: false,
+            warning_label: None,
+        });
     }
 
-    /// Delete a device by UUID.
-    ///
-    /// Cascades to plans and transitions, sets leases device_uuid to NULL.
-    pub async fn delete_device(&self, uuid: &Uuid) -> Result<()> {
-        self.db
-            .execute(
-                "DELETE FROM pending_devices WHERE device_uuid = ?1",
-                (*uuid,),
-            )
-            .await?;
-        self.db
-            .execute("DELETE FROM devices WHERE uuid = ?1", (*uuid,))
-            .await?;
-        Ok(())
+    set_network_interfaces(conn, uuid, &interfaces).await?;
+
+    Ok(())
+}
+
+/// Get network interfaces from device attributes.
+pub async fn get_network_interfaces(
+    conn: &Connection,
+    uuid: &Uuid,
+) -> Result<Vec<NetworkInterface>> {
+    let result = conn
+        .query_row(
+            "SELECT json_extract(attributes, '$.network_interfaces') FROM devices WHERE uuid = ?1",
+            (*uuid,),
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .await
+        .optional()?;
+
+    match result {
+        Some(Some(json_str)) => {
+            let interfaces: Vec<NetworkInterface> =
+                serde_json::from_str(&json_str).unwrap_or_else(|_| Vec::new());
+            Ok(interfaces)
+        }
+        _ => Ok(Vec::new()),
     }
+}
 
-    /// Find device UUID by BMC MAC address.
-    ///
-    /// Searches all devices for a BMC with the given MAC address in their attributes.
-    /// Returns the device UUID if a match is found.
-    pub async fn find_device_by_bmc_mac(&self, mac: &str) -> Result<Option<Uuid>> {
-        let result = self
-            .db
-            .query_row(
-                "SELECT uuid FROM devices
-                 WHERE json_extract(attributes, '$.bmc.mac_address') = ?1",
-                (mac.to_string(),),
-                |row| row.get(0),
-            )
-            .await
-            .optional()?;
+/// Set network interfaces in device attributes.
+pub async fn set_network_interfaces(
+    conn: &Connection,
+    uuid: &Uuid,
+    interfaces: &[NetworkInterface],
+) -> Result<()> {
+    let json_str = serde_json::to_string(interfaces)?;
 
-        Ok(result)
-    }
+    conn.execute(
+        "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', json(?1)) WHERE uuid = ?2",
+        (json_str, *uuid),
+    )
+    .await?;
 
-    /// Assign a platform to a device.
-    pub async fn assign_platform_to_device(
-        &self,
-        device_uuid: &Uuid,
-        platform_id: i64,
-    ) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE devices SET platform_id = ?1 WHERE uuid = ?2",
-                (platform_id, *device_uuid),
-            )
-            .await
-            .context("Failed to assign platform to device")?;
+    Ok(())
+}
 
-        Ok(())
-    }
+/// Create a pending device entry for a MAC address.
+///
+/// Returns the ID of the created pending device. If a pending device already exists
+/// for this MAC, does nothing and returns the existing ID.
+pub async fn create_pending_device(
+    conn: &Connection,
+    mac_address: &str,
+    network_id: i64,
+) -> Result<i64> {
+    conn.execute(
+        "INSERT INTO pending_devices (mac_address, network_id) VALUES (?1, ?2)
+         ON CONFLICT(mac_address) DO NOTHING",
+        (mac_address.to_string(), network_id),
+    )
+    .await?;
 
-    /// Get the platform ID assigned to a device.
-    pub async fn get_device_platform_id(&self, device_uuid: &Uuid) -> Result<Option<i64>> {
-        let result = self
-            .db
-            .query_row(
-                "SELECT platform_id FROM devices WHERE uuid = ?1",
-                (*device_uuid,),
-                |row| row.get::<_, Option<i64>>(0),
-            )
-            .await
-            .optional()?;
+    let id = conn.last_insert_rowid().await;
 
-        Ok(result.flatten())
-    }
-
-    /// List all devices with a specific platform.
-    pub async fn list_devices_with_platform(&self, platform_id: i64) -> Result<Vec<Uuid>> {
-        let uuids = self
-            .db
-            .query(
-                "SELECT uuid FROM devices WHERE platform_id = ?1 ORDER BY uuid",
-                (platform_id,),
-                |row| row.get(0),
-            )
-            .await?;
-
-        Ok(uuids)
-    }
-
-    /// Assign a role to a device.
-    pub async fn assign_role_to_device(&self, device_uuid: &Uuid, role_id: i64) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE devices SET role_id = ?1 WHERE uuid = ?2",
-                (role_id, *device_uuid),
-            )
-            .await
-            .context("Failed to assign role to device")?;
-
-        Ok(())
-    }
-
-    /// Get the role ID assigned to a device.
-    pub async fn get_device_role_id(&self, device_uuid: &Uuid) -> Result<Option<i64>> {
-        let result = self
-            .db
-            .query_row(
-                "SELECT role_id FROM devices WHERE uuid = ?1",
-                (*device_uuid,),
-                |row| row.get::<_, Option<i64>>(0),
-            )
-            .await
-            .optional()?;
-
-        Ok(result.flatten())
-    }
-
-    /// List all devices with a specific role.
-    pub async fn list_devices_with_role(&self, role_id: i64) -> Result<Vec<Uuid>> {
-        let uuids = self
-            .db
-            .query(
-                "SELECT uuid FROM devices WHERE role_id = ?1 ORDER BY uuid",
-                (role_id,),
+    if id == 0 {
+        let existing_id: i64 = conn
+            .query_one(
+                "SELECT id FROM pending_devices WHERE mac_address = ?1",
+                (mac_address.to_string(),),
                 |row| row.get(0),
             )
             .await?;
-
-        Ok(uuids)
+        Ok(existing_id)
+    } else {
+        Ok(id)
     }
+}
 
-    /// Find devices with the same MAC address on the same network.
-    ///
-    /// Returns Vec<(device_uuid, interface_name)>. This function searches for duplicate MAC
-    /// addresses on a specific network, excluding a given device UUID. It's used to detect
-    /// MAC conflicts during device registration.
-    pub async fn find_duplicate_macs_on_network(
-        &self,
-        mac: &str,
-        network_id: i64,
-        exclude_device: &Uuid,
-    ) -> Result<Vec<(Uuid, String)>> {
-        let mac = mac.to_string();
-        let exclude = *exclude_device;
+/// Find pending device ID by MAC address.
+///
+/// Returns None if no pending device exists or if it's already completed.
+pub async fn find_pending_device_by_mac(
+    conn: &Connection,
+    mac_address: &str,
+) -> Result<Option<i64>> {
+    let result = conn
+        .query_row(
+            "SELECT id FROM pending_devices WHERE mac_address = ?1 AND completed_at IS NULL",
+            (mac_address.to_string(),),
+            |row| row.get::<_, i64>(0),
+        )
+        .await
+        .optional()?;
 
-        let rows = self
-            .db
-            .query(
-                "SELECT uuid, attributes FROM devices
-                 WHERE uuid != ?1
-                 AND EXISTS (
-                   SELECT 1 FROM json_each(attributes, '$.network_interfaces') as iface
-                   WHERE json_extract(iface.value, '$.mac_address') = ?2
-                     AND json_extract(iface.value, '$.network_id') = ?3
-                 )",
-                (exclude, mac.clone(), network_id),
-                |row| {
-                    let uuid: Uuid = row.get(0)?;
-                    let attributes_json: Option<String> = row.get(1)?;
-                    Ok((uuid, attributes_json))
-                },
-            )
-            .await?;
+    Ok(result)
+}
 
-        let mut duplicates = Vec::new();
+/// Complete a pending device by linking it to a device UUID.
+///
+/// Marks the pending device as completed.
+pub async fn complete_pending_device(
+    conn: &Connection,
+    mac_address: &str,
+    device_uuid: &Uuid,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE pending_devices
+         SET device_uuid = ?1, completed_at = CURRENT_TIMESTAMP
+         WHERE mac_address = ?2 AND completed_at IS NULL",
+        (*device_uuid, mac_address.to_string()),
+    )
+    .await?;
 
-        for (uuid, attributes_json) in rows {
-            // Parse attributes to find the matching interface name
-            if let Some(json_str) = attributes_json
-                && let Ok(attributes) =
-                    serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&json_str)
-                && let Some(interfaces_value) = attributes.get("network_interfaces")
-                && let Some(interfaces_array) = interfaces_value.as_array()
-            {
-                for interface_value in interfaces_array {
-                    // Parse each interface
-                    if let Ok(interface) =
-                        serde_json::from_value::<NetworkInterface>(interface_value.clone())
-                        && interface.mac_address == mac
-                        && interface.network_id == Some(network_id)
-                    {
-                        duplicates.push((uuid, interface.interface_name.clone()));
-                    }
+    Ok(())
+}
+
+/// Get all pending devices that haven't been completed yet.
+pub async fn get_pending_devices(conn: &Connection) -> Result<Vec<PendingDevice>> {
+    let devices = conn
+        .query(
+            "SELECT id, mac_address, device_uuid, network_id, created_at, completed_at
+             FROM pending_devices
+             WHERE completed_at IS NULL
+             ORDER BY created_at DESC",
+            (),
+            PendingDevice::from_row,
+        )
+        .await?;
+
+    Ok(devices)
+}
+
+/// Delete a pending device by ID.
+pub async fn delete_pending_device(conn: &Connection, id: i64) -> Result<()> {
+    conn.execute("DELETE FROM pending_devices WHERE id = ?1", (id,))
+        .await?;
+    Ok(())
+}
+
+/// Delete a device by UUID.
+///
+/// Cascades to plans and transitions, sets leases device_uuid to NULL.
+pub async fn delete_device(conn: &Connection, uuid: &Uuid) -> Result<()> {
+    conn.execute(
+        "DELETE FROM pending_devices WHERE device_uuid = ?1",
+        (*uuid,),
+    )
+    .await?;
+    conn.execute("DELETE FROM devices WHERE uuid = ?1", (*uuid,))
+        .await?;
+    Ok(())
+}
+
+/// Find device UUID by BMC MAC address.
+///
+/// Searches all devices for a BMC with the given MAC address in their attributes.
+/// Returns the device UUID if a match is found.
+pub async fn find_device_by_bmc_mac(conn: &Connection, mac: &str) -> Result<Option<Uuid>> {
+    let result = conn
+        .query_row(
+            "SELECT uuid FROM devices
+             WHERE json_extract(attributes, '$.bmc.mac_address') = ?1",
+            (mac.to_string(),),
+            |row| row.get(0),
+        )
+        .await
+        .optional()?;
+
+    Ok(result)
+}
+
+/// Assign a platform to a device.
+pub async fn assign_platform_to_device(
+    conn: &Connection,
+    device_uuid: &Uuid,
+    platform_id: i64,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE devices SET platform_id = ?1 WHERE uuid = ?2",
+        (platform_id, *device_uuid),
+    )
+    .await
+    .context("Failed to assign platform to device")?;
+
+    Ok(())
+}
+
+/// Get the platform ID assigned to a device.
+pub async fn get_device_platform_id(conn: &Connection, device_uuid: &Uuid) -> Result<Option<i64>> {
+    let result = conn
+        .query_row(
+            "SELECT platform_id FROM devices WHERE uuid = ?1",
+            (*device_uuid,),
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .await
+        .optional()?;
+
+    Ok(result.flatten())
+}
+
+/// List all devices with a specific platform.
+pub async fn list_devices_with_platform(conn: &Connection, platform_id: i64) -> Result<Vec<Uuid>> {
+    let uuids = conn
+        .query(
+            "SELECT uuid FROM devices WHERE platform_id = ?1 ORDER BY uuid",
+            (platform_id,),
+            |row| row.get(0),
+        )
+        .await?;
+
+    Ok(uuids)
+}
+
+/// Assign a role to a device.
+pub async fn assign_role_to_device(
+    conn: &Connection,
+    device_uuid: &Uuid,
+    role_id: i64,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE devices SET role_id = ?1 WHERE uuid = ?2",
+        (role_id, *device_uuid),
+    )
+    .await
+    .context("Failed to assign role to device")?;
+
+    Ok(())
+}
+
+/// Get the role ID assigned to a device.
+pub async fn get_device_role_id(conn: &Connection, device_uuid: &Uuid) -> Result<Option<i64>> {
+    let result = conn
+        .query_row(
+            "SELECT role_id FROM devices WHERE uuid = ?1",
+            (*device_uuid,),
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .await
+        .optional()?;
+
+    Ok(result.flatten())
+}
+
+/// List all devices with a specific role.
+pub async fn list_devices_with_role(conn: &Connection, role_id: i64) -> Result<Vec<Uuid>> {
+    let uuids = conn
+        .query(
+            "SELECT uuid FROM devices WHERE role_id = ?1 ORDER BY uuid",
+            (role_id,),
+            |row| row.get(0),
+        )
+        .await?;
+
+    Ok(uuids)
+}
+
+/// Find devices with the same MAC address on the same network.
+///
+/// Returns Vec<(device_uuid, interface_name)>. This function searches for duplicate MAC
+/// addresses on a specific network, excluding a given device UUID. It's used to detect
+/// MAC conflicts during device registration.
+pub async fn find_duplicate_macs_on_network(
+    conn: &Connection,
+    mac: &str,
+    network_id: i64,
+    exclude_device: &Uuid,
+) -> Result<Vec<(Uuid, String)>> {
+    let mac = mac.to_string();
+    let exclude = *exclude_device;
+
+    let rows = conn
+        .query(
+            "SELECT uuid, attributes FROM devices
+             WHERE uuid != ?1
+             AND EXISTS (
+               SELECT 1 FROM json_each(attributes, '$.network_interfaces') as iface
+               WHERE json_extract(iface.value, '$.mac_address') = ?2
+                 AND json_extract(iface.value, '$.network_id') = ?3
+             )",
+            (exclude, mac.clone(), network_id),
+            |row| {
+                let uuid: Uuid = row.get(0)?;
+                let attributes_json: Option<String> = row.get(1)?;
+                Ok((uuid, attributes_json))
+            },
+        )
+        .await?;
+
+    let mut duplicates = Vec::new();
+
+    for (uuid, attributes_json) in rows {
+        if let Some(json_str) = attributes_json
+            && let Ok(attributes) =
+                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&json_str)
+            && let Some(interfaces_value) = attributes.get("network_interfaces")
+            && let Some(interfaces_array) = interfaces_value.as_array()
+        {
+            for interface_value in interfaces_array {
+                if let Ok(interface) =
+                    serde_json::from_value::<NetworkInterface>(interface_value.clone())
+                    && interface.mac_address == mac
+                    && interface.network_id == Some(network_id)
+                {
+                    duplicates.push((uuid, interface.interface_name.clone()));
                 }
             }
         }
-
-        Ok(duplicates)
     }
+
+    Ok(duplicates)
 }
 
 /// Extract last UUID segment (after final hyphen) for hostname generation.
@@ -703,30 +634,28 @@ mod tests {
             .expect("test UUID should be valid")
     }
 
-    async fn create_test_store(path: String) -> DirectorStore {
-        let db = Arc::new(crate::database::open(path).await.unwrap());
-        // Note: No default network is created. Tests that need networks should create them explicitly.
-        DirectorStore::new(db)
+    async fn setup_db(path: String) -> Connection {
+        let factory =
+            crate::database::DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        crate::database::run_migrations(&factory).await.unwrap()
     }
 
     /// Helper to create a test network and pool for tests that need DHCP functionality.
-    async fn create_test_network(db: &Arc<crate::database::Connection>) -> i64 {
-        let dhcp_store = crate::dhcp::DhcpStore::new(db.clone());
-        let network = dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+    async fn create_test_network(conn: &Connection) -> i64 {
+        let network = crate::dhcp::store::create_network(
+            conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
-        dhcp_store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        crate::dhcp::store::create_pool(conn, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
@@ -747,20 +676,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_hostname() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x20);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
+        set_hostname(&db, &uuid, "test-hostname").await.unwrap();
 
-        // Set hostname
-        store.set_hostname(&uuid, "test-hostname").await.unwrap();
-
-        // Verify
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.hostname.as_ref().unwrap(),
             "test-hostname"
@@ -769,23 +693,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_mac_address() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x21);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
+            .await
+            .unwrap();
+        set_mac_address(&db, &uuid, "aa:bb:cc:dd:ee:ff")
             .await
             .unwrap();
 
-        // Set MAC address
-        store
-            .set_mac_address(&uuid, "aa:bb:cc:dd:ee:ff")
-            .await
-            .unwrap();
-
-        // Verify
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.mac_address.as_ref().unwrap(),
             "aa:bb:cc:dd:ee:ff"
@@ -794,50 +712,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_ip_address() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x23);
         let mac = "aa:bb:cc:dd:ee:ff";
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
+        set_ip_address(&db, &uuid, "10.0.0.150", mac).await.unwrap();
 
-        // Set IP address for a MAC (creates new interface)
-        store
-            .set_ip_address(&uuid, "10.0.0.150", mac)
-            .await
-            .unwrap();
-
-        // Verify interface was created with correct IP
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 1);
         assert_eq!(interfaces[0].mac_address, mac);
         assert_eq!(interfaces[0].ip_address, Some("10.0.0.150".to_string()));
 
-        // Verify legacy ip_address field is NOT set
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert!(device.attributes.static_ip.is_none());
     }
 
     #[tokio::test]
     async fn test_hostname_generation_on_register() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x22);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
-
-        // Generate and set hostname
         let hostname = generate_hostname_from_uuid(&uuid);
-        store.set_hostname(&uuid, &hostname).await.unwrap();
+        set_hostname(&db, &uuid, &hostname).await.unwrap();
 
-        // Verify
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.hostname.as_ref().unwrap(),
             "node-446655440022"
@@ -846,23 +750,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_attributes_preserves_existing() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x24);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
+        set_hostname(&db, &uuid, "server-01").await.unwrap();
 
-        // Set initial attributes (hostname via set_hostname to simulate real flow)
-        store.set_hostname(&uuid, "server-01").await.unwrap();
-
-        // Verify initial state
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(device.attributes.hostname.as_ref().unwrap(), "server-01");
 
-        // Simulate hardware discovery updating attributes
         let mut hardware_attrs = serde_json::Map::new();
         hardware_attrs.insert(
             "manufacturer".to_string(),
@@ -877,22 +775,14 @@ mod tests {
             serde_json::Value::String("ABC12345".to_string()),
         );
 
-        store
-            .update_attributes(&uuid, hardware_attrs)
-            .await
-            .unwrap();
+        update_attributes(&db, &uuid, hardware_attrs).await.unwrap();
 
-        // Verify ALL attributes are present (both old and new)
-        let device = store.get_device(&uuid).await.unwrap();
-
-        // Original attribute should be preserved
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.hostname.as_ref().unwrap(),
             "server-01",
             "hostname should be preserved after update_attributes"
         );
-
-        // New attributes should be added
         assert_eq!(
             device.attributes.manufacturer.as_ref().unwrap(),
             "Dell Inc."
@@ -909,16 +799,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_attributes_overwrites_existing_keys() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x25);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set initial attributes
         let mut initial_attrs = serde_json::Map::new();
         initial_attrs.insert(
             "hostname".to_string(),
@@ -928,9 +815,8 @@ mod tests {
             "manufacturer".to_string(),
             serde_json::Value::String("Unknown".to_string()),
         );
-        store.update_attributes(&uuid, initial_attrs).await.unwrap();
+        update_attributes(&db, &uuid, initial_attrs).await.unwrap();
 
-        // Update with overlapping keys
         let mut new_attrs = serde_json::Map::new();
         new_attrs.insert(
             "hostname".to_string(),
@@ -940,11 +826,9 @@ mod tests {
             "product_name".to_string(),
             serde_json::Value::String("PowerEdge".to_string()),
         );
-        store.update_attributes(&uuid, new_attrs).await.unwrap();
+        update_attributes(&db, &uuid, new_attrs).await.unwrap();
 
-        // Verify overlapping key is updated, non-overlapping keys are preserved
-        let device = store.get_device(&uuid).await.unwrap();
-
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.hostname.as_ref().unwrap(),
             "new-hostname",
@@ -964,57 +848,43 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_attributes_empty_map() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x26);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
+        set_hostname(&db, &uuid, "test-host").await.unwrap();
 
-        // Set initial attributes
-        store.set_hostname(&uuid, "test-host").await.unwrap();
-
-        // Update with empty map (should preserve existing)
         let empty_attrs = serde_json::Map::new();
-        store.update_attributes(&uuid, empty_attrs).await.unwrap();
+        update_attributes(&db, &uuid, empty_attrs).await.unwrap();
 
-        // Verify existing attributes are preserved
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(device.attributes.hostname.as_ref().unwrap(), "test-host");
     }
 
-    // Tests for multi-NIC support
-
     #[tokio::test]
     async fn test_get_network_interfaces_empty() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x30);
 
-        // Register device without any NICs
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Get interfaces should return empty vec
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 0);
     }
 
     #[tokio::test]
     async fn test_get_network_interfaces_single() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x31);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set single network interface
         let interfaces = vec![NetworkInterface {
             interface_name: "eth0".to_string(),
             mac_address: "aa:bb:cc:dd:ee:01".to_string(),
@@ -1024,13 +894,11 @@ mod tests {
             disabled: false,
             warning_label: None,
         }];
-        store
-            .set_network_interfaces(&uuid, &interfaces)
+        set_network_interfaces(&db, &uuid, &interfaces)
             .await
             .unwrap();
 
-        // Retrieve and verify
-        let retrieved = store.get_network_interfaces(&uuid).await.unwrap();
+        let retrieved = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(retrieved.len(), 1);
         assert_eq!(retrieved[0].interface_name, "eth0");
         assert_eq!(retrieved[0].mac_address, "aa:bb:cc:dd:ee:01");
@@ -1039,16 +907,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_network_interfaces_multiple() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x32);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set multiple network interfaces
         let interfaces = vec![
             NetworkInterface {
                 interface_name: "eth0".to_string(),
@@ -1078,13 +943,11 @@ mod tests {
                 warning_label: None,
             },
         ];
-        store
-            .set_network_interfaces(&uuid, &interfaces)
+        set_network_interfaces(&db, &uuid, &interfaces)
             .await
             .unwrap();
 
-        // Retrieve and verify
-        let retrieved = store.get_network_interfaces(&uuid).await.unwrap();
+        let retrieved = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(retrieved.len(), 3);
         assert_eq!(retrieved[0].interface_name, "eth0");
         assert_eq!(retrieved[1].interface_name, "eth1");
@@ -1093,16 +956,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_network_interfaces_overwrites() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x33);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set initial interfaces
         let initial = vec![NetworkInterface {
             interface_name: "eth0".to_string(),
             mac_address: "aa:bb:cc:dd:ee:01".to_string(),
@@ -1112,9 +972,8 @@ mod tests {
             disabled: false,
             warning_label: None,
         }];
-        store.set_network_interfaces(&uuid, &initial).await.unwrap();
+        set_network_interfaces(&db, &uuid, &initial).await.unwrap();
 
-        // Overwrite with different interfaces
         let updated = vec![
             NetworkInterface {
                 interface_name: "ens0".to_string(),
@@ -1135,10 +994,9 @@ mod tests {
                 warning_label: None,
             },
         ];
-        store.set_network_interfaces(&uuid, &updated).await.unwrap();
+        set_network_interfaces(&db, &uuid, &updated).await.unwrap();
 
-        // Verify it was overwritten
-        let retrieved = store.get_network_interfaces(&uuid).await.unwrap();
+        let retrieved = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(retrieved.len(), 2);
         assert_eq!(retrieved[0].interface_name, "ens0");
         assert_eq!(retrieved[1].interface_name, "ens1");
@@ -1146,42 +1004,32 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_device_by_mac_legacy_field() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x34);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
+            .await
+            .unwrap();
+        set_mac_address(&db, &uuid, "aa:bb:cc:dd:ee:ff")
             .await
             .unwrap();
 
-        // Set MAC using legacy method
-        store
-            .set_mac_address(&uuid, "aa:bb:cc:dd:ee:ff")
-            .await
-            .unwrap();
-
-        // Find by MAC should work
-        let found = store.find_device_by_mac("aa:bb:cc:dd:ee:ff").await.unwrap();
+        let found = find_device_by_mac(&db, "aa:bb:cc:dd:ee:ff").await.unwrap();
         assert_eq!(found, Some(uuid));
 
-        // Non-existent MAC should return None
-        let not_found = store.find_device_by_mac("00:00:00:00:00:00").await.unwrap();
+        let not_found = find_device_by_mac(&db, "00:00:00:00:00:00").await.unwrap();
         assert_eq!(not_found, None);
     }
 
     #[tokio::test]
     async fn test_find_device_by_mac_in_interfaces_array() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x35);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set network interfaces
         let interfaces = vec![
             NetworkInterface {
                 interface_name: "eth0".to_string(),
@@ -1202,38 +1050,29 @@ mod tests {
                 warning_label: None,
             },
         ];
-        store
-            .set_network_interfaces(&uuid, &interfaces)
+        set_network_interfaces(&db, &uuid, &interfaces)
             .await
             .unwrap();
 
-        // Find by primary MAC
-        let found1 = store.find_device_by_mac("aa:bb:cc:dd:ee:01").await.unwrap();
+        let found1 = find_device_by_mac(&db, "aa:bb:cc:dd:ee:01").await.unwrap();
         assert_eq!(found1, Some(uuid));
 
-        // Find by secondary MAC
-        let found2 = store.find_device_by_mac("aa:bb:cc:dd:ee:02").await.unwrap();
+        let found2 = find_device_by_mac(&db, "aa:bb:cc:dd:ee:02").await.unwrap();
         assert_eq!(found2, Some(uuid));
 
-        // Non-existent MAC should return None
-        let not_found = store.find_device_by_mac("00:00:00:00:00:00").await.unwrap();
+        let not_found = find_device_by_mac(&db, "00:00:00:00:00:00").await.unwrap();
         assert_eq!(not_found, None);
     }
 
     #[tokio::test]
     async fn test_find_device_by_any_mac() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x36);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
-
-        // Set both legacy MAC and interfaces array
-        store
-            .set_mac_address(&uuid, "aa:bb:cc:dd:ee:ff")
+        set_mac_address(&db, &uuid, "aa:bb:cc:dd:ee:ff")
             .await
             .unwrap();
 
@@ -1257,67 +1096,49 @@ mod tests {
                 warning_label: None,
             },
         ];
-        store
-            .set_network_interfaces(&uuid, &interfaces)
+        set_network_interfaces(&db, &uuid, &interfaces)
             .await
             .unwrap();
 
-        // Find by legacy MAC
-        let found_legacy = store
-            .find_device_by_any_mac("aa:bb:cc:dd:ee:ff")
-            .await
-            .unwrap();
+        // find_device_by_mac searches both legacy field and interfaces
+        let found_legacy = find_device_by_mac(&db, "aa:bb:cc:dd:ee:ff").await.unwrap();
         assert_eq!(found_legacy, Some(uuid));
 
-        // Find by interface MAC
-        let found_iface = store
-            .find_device_by_any_mac("aa:bb:cc:dd:ee:02")
-            .await
-            .unwrap();
+        let found_iface = find_device_by_mac(&db, "aa:bb:cc:dd:ee:02").await.unwrap();
         assert_eq!(found_iface, Some(uuid));
     }
 
     #[tokio::test]
     async fn test_set_mac_address_legacy_only() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x37);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
+            .await
+            .unwrap();
+        set_mac_address(&db, &uuid, "aa:bb:cc:dd:ee:ff")
             .await
             .unwrap();
 
-        // Set MAC address without interfaces array
-        store
-            .set_mac_address(&uuid, "aa:bb:cc:dd:ee:ff")
-            .await
-            .unwrap();
-
-        // Verify legacy field is set
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.mac_address.as_ref().unwrap(),
             "aa:bb:cc:dd:ee:ff"
         );
 
-        // Verify interfaces array is still empty
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 0);
     }
 
     #[tokio::test]
     async fn test_set_mac_address_updates_first_interface() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x38);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set network interfaces
         let interfaces = vec![
             NetworkInterface {
                 interface_name: "eth0".to_string(),
@@ -1338,72 +1159,54 @@ mod tests {
                 warning_label: None,
             },
         ];
-        store
-            .set_network_interfaces(&uuid, &interfaces)
+        set_network_interfaces(&db, &uuid, &interfaces)
             .await
             .unwrap();
 
-        // Update MAC address
-        store
-            .set_mac_address(&uuid, "11:22:33:44:55:66")
+        set_mac_address(&db, &uuid, "11:22:33:44:55:66")
             .await
             .unwrap();
 
-        // Verify legacy field is updated
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.mac_address.as_ref().unwrap(),
             "11:22:33:44:55:66"
         );
 
-        // Verify first interface MAC is updated
-        let updated_interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let updated_interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(updated_interfaces[0].mac_address, "11:22:33:44:55:66");
-        // Secondary interface should be unchanged
         assert_eq!(updated_interfaces[1].mac_address, "aa:bb:cc:dd:ee:02");
     }
 
     #[tokio::test]
     async fn test_set_ip_address_creates_interface_when_missing() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x39);
         let mac = "aa:bb:cc:dd:ee:ff";
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
+        set_ip_address(&db, &uuid, "10.0.0.100", mac).await.unwrap();
 
-        // Set IP address without pre-existing interfaces array
-        store
-            .set_ip_address(&uuid, "10.0.0.100", mac)
-            .await
-            .unwrap();
-
-        // Verify interface was created
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 1);
         assert_eq!(interfaces[0].mac_address, mac);
         assert_eq!(interfaces[0].ip_address, Some("10.0.0.100".to_string()));
 
-        // Verify legacy field is NOT set
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert!(device.attributes.static_ip.is_none());
     }
 
     #[tokio::test]
     async fn test_set_ip_address_updates_by_mac() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x40);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set network interfaces
         let interfaces = vec![
             NetworkInterface {
                 interface_name: "eth0".to_string(),
@@ -1424,70 +1227,54 @@ mod tests {
                 warning_label: None,
             },
         ];
-        store
-            .set_network_interfaces(&uuid, &interfaces)
+        set_network_interfaces(&db, &uuid, &interfaces)
             .await
             .unwrap();
 
-        // Update IP address for eth1 (non-primary) by MAC
-        store
-            .set_ip_address(&uuid, "192.168.1.50", "aa:bb:cc:dd:ee:02")
+        set_ip_address(&db, &uuid, "192.168.1.50", "aa:bb:cc:dd:ee:02")
             .await
             .unwrap();
 
-        // Verify eth1 IP is updated
-        let updated_interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let updated_interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(
             updated_interfaces[1].ip_address,
             Some("192.168.1.50".to_string())
         );
-        // Primary interface (eth0) should be unchanged
         assert_eq!(
             updated_interfaces[0].ip_address,
             Some("10.0.0.100".to_string())
         );
 
-        // Verify legacy field is NOT set
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert!(device.attributes.static_ip.is_none());
     }
 
     #[tokio::test]
     async fn test_backward_compatibility_legacy_device() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x41);
 
-        // Register device and set up as a legacy device (no network_interfaces)
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
+            .await
+            .unwrap();
+        set_mac_address(&db, &uuid, "aa:bb:cc:dd:ee:ff")
+            .await
+            .unwrap();
+        set_ip_address(&db, &uuid, "10.0.0.100", "aa:bb:cc:dd:ee:ff")
             .await
             .unwrap();
 
-        store
-            .set_mac_address(&uuid, "aa:bb:cc:dd:ee:ff")
-            .await
-            .unwrap();
-        store
-            .set_ip_address(&uuid, "10.0.0.100", "aa:bb:cc:dd:ee:ff")
-            .await
-            .unwrap();
-
-        // Verify legacy mac_address field still works
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         assert_eq!(
             device.attributes.mac_address.as_ref().unwrap(),
             "aa:bb:cc:dd:ee:ff"
         );
-
-        // New behavior: ip_address is stored in network_interfaces, not legacy field
         assert!(device.attributes.static_ip.is_none());
 
-        // Verify find_device_by_mac still works
-        let found = store.find_device_by_mac("aa:bb:cc:dd:ee:ff").await.unwrap();
+        let found = find_device_by_mac(&db, "aa:bb:cc:dd:ee:ff").await.unwrap();
         assert_eq!(found, Some(uuid));
 
-        // Verify network_interfaces was created with the IP
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 1);
         assert_eq!(interfaces[0].mac_address, "aa:bb:cc:dd:ee:ff");
         assert_eq!(interfaces[0].ip_address, Some("10.0.0.100".to_string()));
@@ -1495,82 +1282,64 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_ip_address_for_bmc() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid = test_uuid(0x42);
         let bmc_mac = "aa:bb:cc:dd:ee:aa";
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set BMC information in device attributes
-        store.db
-            .execute(
-                r#"UPDATE devices SET attributes = json_set(attributes, '$.bmc',
+        db.execute(
+            r#"UPDATE devices SET attributes = json_set(attributes, '$.bmc',
                json('{"mac_address":"aa:bb:cc:dd:ee:aa","ip_address":null,"ip_address_source":"Unknown"}')
             ) WHERE uuid = ?1"#,
-                (uuid,),
-            )
+            (uuid,),
+        )
+        .await
+        .unwrap();
+
+        set_ip_address(&db, &uuid, "10.0.1.50", bmc_mac)
             .await
             .unwrap();
 
-        // Set IP address for BMC MAC
-        store
-            .set_ip_address(&uuid, "10.0.1.50", bmc_mac)
-            .await
-            .unwrap();
-
-        // Verify BMC IP was updated
-        let device = store.get_device(&uuid).await.unwrap();
+        let device = get_device(&db, &uuid).await.unwrap();
         let bmc = device.attributes.bmc.as_ref().unwrap();
         assert_eq!(bmc.ip_address.as_ref().unwrap(), "10.0.1.50");
 
-        // Verify network_interfaces was NOT created
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 0);
     }
 
     #[tokio::test]
     async fn test_get_network_interfaces_invalid_json() {
-        let store = create_test_store(test_database_path!()).await;
-        let uuid = test_uuid(0x42);
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0x43);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Manually set invalid JSON in network_interfaces field
-        store.db
-            .execute(
-                "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', 'invalid') WHERE uuid = ?1",
-                (uuid,),
-            )
-            .await
-            .unwrap();
+        db.execute(
+            "UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces', 'invalid') WHERE uuid = ?1",
+            (uuid,),
+        )
+        .await
+        .unwrap();
 
-        // Should return empty vec instead of error
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 0);
     }
 
-    // Tests for duplicate MAC detection
-
     #[tokio::test]
     async fn test_network_interface_disabled_fields_serialization() {
-        let store = create_test_store(test_database_path!()).await;
-        let uuid = test_uuid(0x43);
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0x44);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Create interface with new fields
         let interface = NetworkInterface {
             interface_name: "eth0".to_string(),
             mac_address: "aa:bb:cc:dd:ee:01".to_string(),
@@ -1580,14 +1349,11 @@ mod tests {
             disabled: true,
             warning_label: Some("Duplicate MAC on network main".to_string()),
         };
-
-        store
-            .set_network_interfaces(&uuid, std::slice::from_ref(&interface))
+        set_network_interfaces(&db, &uuid, std::slice::from_ref(&interface))
             .await
             .unwrap();
 
-        // Retrieve and verify all fields
-        let retrieved = store.get_network_interfaces(&uuid).await.unwrap();
+        let retrieved = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(retrieved.len(), 1);
         assert_eq!(retrieved[0].network_id, Some(1));
         assert!(retrieved[0].disabled);
@@ -1599,28 +1365,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_network_interface_backward_compatibility() {
-        let store = create_test_store(test_database_path!()).await;
-        let uuid = test_uuid(0x44);
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0x45);
 
-        // Register device
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Manually set old-style interface without new fields
-        store.db
-            .execute(
-                r#"UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces',
+        db.execute(
+            r#"UPDATE devices SET attributes = json_set(attributes, '$.network_interfaces',
                json('[{"interface_name":"eth0","mac_address":"aa:bb:cc:dd:ee:01","ip_address":"10.0.0.100"}]')
             ) WHERE uuid = ?1"#,
-                (uuid,),
-            )
-            .await
-            .unwrap();
+            (uuid,),
+        )
+        .await
+        .unwrap();
 
-        // Should deserialize with default values for new fields
-        let interfaces = store.get_network_interfaces(&uuid).await.unwrap();
+        let interfaces = get_network_interfaces(&db, &uuid).await.unwrap();
         assert_eq!(interfaces.len(), 1);
         assert_eq!(interfaces[0].network_id, None);
         assert!(!interfaces[0].disabled);
@@ -1629,53 +1390,49 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_on_network_no_duplicates() {
-        let store = create_test_store(test_database_path!()).await;
-        let uuid1 = test_uuid(0x45);
-        let uuid2 = test_uuid(0x46);
+        let db = setup_db(test_database_path!()).await;
+        let uuid1 = test_uuid(0x46);
+        let uuid2 = test_uuid(0x47);
 
-        // Register two devices
-        store
-            .register_device(&uuid1, Architecture::X86_64)
+        register_device(&db, &uuid1, Architecture::X86_64)
             .await
             .unwrap();
-        store
-            .register_device(&uuid2, Architecture::X86_64)
+        register_device(&db, &uuid2, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set different MACs on same network
-        let interface1 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: "aa:bb:cc:dd:ee:01".to_string(),
-            ip_address: Some("10.0.0.100".to_string()),
-            network_id: Some(1),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
+        set_network_interfaces(
+            &db,
+            &uuid1,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: "aa:bb:cc:dd:ee:01".to_string(),
+                ip_address: Some("10.0.0.100".to_string()),
+                network_id: Some(1),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
+        set_network_interfaces(
+            &db,
+            &uuid2,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: "aa:bb:cc:dd:ee:02".to_string(),
+                ip_address: Some("10.0.0.101".to_string()),
+                network_id: Some(1),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
 
-        let interface2 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: "aa:bb:cc:dd:ee:02".to_string(),
-            ip_address: Some("10.0.0.101".to_string()),
-            network_id: Some(1),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
-
-        store
-            .set_network_interfaces(&uuid1, &[interface1])
-            .await
-            .unwrap();
-        store
-            .set_network_interfaces(&uuid2, &[interface2])
-            .await
-            .unwrap();
-
-        // Should find no duplicates
-        let duplicates = store
-            .find_duplicate_macs_on_network("aa:bb:cc:dd:ee:01", 1, &uuid1)
+        let duplicates = find_duplicate_macs_on_network(&db, "aa:bb:cc:dd:ee:01", 1, &uuid1)
             .await
             .unwrap();
         assert_eq!(duplicates.len(), 0);
@@ -1683,65 +1440,59 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_on_network_finds_duplicate() {
-        let store = create_test_store(test_database_path!()).await;
-        let uuid1 = test_uuid(0x47);
-        let uuid2 = test_uuid(0x48);
+        let db = setup_db(test_database_path!()).await;
+        let uuid1 = test_uuid(0x48);
+        let uuid2 = test_uuid(0x49);
 
-        // Register two devices
-        store
-            .register_device(&uuid1, Architecture::X86_64)
+        register_device(&db, &uuid1, Architecture::X86_64)
             .await
             .unwrap();
-        store
-            .register_device(&uuid2, Architecture::X86_64)
+        register_device(&db, &uuid2, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set SAME MAC on same network
         let mac = "aa:bb:cc:dd:ee:99";
         let network_id = 1i64;
 
-        let interface1 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("10.0.0.100".to_string()),
-            network_id: Some(network_id),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
+        set_network_interfaces(
+            &db,
+            &uuid1,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("10.0.0.100".to_string()),
+                network_id: Some(network_id),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
+        set_network_interfaces(
+            &db,
+            &uuid2,
+            &[NetworkInterface {
+                interface_name: "ens0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("10.0.0.101".to_string()),
+                network_id: Some(network_id),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
 
-        let interface2 = NetworkInterface {
-            interface_name: "ens0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("10.0.0.101".to_string()),
-            network_id: Some(network_id),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
-
-        store
-            .set_network_interfaces(&uuid1, &[interface1])
-            .await
-            .unwrap();
-        store
-            .set_network_interfaces(&uuid2, &[interface2])
-            .await
-            .unwrap();
-
-        // Should find duplicate when checking from uuid1
-        let duplicates = store
-            .find_duplicate_macs_on_network(mac, network_id, &uuid1)
+        let duplicates = find_duplicate_macs_on_network(&db, mac, network_id, &uuid1)
             .await
             .unwrap();
         assert_eq!(duplicates.len(), 1);
         assert_eq!(duplicates[0].0, uuid2);
         assert_eq!(duplicates[0].1, "ens0");
 
-        // Should find duplicate when checking from uuid2
-        let duplicates = store
-            .find_duplicate_macs_on_network(mac, network_id, &uuid2)
+        let duplicates = find_duplicate_macs_on_network(&db, mac, network_id, &uuid2)
             .await
             .unwrap();
         assert_eq!(duplicates.len(), 1);
@@ -1751,63 +1502,55 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_on_different_networks() {
-        let store = create_test_store(test_database_path!()).await;
-        let uuid1 = test_uuid(0x49);
-        let uuid2 = test_uuid(0x4A);
+        let db = setup_db(test_database_path!()).await;
+        let uuid1 = test_uuid(0x4A);
+        let uuid2 = test_uuid(0x4B);
 
-        // Register two devices
-        store
-            .register_device(&uuid1, Architecture::X86_64)
+        register_device(&db, &uuid1, Architecture::X86_64)
             .await
             .unwrap();
-        store
-            .register_device(&uuid2, Architecture::X86_64)
+        register_device(&db, &uuid2, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set SAME MAC on DIFFERENT networks
         let mac = "aa:bb:cc:dd:ee:88";
-        let network_id = 1i64;
+        set_network_interfaces(
+            &db,
+            &uuid1,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("10.0.0.100".to_string()),
+                network_id: Some(1),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
+        set_network_interfaces(
+            &db,
+            &uuid2,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("192.168.1.100".to_string()),
+                network_id: Some(2),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
 
-        let interface1 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("10.0.0.100".to_string()),
-            network_id: Some(network_id),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
-
-        let interface2 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("192.168.1.100".to_string()),
-            network_id: Some(2),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
-
-        store
-            .set_network_interfaces(&uuid1, &[interface1])
-            .await
-            .unwrap();
-        store
-            .set_network_interfaces(&uuid2, &[interface2])
-            .await
-            .unwrap();
-
-        // Should NOT find duplicate on network 1 (only uuid1 is on network 1)
-        let duplicates = store
-            .find_duplicate_macs_on_network(mac, network_id, &uuid1)
+        let duplicates = find_duplicate_macs_on_network(&db, mac, 1i64, &uuid1)
             .await
             .unwrap();
         assert_eq!(duplicates.len(), 0);
 
-        // Should NOT find duplicate on network 2 (only uuid2 is on network 2)
-        let duplicates = store
-            .find_duplicate_macs_on_network(mac, 2i64, &uuid2)
+        let duplicates = find_duplicate_macs_on_network(&db, mac, 2i64, &uuid2)
             .await
             .unwrap();
         assert_eq!(duplicates.len(), 0);
@@ -1815,80 +1558,75 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_multiple_duplicates() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid1 = test_uuid(0x51);
         let uuid2 = test_uuid(0x52);
         let uuid3 = test_uuid(0x53);
 
-        // Register three devices
-        store
-            .register_device(&uuid1, Architecture::X86_64)
+        register_device(&db, &uuid1, Architecture::X86_64)
             .await
             .unwrap();
-        store
-            .register_device(&uuid2, Architecture::X86_64)
+        register_device(&db, &uuid2, Architecture::X86_64)
             .await
             .unwrap();
-        store
-            .register_device(&uuid3, Architecture::X86_64)
+        register_device(&db, &uuid3, Architecture::X86_64)
             .await
             .unwrap();
 
-        // All three have same MAC on same network
         let mac = "aa:bb:cc:dd:ee:77";
         let network_id = 1i64;
 
-        let interface1 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("10.0.0.100".to_string()),
-            network_id: Some(network_id),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
+        set_network_interfaces(
+            &db,
+            &uuid1,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("10.0.0.100".to_string()),
+                network_id: Some(network_id),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
+        set_network_interfaces(
+            &db,
+            &uuid2,
+            &[NetworkInterface {
+                interface_name: "ens0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("10.0.0.101".to_string()),
+                network_id: Some(network_id),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
+        set_network_interfaces(
+            &db,
+            &uuid3,
+            &[NetworkInterface {
+                interface_name: "enp0s3".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("10.0.0.102".to_string()),
+                network_id: Some(network_id),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
 
-        let interface2 = NetworkInterface {
-            interface_name: "ens0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("10.0.0.101".to_string()),
-            network_id: Some(network_id),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
-
-        let interface3 = NetworkInterface {
-            interface_name: "enp0s3".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("10.0.0.102".to_string()),
-            network_id: Some(network_id),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
-
-        store
-            .set_network_interfaces(&uuid1, &[interface1])
-            .await
-            .unwrap();
-        store
-            .set_network_interfaces(&uuid2, &[interface2])
-            .await
-            .unwrap();
-        store
-            .set_network_interfaces(&uuid3, &[interface3])
-            .await
-            .unwrap();
-
-        // Should find 2 duplicates when checking from uuid1
-        let mut duplicates = store
-            .find_duplicate_macs_on_network(mac, network_id, &uuid1)
+        let mut duplicates = find_duplicate_macs_on_network(&db, mac, network_id, &uuid1)
             .await
             .unwrap();
         assert_eq!(duplicates.len(), 2);
 
-        // Sort for deterministic testing
         duplicates.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(duplicates[0].0, uuid2);
         assert_eq!(duplicates[0].1, "ens0");
@@ -1898,56 +1636,52 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_duplicate_macs_no_network_id() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
         let uuid1 = test_uuid(0x54);
         let uuid2 = test_uuid(0x55);
 
-        // Register two devices
-        store
-            .register_device(&uuid1, Architecture::X86_64)
+        register_device(&db, &uuid1, Architecture::X86_64)
             .await
             .unwrap();
-        store
-            .register_device(&uuid2, Architecture::X86_64)
+        register_device(&db, &uuid2, Architecture::X86_64)
             .await
             .unwrap();
 
-        // Set same MAC but without network_id (legacy interface)
         let mac = "aa:bb:cc:dd:ee:66";
         let network_id = 1i64;
 
-        let interface1 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: None,
-            network_id: None,
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
+        set_network_interfaces(
+            &db,
+            &uuid1,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: None,
+                network_id: None,
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
+        set_network_interfaces(
+            &db,
+            &uuid2,
+            &[NetworkInterface {
+                interface_name: "eth0".to_string(),
+                mac_address: mac.to_string(),
+                ip_address: Some("10.0.0.100".to_string()),
+                network_id: Some(network_id),
+                speed_mbps: None,
+                disabled: false,
+                warning_label: None,
+            }],
+        )
+        .await
+        .unwrap();
 
-        let interface2 = NetworkInterface {
-            interface_name: "eth0".to_string(),
-            mac_address: mac.to_string(),
-            ip_address: Some("10.0.0.100".to_string()),
-            network_id: Some(network_id),
-            speed_mbps: None,
-            disabled: false,
-            warning_label: None,
-        };
-
-        store
-            .set_network_interfaces(&uuid1, &[interface1])
-            .await
-            .unwrap();
-        store
-            .set_network_interfaces(&uuid2, &[interface2])
-            .await
-            .unwrap();
-
-        // Should NOT find uuid1 (no network_id) when searching network 1
-        let duplicates = store
-            .find_duplicate_macs_on_network(mac, network_id, &uuid2)
+        let duplicates = find_duplicate_macs_on_network(&db, mac, network_id, &uuid2)
             .await
             .unwrap();
         assert_eq!(duplicates.len(), 0);
@@ -1955,60 +1689,48 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_pending_device() {
-        let store = create_test_store(test_database_path!()).await;
-        let network_id = create_test_network(&store.db).await;
+        let db = setup_db(test_database_path!()).await;
+        let network_id = create_test_network(&db).await;
         let mac = "aa:bb:cc:dd:ee:99";
 
-        // Create a pending device
-        let pending_id = store.create_pending_device(mac, network_id).await.unwrap();
+        let pending_id = create_pending_device(&db, mac, network_id).await.unwrap();
 
-        // Verify it was created
-        let pending_devices = store.get_pending_devices().await.unwrap();
+        let pending_devices = get_pending_devices(&db).await.unwrap();
         assert_eq!(pending_devices.len(), 1);
         assert_eq!(pending_devices[0].id, pending_id);
         assert_eq!(pending_devices[0].mac_address, mac);
 
-        // Delete the pending device
-        store.delete_pending_device(pending_id).await.unwrap();
+        delete_pending_device(&db, pending_id).await.unwrap();
 
-        // Verify it was deleted
-        let pending_devices = store.get_pending_devices().await.unwrap();
+        let pending_devices = get_pending_devices(&db).await.unwrap();
         assert_eq!(pending_devices.len(), 0);
     }
 
     #[tokio::test]
     async fn test_delete_nonexistent_pending_device() {
-        let store = create_test_store(test_database_path!()).await;
+        let db = setup_db(test_database_path!()).await;
 
-        // Deleting a non-existent pending device should not error
-        // (SQL DELETE on non-existent row succeeds with 0 rows affected)
-        let result = store.delete_pending_device(999).await;
+        let result = delete_pending_device(&db, 999).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn test_delete_device_with_pending() {
-        let store = create_test_store(test_database_path!()).await;
-        let network_id = create_test_network(&store.db).await;
-        let uuid = test_uuid(0x54);
+        let db = setup_db(test_database_path!()).await;
+        let network_id = create_test_network(&db).await;
+        let uuid = test_uuid(0x56);
         let mac = "aa:bb:cc:dd:ee:99";
 
-        // Create a pending device
-        store.create_pending_device(mac, network_id).await.unwrap();
+        create_pending_device(&db, mac, network_id).await.unwrap();
 
-        // Register a device for the pending
-        store
-            .register_device(&uuid, Architecture::X86_64)
+        register_device(&db, &uuid, Architecture::X86_64)
             .await
             .unwrap();
-        store.complete_pending_device(mac, &uuid).await.unwrap();
+        complete_pending_device(&db, mac, &uuid).await.unwrap();
 
-        // Delete the device
-        store.delete_device(&uuid).await.unwrap();
+        delete_device(&db, &uuid).await.unwrap();
 
-        // Ensure pending entry is removed
-        let exists: rusqlite::Result<bool> = store
-            .db
+        let exists: rusqlite::Result<bool> = db
             .query_one(
                 "SELECT 1 FROM pending_devices WHERE mac_address = ?1",
                 (mac.to_string(),),

--- a/rack-director/src/director/store.rs
+++ b/rack-director/src/director/store.rs
@@ -1714,6 +1714,132 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    // ===== Failure-mode tests =====
+
+    /// get_device with a UUID that does not exist must return an error.
+    #[tokio::test]
+    async fn test_get_device_not_found() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF0);
+
+        let result = get_device(&db, &uuid).await;
+        assert!(
+            result.is_err(),
+            "get_device must return Err for unknown UUID"
+        );
+    }
+
+    /// register_device with a UUID that is already present must return an error
+    /// because of the PRIMARY KEY constraint on the devices table.
+    #[tokio::test]
+    async fn test_register_device_duplicate_uuid() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF1);
+
+        register_device(&db, &uuid, Architecture::X86_64)
+            .await
+            .unwrap();
+
+        let result = register_device(&db, &uuid, Architecture::X86_64).await;
+        assert!(
+            result.is_err(),
+            "register_device must return Err for duplicate UUID"
+        );
+    }
+
+    /// device_exists with a UUID that does not exist must return false (not an error).
+    #[tokio::test]
+    async fn test_device_exists_not_found() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF2);
+
+        let exists = device_exists(&db, &uuid).await.unwrap();
+        assert!(!exists, "device_exists must return false for unknown UUID");
+    }
+
+    /// find_device_by_mac with a MAC that matches no device must return None.
+    #[tokio::test]
+    async fn test_find_device_by_mac_not_found() {
+        let db = setup_db(test_database_path!()).await;
+
+        let result = find_device_by_mac(&db, "ff:ff:ff:ff:ff:ff").await.unwrap();
+        assert_eq!(
+            result, None,
+            "find_device_by_mac must return None when MAC is absent"
+        );
+    }
+
+    /// delete_device with a UUID that does not exist must succeed silently
+    /// (DELETE with no matching rows is not an error in SQLite).
+    #[tokio::test]
+    async fn test_delete_device_nonexistent() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF3);
+
+        let result = delete_device(&db, &uuid).await;
+        assert!(
+            result.is_ok(),
+            "delete_device must return Ok for unknown UUID"
+        );
+    }
+
+    /// update_attributes with a UUID that does not exist must return an error
+    /// because it calls get_device internally, which fails for unknown UUIDs.
+    #[tokio::test]
+    async fn test_update_attributes_nonexistent() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF4);
+
+        let attrs = serde_json::Map::new();
+        let result = update_attributes(&db, &uuid, attrs).await;
+        assert!(
+            result.is_err(),
+            "update_attributes must return Err for unknown UUID"
+        );
+    }
+
+    /// complete_pending_device with a MAC that does not exist in pending_devices
+    /// must return Ok — the UPDATE simply affects 0 rows, which is not an error.
+    #[tokio::test]
+    async fn test_complete_pending_device_nonexistent() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF5);
+
+        let result = complete_pending_device(&db, "ff:00:00:00:00:00", &uuid).await;
+        assert!(
+            result.is_ok(),
+            "complete_pending_device must return Ok when MAC is absent (0 rows updated)"
+        );
+    }
+
+    /// assign_platform_to_device with a UUID that does not exist must return Ok —
+    /// the UPDATE simply affects 0 rows, which is not an error.
+    #[tokio::test]
+    async fn test_assign_platform_nonexistent() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF6);
+
+        let result = assign_platform_to_device(&db, &uuid, 999).await;
+        assert!(
+            result.is_ok(),
+            "assign_platform_to_device must return Ok when device UUID is absent"
+        );
+    }
+
+    /// assign_role_to_device with a UUID that does not exist must return Ok —
+    /// the UPDATE simply affects 0 rows, which is not an error.
+    #[tokio::test]
+    async fn test_assign_role_nonexistent() {
+        let db = setup_db(test_database_path!()).await;
+        let uuid = test_uuid(0xF7);
+
+        let result = assign_role_to_device(&db, &uuid, 999).await;
+        assert!(
+            result.is_ok(),
+            "assign_role_to_device must return Ok when device UUID is absent"
+        );
+    }
+
     #[tokio::test]
     async fn test_delete_device_with_pending() {
         let db = setup_db(test_database_path!()).await;

--- a/rack-director/src/http/cnc/boot_files.rs
+++ b/rack-director/src/http/cnc/boot_files.rs
@@ -85,18 +85,12 @@ mod tests {
 
     use crate::{
         boot_files::FilesystemBootFileProvider,
-        database,
-        director::Director,
         storage::{ImageStore, ImageStoreConfig},
     };
 
     /// Create a test AppState with temporary directory and sample boot files
     async fn create_test_state() -> (Arc<AppState>, TempDir) {
         let temp_dir = TempDir::new().unwrap();
-
-        // Create database
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Create boot files directory with test files
         let boot_files_dir = temp_dir.path().join("boot");
@@ -138,13 +132,19 @@ mod tests {
         })
         .unwrap();
 
+        let db_path = temp_dir.path().join("test.db");
+
+        let connection_factory: Arc<dyn crate::database::ConnectionFactory> = Arc::new(
+            crate::database::DatabaseConnectionFactory::new(db_path.clone()),
+        );
+        // Run migrations; drop the returned connection (file-backed DB persists)
+        let _ = crate::database::run_migrations(connection_factory.as_ref())
+            .await
+            .unwrap();
+
         let state = Arc::new(AppState {
-            director: Director::new(db.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
+            connection_factory,
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
-            roles_store: crate::roles::RolesStore::new(db.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });

--- a/rack-director/src/http/cnc/boot_files.rs
+++ b/rack-director/src/http/cnc/boot_files.rs
@@ -96,8 +96,7 @@ mod tests {
 
         // Create database
         let db_path = temp_dir.path().join("test.db");
-        let db = database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(tokio::sync::Mutex::new(db));
+        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Create boot files directory with test files
         let boot_files_dir = temp_dir.path().join("boot");
@@ -140,12 +139,12 @@ mod tests {
         .unwrap();
 
         let state = Arc::new(AppState {
-            director: Director::new(db_tokio.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db_tokio.clone()),
+            director: Director::new(db.clone()),
+            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db_tokio.clone()),
-            roles_store: crate::roles::RolesStore::new(db_tokio.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db_tokio),
+            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
+            roles_store: crate::roles::RolesStore::new(db.clone()),
+            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });

--- a/rack-director/src/http/cnc/device_registration.rs
+++ b/rack-director/src/http/cnc/device_registration.rs
@@ -1,6 +1,6 @@
-use crate::http::AppState;
+use crate::{database::Connection, dhcp, director::Director};
 use log::warn;
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
 use uuid::Uuid;
 
 /// Resolves the MAC address for a device from query parameter or DHCP lookup.
@@ -10,7 +10,7 @@ use uuid::Uuid;
 /// 2. By looking up the client IP address in DHCP leases (fallback for older clients)
 ///
 /// # Arguments
-/// * `state` - Application state containing DHCP store
+/// * `conn` - Database connection
 /// * `mac_param` - Optional MAC address from query parameter
 /// * `client_addr` - Client socket address (IP + port)
 ///
@@ -18,7 +18,7 @@ use uuid::Uuid;
 /// * `Some(String)` - MAC address if found via parameter or DHCP lookup
 /// * `None` - If MAC cannot be determined
 pub async fn resolve_mac_address(
-    state: &Arc<AppState>,
+    conn: &Connection,
     mac_param: Option<&String>,
     client_addr: SocketAddr,
 ) -> Option<String> {
@@ -27,7 +27,7 @@ pub async fn resolve_mac_address(
         _ => {
             // Fallback: Look up MAC address from client IP (may not work in all network setups)
             let client_ip = client_addr.ip().to_string();
-            if let Ok(leases) = state.dhcp_store.get_all_leases().await {
+            if let Ok(leases) = dhcp::store::get_all_leases(conn).await {
                 leases
                     .iter()
                     .find(|l| l.ip_address == client_ip)
@@ -50,17 +50,19 @@ pub async fn resolve_mac_address(
 /// All errors are logged but not propagated, making registration best-effort.
 ///
 /// # Arguments
-/// * `state` - Application state containing director
+/// * `conn` - Database connection
 /// * `device_uuid` - UUID of the device to register
 /// * `mac_address` - Optional MAC address to link with pending devices
 pub async fn register_and_start_discovery(
-    state: &Arc<AppState>,
+    conn: &Connection,
     device_uuid: &Uuid,
     mac_address: Option<&String>,
 ) {
+    let director = Director::new(conn);
+
     // Check for pending device
     if let Some(mac) = mac_address
-        && let Ok(Some(_)) = state.director.find_pending_device_by_mac(mac).await
+        && let Ok(Some(_)) = director.find_pending_device_by_mac(mac).await
     {
         log::info!(
             "Completing pending device for MAC {} with UUID {}",
@@ -70,8 +72,7 @@ pub async fn register_and_start_discovery(
     }
 
     // Register device
-    if let Err(e) = state
-        .director
+    if let Err(e) = director
         .register_device(device_uuid, crate::operating_systems::Architecture::X86_64)
         .await
     {
@@ -81,35 +82,30 @@ pub async fn register_and_start_discovery(
 
     // Complete pending device link
     if let Some(mac) = mac_address
-        && let Err(e) = state
-            .director
-            .complete_pending_device(mac, device_uuid)
-            .await
+        && let Err(e) = director.complete_pending_device(mac, device_uuid).await
     {
         warn!("Couldn't complete pending device: {}", e);
     }
 
     // Create static DHCP reservation from active lease
     if let Some(mac) = mac_address
-        && let Ok(Some(lease)) = state.dhcp_store.get_lease_by_mac(mac).await
+        && let Ok(Some(lease)) = dhcp::store::get_lease_by_mac(conn, mac).await
         && let Some(network_id) = lease.network_id
     {
-        let hostname = state
-            .director
+        let hostname = director
             .get_device(device_uuid)
             .await
             .ok()
             .and_then(|d| d.attributes.hostname);
 
-        if let Err(e) = state
-            .dhcp_store
-            .create_or_update_static_reservation(
-                network_id,
-                mac,
-                &lease.ip_address,
-                hostname.as_deref(),
-            )
-            .await
+        if let Err(e) = dhcp::store::create_or_update_static_reservation(
+            conn,
+            network_id,
+            mac,
+            &lease.ip_address,
+            hostname.as_deref(),
+        )
+        .await
         {
             warn!(
                 "Couldn't create static DHCP reservation for device {}: {}",
@@ -119,8 +115,7 @@ pub async fn register_and_start_discovery(
     }
 
     // Automatically start discovery transition for newly registered devices
-    if let Err(e) = state
-        .director
+    if let Err(e) = director
         .start_lifecycle_transition(
             device_uuid,
             crate::lifecycle::DeviceLifecycle::Unprovisioned,
@@ -137,71 +132,36 @@ pub async fn register_and_start_discovery(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
-    use crate::storage::ImageStore;
+    use crate::test_database_path;
+    use std::net::Ipv4Addr;
     use uuid::Uuid;
 
     fn test_uuid() -> Uuid {
         Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap()
     }
-    use crate::director::Director;
-    use std::net::Ipv4Addr;
-    use std::sync::Arc;
-    use tempfile::tempdir;
 
-    async fn create_test_state() -> (Arc<AppState>, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-
-        // Note: No default network is created. Tests that need networks should create them explicitly.
-
-        let _storage_path = temp_dir.path().join("images");
-        let image_store = ImageStore::memory("http://localhost:8080");
-
-        let agent_images_path = temp_dir.path().join("agent-image");
-        std::fs::create_dir_all(&agent_images_path).unwrap();
-
-        // Create boot files directory for testing
-        let boot_files_path = temp_dir.path().join("boot");
-        std::fs::create_dir_all(&boot_files_path).unwrap();
-
-        let boot_file_provider =
-            Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
-
-        let state = Arc::new(AppState {
-            director: Director::new(db.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
-            image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
-            roles_store: crate::roles::RolesStore::new(db.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db),
-            agent_images_path,
-            boot_file_provider,
-        });
-
-        (state, temp_dir)
+    async fn create_test_conn(path: String) -> Connection {
+        let factory =
+            crate::database::DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        crate::database::run_migrations(&factory).await.unwrap()
     }
 
-    /// Helper to create a test network for tests that need DHCP functionality
-    async fn create_test_network(state: &AppState) -> i64 {
-        let network = state
-            .dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+    /// Helper to create a test network for tests that need DHCP functionality.
+    async fn create_test_network(conn: &Connection) -> i64 {
+        let network = dhcp::store::create_network(
+            conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
-        state
-            .dhcp_store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        dhcp::store::create_pool(conn, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
@@ -210,71 +170,71 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_mac_address_from_parameter() {
-        let (state, _temp_dir) = create_test_state().await;
+        let conn = create_test_conn(test_database_path!()).await;
         let mac = "aa:bb:cc:dd:ee:ff".to_string();
         let addr = "127.0.0.1:1234".parse().unwrap();
 
-        let result = resolve_mac_address(&state, Some(&mac), addr).await;
+        let result = resolve_mac_address(&conn, Some(&mac), addr).await;
         assert_eq!(result, Some(mac));
     }
 
     #[tokio::test]
     async fn test_resolve_mac_address_empty_parameter() {
-        let (state, _temp_dir) = create_test_state().await;
+        let conn = create_test_conn(test_database_path!()).await;
         let empty_mac = "".to_string();
         let addr = "127.0.0.1:1234".parse().unwrap();
 
-        let result = resolve_mac_address(&state, Some(&empty_mac), addr).await;
+        let result = resolve_mac_address(&conn, Some(&empty_mac), addr).await;
         // Should attempt DHCP lookup, which will return None with no leases
         assert_eq!(result, None);
     }
 
     #[tokio::test]
     async fn test_resolve_mac_address_from_dhcp() {
-        let (state, _temp_dir) = create_test_state().await;
-        let network_id = create_test_network(&state).await;
+        let conn = create_test_conn(test_database_path!()).await;
+        let network_id = create_test_network(&conn).await;
         let mac = "aa:bb:cc:dd:ee:ff";
         let ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
 
-        // Create a DHCP lease
-        state
-            .dhcp_store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip,
-                None,
-                crate::dhcp::LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &ip,
+            None,
+            crate::dhcp::LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         let addr: SocketAddr = format!("{}:1234", ip).parse().unwrap();
-        let result = resolve_mac_address(&state, None, addr).await;
+        let result = resolve_mac_address(&conn, None, addr).await;
         assert_eq!(result, Some(mac.to_string()));
     }
 
     #[tokio::test]
     async fn test_register_and_start_discovery() {
-        let (state, _temp_dir) = create_test_state().await;
+        let conn = create_test_conn(test_database_path!()).await;
         let uuid = test_uuid();
 
         // Verify device doesn't exist
-        assert!(!state.director.device_exists(&uuid).await.unwrap());
+        assert!(!Director::new(&conn).device_exists(&uuid).await.unwrap());
 
-        register_and_start_discovery(&state, &uuid, None).await;
+        register_and_start_discovery(&conn, &uuid, None).await;
 
         // Verify device was registered
-        assert!(state.director.device_exists(&uuid).await.unwrap());
+        assert!(Director::new(&conn).device_exists(&uuid).await.unwrap());
 
         // Verify lifecycle was started (device should be in New state)
-        let lifecycle = state.director.get_device_lifecycle(&uuid).await.unwrap();
+        let lifecycle = Director::new(&conn)
+            .get_device_lifecycle(&uuid)
+            .await
+            .unwrap();
         assert_eq!(lifecycle, Some(crate::lifecycle::DeviceLifecycle::New));
 
         // Verify discovery plan was created
-        let plan = state
-            .director
+        let plan = Director::new(&conn)
             .get_active_plan_for_device(&uuid)
             .await
             .unwrap();
@@ -283,34 +243,31 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_and_start_discovery_with_pending_device() {
-        let (state, _temp_dir) = create_test_state().await;
-        let network_id = create_test_network(&state).await;
+        let conn = create_test_conn(test_database_path!()).await;
+        let network_id = create_test_network(&conn).await;
         let uuid = test_uuid();
         let mac = "aa:bb:cc:dd:ee:ff".to_string();
 
         // Create pending device
-        state
-            .director
+        Director::new(&conn)
             .create_pending_device(&mac, network_id)
             .await
             .unwrap();
 
         // Verify pending device exists
-        let pending = state
-            .director
+        let pending = Director::new(&conn)
             .find_pending_device_by_mac(&mac)
             .await
             .unwrap();
         assert!(pending.is_some());
 
-        register_and_start_discovery(&state, &uuid, Some(&mac)).await;
+        register_and_start_discovery(&conn, &uuid, Some(&mac)).await;
 
         // Verify device was registered
-        assert!(state.director.device_exists(&uuid).await.unwrap());
+        assert!(Director::new(&conn).device_exists(&uuid).await.unwrap());
 
         // Verify pending device was completed (removed)
-        let pending = state
-            .director
+        let pending = Director::new(&conn)
             .find_pending_device_by_mac(&mac)
             .await
             .unwrap();
@@ -319,34 +276,30 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_and_start_discovery_creates_static_reservation() {
-        let (state, _temp_dir) = create_test_state().await;
-        let network_id = create_test_network(&state).await;
+        let conn = create_test_conn(test_database_path!()).await;
+        let network_id = create_test_network(&conn).await;
         let uuid = test_uuid();
         let mac = "aa:bb:cc:dd:ee:11".to_string();
 
         // Create a DHCP lease for this MAC (without device_uuid initially)
-        use std::net::Ipv4Addr;
         let ip: Ipv4Addr = "10.0.0.150".parse().unwrap();
-        state
-            .dhcp_store
-            .create_or_update_lease_with_network(
-                &mac,
-                &ip,
-                None, // Device doesn't exist yet
-                crate::dhcp::LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_or_update_lease_with_network(
+            &conn,
+            &mac,
+            &ip,
+            None, // Device doesn't exist yet
+            crate::dhcp::LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Register device - this should create a static reservation
-        register_and_start_discovery(&state, &uuid, Some(&mac)).await;
+        register_and_start_discovery(&conn, &uuid, Some(&mac)).await;
 
         // Verify static reservation was created
-        let reservation = state
-            .dhcp_store
-            .get_static_reservation(network_id, &mac)
+        let reservation = dhcp::store::get_static_reservation(&conn, network_id, &mac)
             .await
             .unwrap();
         assert!(reservation.is_some());
@@ -356,7 +309,7 @@ mod tests {
         assert_eq!(r.network_id, network_id);
 
         // Verify hostname is included
-        let device = state.director.get_device(&uuid).await.unwrap();
+        let device = Director::new(&conn).get_device(&uuid).await.unwrap();
         assert_eq!(r.hostname, device.attributes.hostname);
     }
 }

--- a/rack-director/src/http/cnc/device_registration.rs
+++ b/rack-director/src/http/cnc/device_registration.rs
@@ -148,13 +148,11 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
 
     async fn create_test_state() -> (Arc<AppState>, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(Mutex::new(db));
+        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Note: No default network is created. Tests that need networks should create them explicitly.
 
@@ -172,12 +170,12 @@ mod tests {
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
         let state = Arc::new(AppState {
-            director: Director::new(db_tokio.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db_tokio.clone()),
+            director: Director::new(db.clone()),
+            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db_tokio.clone()),
-            roles_store: crate::roles::RolesStore::new(db_tokio.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db_tokio),
+            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
+            roles_store: crate::roles::RolesStore::new(db.clone()),
+            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });

--- a/rack-director/src/http/cnc/install_script.rs
+++ b/rack-director/src/http/cnc/install_script.rs
@@ -1,5 +1,6 @@
-use crate::http::{AppState, error::Error};
+use crate::http::error::Error;
 use crate::templates;
+use crate::{database, dhcp, director::Director, operating_systems, roles};
 use anyhow::anyhow;
 use axum::{
     http::{StatusCode, header},
@@ -7,7 +8,6 @@ use axum::{
 };
 use common::Ipv4Subnet;
 use futures::TryStreamExt;
-use std::sync::Arc;
 use uuid::Uuid;
 
 /// Renders an install script template for a specific device.
@@ -20,34 +20,33 @@ use uuid::Uuid;
 /// 5. Renders the template with device context
 ///
 /// # Arguments
-/// * `state` - Application state containing stores for devices, roles, OS, and images
+/// * `conn` - An open database connection
+/// * `image_store` - Image store for downloading script templates
 /// * `device_uuid` - UUID of the device requesting the install script
 ///
 /// # Returns
 /// * `Ok(Response)` - HTTP response containing the rendered install script
 /// * `Err(Error)` - Error if device not found, missing role, template issues, etc.
 pub async fn render_for_device(
-    state: &Arc<AppState>,
+    conn: &database::Connection,
+    image_store: &crate::storage::ImageStore,
     device_uuid: &Uuid,
 ) -> Result<Response<String>, Error> {
+    let director = Director::new(conn);
+
     // Get device
-    let device = state
-        .director
+    let device = director
         .get_device(device_uuid)
         .await
         .map_err(Error::ServerInternalError)?;
 
     // Get device role
-    let role_id = state
-        .director
-        .get_device_role_id(device_uuid)
+    let role_id = crate::director::store::get_device_role_id(conn, device_uuid)
         .await
         .map_err(Error::ServerInternalError)?
         .ok_or_else(|| Error::NotFound("Device has no role assigned".to_string()))?;
 
-    let role = state
-        .roles_store
-        .get(role_id)
+    let role = roles::store::get(conn, role_id)
         .await
         .map_err(Error::ServerInternalError)?;
 
@@ -55,16 +54,12 @@ pub async fn render_for_device(
     let arch = device.architecture;
 
     // Get OS architecture configuration
-    let os_arch = state
-        .os_store
-        .get_architecture(role.os_id, arch)
+    let os_arch = operating_systems::store::get_architecture(conn, role.os_id, arch)
         .await
         .map_err(|e| Error::NotFound(format!("OS architecture not found: {}", e)))?;
 
     // Get OS
-    let os = state
-        .os_store
-        .get(role.os_id)
+    let os = operating_systems::store::get(conn, role.os_id)
         .await
         .map_err(Error::ServerInternalError)?;
 
@@ -74,13 +69,9 @@ pub async fn render_for_device(
         .ok_or_else(|| Error::NotFound("No install script for this OS architecture".to_string()))?;
 
     // Download install script template from storage
-    let stream = state
-        .image_store
-        .download(&script_path)
-        .await
-        .map_err(|e| {
-            Error::ServerInternalError(anyhow::anyhow!("Failed to download script: {}", e))
-        })?;
+    let stream = image_store.download(&script_path).await.map_err(|e| {
+        Error::ServerInternalError(anyhow::anyhow!("Failed to download script: {}", e))
+    })?;
 
     // Collect stream into bytes (install scripts are small text files)
     let script_bytes = stream
@@ -99,7 +90,7 @@ pub async fn render_for_device(
     })?;
 
     // Get device network info
-    let network_info = get_device_network_info(state, device_uuid).await?;
+    let network_info = get_device_network_info_with_db(conn, device_uuid).await?;
 
     // Get device attributes
     let hostname = device.attributes.hostname.clone();
@@ -123,33 +114,19 @@ pub async fn render_for_device(
         .expect("response building should never error"))
 }
 
-/// Retrieves network configuration information for a device from its DHCP lease.
-///
-/// Looks up the device's active DHCP lease and constructs network information
-/// including IP address, MAC address, gateway, DNS servers, and netmask.
-///
-/// # Arguments
-/// * `state` - Application state containing DHCP store
-/// * `device_uuid` - UUID of the device to get network info for
-///
-/// # Returns
-/// * `Ok(NetworkInfo)` - Network configuration details
-/// * `Err(Error::NotFound)` - If device has no active DHCP lease
-/// * `Err(Error::ServerInternalError)` - If network lookup fails
-pub async fn get_device_network_info(
-    state: &Arc<AppState>,
+/// Inner implementation that accepts an already-opened database connection.
+async fn get_device_network_info_with_db(
+    conn: &database::Connection,
     device_uuid: &Uuid,
 ) -> Result<templates::NetworkInfo, Error> {
     // Try to find device's lease
-    let lease = state
-        .dhcp_store
-        .find_lease_by_device_uuid(device_uuid)
+    let lease = dhcp::store::find_lease_by_device_uuid(conn, device_uuid)
         .await
         .map_err(Error::ServerInternalError)?;
 
     if let Some(lease) = lease {
         // Get DHCP config for gateway and DNS
-        let network = state.dhcp_store.get_network(lease.id).await?;
+        let network = dhcp::store::get_network(conn, lease.id).await?;
         let dns_servers = network.dns_servers;
 
         let subnet: Ipv4Subnet = network.subnet.parse().map_err(anyhow::Error::new)?;
@@ -169,9 +146,10 @@ pub async fn get_device_network_info(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
-    use crate::director::Director;
+    use crate::database::{DatabaseConnectionFactory, run_migrations};
+    use crate::http::AppState;
     use crate::storage::ImageStore;
+    use crate::test_database_path;
     use std::net::Ipv4Addr;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -181,15 +159,22 @@ mod tests {
         Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap()
     }
 
-    async fn create_test_state() -> (Arc<AppState>, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
+    async fn create_test_conn(path: String) -> database::Connection {
+        let factory = DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        run_migrations(&factory).await.unwrap()
+    }
 
-        // Note: No default network is created. Tests that need networks should create them explicitly.
+    async fn create_test_state(
+        factory: DatabaseConnectionFactory,
+    ) -> (Arc<AppState>, tempfile::TempDir, database::Connection) {
+        let conn: Arc<dyn crate::database::ConnectionFactory> = Arc::new(factory);
+        // Run migrations and retain the connection so the in-memory DB persists for the test
+        let migration_conn = run_migrations(conn.as_ref()).await.unwrap();
 
-        let _storage_path = temp_dir.path().join("images");
         let image_store = ImageStore::memory("http://localhost:8080");
+
+        // Create temporary directories needed for agent images and boot files
+        let temp_dir = tempdir().unwrap();
 
         let agent_images_path = temp_dir.path().join("agent-image");
         std::fs::create_dir_all(&agent_images_path).unwrap();
@@ -202,38 +187,31 @@ mod tests {
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
         let state = Arc::new(AppState {
-            director: Director::new(db.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
+            connection_factory: conn,
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
-            roles_store: crate::roles::RolesStore::new(db.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });
 
-        (state, temp_dir)
+        (state, temp_dir, migration_conn)
     }
 
     /// Helper to create a test network for tests that need DHCP functionality
-    async fn create_test_network(state: &AppState) -> i64 {
-        let network = state
-            .dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+    async fn create_test_network(conn: &database::Connection) -> i64 {
+        let network = crate::dhcp::store::create_network(
+            conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
-        state
-            .dhcp_store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        crate::dhcp::store::create_pool(conn, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
@@ -242,16 +220,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_device_network_info_no_lease() {
-        let (state, _temp_dir) = create_test_state().await;
+        let conn = create_test_conn(test_database_path!()).await;
 
         let uuid = test_uuid();
-        state
-            .director
+        Director::new(&conn)
             .register_device(&uuid, crate::operating_systems::Architecture::X86_64)
             .await
             .unwrap();
 
-        let result = get_device_network_info(&state, &uuid).await;
+        let result = get_device_network_info_with_db(&conn, &uuid).await;
         assert!(result.is_err());
         match result {
             Err(Error::NotFound(msg)) => {
@@ -263,34 +240,32 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_device_network_info_with_lease() {
-        let (state, _temp_dir) = create_test_state().await;
-        let network_id = create_test_network(&state).await;
+        let conn = create_test_conn(test_database_path!()).await;
+        let network_id = create_test_network(&conn).await;
 
         let uuid = test_uuid();
         let mac = "aa:bb:cc:dd:ee:ff";
 
-        state
-            .director
+        Director::new(&conn)
             .register_device(&uuid, crate::operating_systems::Architecture::X86_64)
             .await
             .unwrap();
 
         // Create a DHCP lease
         let ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
-        state
-            .dhcp_store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip,
-                Some(&uuid),
-                crate::dhcp::LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        crate::dhcp::store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &ip,
+            Some(&uuid),
+            crate::dhcp::LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
-        let result = get_device_network_info(&state, &uuid).await;
+        let result = get_device_network_info_with_db(&conn, &uuid).await;
         let network_info = match result {
             Ok(info) => info,
             Err(_) => panic!("Expected Ok, got Err"),
@@ -303,16 +278,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_render_for_device_no_role() {
-        let (state, _temp_dir) = create_test_state().await;
+        use crate::test_connection_factory;
+        let (state, _temp_dir, _migration_conn) =
+            create_test_state(test_connection_factory!()).await;
 
         let uuid = test_uuid();
-        state
-            .director
-            .register_device(&uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = state.connection_factory.open().await.unwrap();
+            Director::new(&conn)
+                .register_device(&uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
-        let result = render_for_device(&state, &uuid).await;
+        let conn = state.connection_factory.open().await.unwrap();
+        let result = render_for_device(&conn, &state.image_store, &uuid).await;
         // Should get NotFound error when device has no role
         match result {
             Ok(_) => panic!("Expected error but got Ok"),

--- a/rack-director/src/http/cnc/install_script.rs
+++ b/rack-director/src/http/cnc/install_script.rs
@@ -144,6 +144,7 @@ pub async fn get_device_network_info(
     let lease = state
         .dhcp_store
         .find_lease_by_device_uuid(device_uuid)
+        .await
         .map_err(Error::ServerInternalError)?;
 
     if let Some(lease) = lease {
@@ -174,7 +175,6 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
     use uuid::Uuid;
 
     fn test_uuid() -> Uuid {
@@ -184,8 +184,7 @@ mod tests {
     async fn create_test_state() -> (Arc<AppState>, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(Mutex::new(db));
+        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Note: No default network is created. Tests that need networks should create them explicitly.
 
@@ -203,12 +202,12 @@ mod tests {
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
         let state = Arc::new(AppState {
-            director: Director::new(db_tokio.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db_tokio.clone()),
+            director: Director::new(db.clone()),
+            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db_tokio.clone()),
-            roles_store: crate::roles::RolesStore::new(db_tokio.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db_tokio),
+            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
+            roles_store: crate::roles::RolesStore::new(db.clone()),
+            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });

--- a/rack-director/src/http/cnc/mod.rs
+++ b/rack-director/src/http/cnc/mod.rs
@@ -497,8 +497,7 @@ mod tests {
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(tokio::sync::Mutex::new(db));
+        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Note: No default network is created. Tests that need networks should create them explicitly.
 
@@ -530,12 +529,12 @@ mod tests {
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
         let state = Arc::new(AppState {
-            director: Director::new(db_tokio.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db_tokio.clone()),
+            director: Director::new(db.clone()),
+            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db_tokio.clone()),
-            roles_store: crate::roles::RolesStore::new(db_tokio.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db_tokio),
+            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
+            roles_store: crate::roles::RolesStore::new(db.clone()),
+            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });

--- a/rack-director/src/http/cnc/mod.rs
+++ b/rack-director/src/http/cnc/mod.rs
@@ -22,10 +22,13 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use uuid::Uuid;
 
-use crate::{director::NetworkInterface, http::AppState};
-use common::device_attributes::{BmcConfig, DeviceAttributes};
-
 use crate::http::error::Error;
+use crate::{
+    dhcp,
+    director::{Director, NetworkInterface},
+    http::AppState,
+};
+use common::device_attributes::{BmcConfig, DeviceAttributes};
 
 use ipxe_scripts::{build_response, generate_uuid_redirect};
 
@@ -62,30 +65,32 @@ async fn ipxe_handler(
         None => return Ok(generate_uuid_redirect(&root_url)),
     };
 
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(Error::ServerInternalError)?;
+    let director = Director::new(&conn);
+
     // Resolve MAC address from parameter or DHCP lookup
     let mac_address =
-        device_registration::resolve_mac_address(&state, params.mac.as_ref(), addr).await;
+        device_registration::resolve_mac_address(&conn, params.mac.as_ref(), addr).await;
 
     // Discovery Support
     // For devices that don't exist, determine if the device should be created.
     // TODO: Please make this better.
-    if !state.director.device_exists(&uuid).await?
+    if !director.device_exists(&uuid).await?
         && let Some(mac) = &mac_address
     {
-        if state
-            .director
-            .find_pending_device_by_mac(mac)
-            .await?
-            .is_some()
-        {
+        if director.find_pending_device_by_mac(mac).await?.is_some() {
             info!("Found pending device {}. Starting discovery.", uuid);
-            device_registration::register_and_start_discovery(&state, &uuid, Some(mac)).await;
+            device_registration::register_and_start_discovery(&conn, &uuid, Some(mac)).await;
         } else {
             // Device is not pending. Check to see if the network has autodiscovery enabled.
-            let dhcp_lease = state.dhcp_store.get_lease_by_mac(mac).await?;
+            let dhcp_lease = dhcp::store::get_lease_by_mac(&conn, mac).await?;
             if let Some(lease) = dhcp_lease {
                 if let Some(netid) = lease.network_id {
-                    let dhcp_network = state.dhcp_store.get_network(netid).await?;
+                    let dhcp_network = dhcp::store::get_network(&conn, netid).await?;
 
                     // Register device if it doesn't exist and automatically start discovery
                     if dhcp_network.enable_autodiscovery {
@@ -93,7 +98,7 @@ async fn ipxe_handler(
                             "Found new device {} on network with autodiscovery enabled. Adopting and starting discovery.",
                             uuid
                         );
-                        device_registration::register_and_start_discovery(&state, &uuid, Some(mac))
+                        device_registration::register_and_start_discovery(&conn, &uuid, Some(mac))
                             .await;
                     }
                 } else {
@@ -109,13 +114,13 @@ async fn ipxe_handler(
 
     // Handle boot event - advance plan if current action supports it
     // This must happen before we check the boot target, because on_boot() might advance the plan
-    if let Err(e) = state.director.on_boot(&uuid).await {
+    if let Err(e) = director.on_boot(&uuid).await {
         log::warn!("Failed to handle boot event for {}: {:?}", uuid, e);
     }
 
     // Store network info from DHCP lease (reuse the MAC address lookup from above)
     if let Some(mac) = &mac_address {
-        if let Ok(Some(lease)) = state.dhcp_store.get_lease_by_mac(mac).await {
+        if let Ok(Some(lease)) = dhcp::store::get_lease_by_mac(&conn, mac).await {
             log::info!(
                 "Found DHCP lease for device {}: MAC {} IP {}",
                 uuid,
@@ -125,8 +130,7 @@ async fn ipxe_handler(
 
             // Update IP address for the interface with this MAC
             // This will also create the interface if it doesn't exist yet
-            if let Err(e) = state
-                .director
+            if let Err(e) = director
                 .set_device_ip_address(&uuid, &lease.ip_address, &lease.mac_address)
                 .await
             {
@@ -134,8 +138,7 @@ async fn ipxe_handler(
             }
 
             // Update legacy MAC address field for backward compatibility
-            if let Err(e) = state
-                .director
+            if let Err(e) = director
                 .set_device_mac_address(&uuid, &lease.mac_address)
                 .await
             {
@@ -147,7 +150,7 @@ async fn ipxe_handler(
     }
 
     // Non-fatal. If the boot target can't be found, redirect loop back here to try again
-    let boot_target = match state.director.next_boot_target(&uuid).await {
+    let boot_target = match director.next_boot_target(&uuid).await {
         Ok(x) => x,
         Err(e) => {
             warn!("Couldn't get boot target from director for {uuid}: {e}");
@@ -172,7 +175,13 @@ async fn install_script_handler(
         .uuid
         .ok_or_else(|| Error::BadRequest("Missing uuid parameter".to_string()))?;
 
-    install_script::render_for_device(&state, &uuid).await
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(Error::ServerInternalError)?;
+
+    install_script::render_for_device(&conn, &state.image_store, &uuid).await
 }
 
 async fn agent_images_handler(
@@ -246,12 +255,14 @@ async fn update_attributes(
         }
     };
 
+    let conn = match state.connection_factory.open().await {
+        Ok(conn) => conn,
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    let director = Director::new(&conn);
+
     // Store the attributes as provided by the agent
-    if let Err(e) = state
-        .director
-        .update_attributes(&uuid, attributes_json)
-        .await
-    {
+    if let Err(e) = director.update_attributes(&uuid, attributes_json).await {
         warn!("Couldn't update attributes for {uuid}: {e}");
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     }
@@ -275,16 +286,15 @@ async fn update_attributes(
 
         // Enrich interfaces with DHCP lease information
         let mut enriched_interfaces =
-            network_processing::enrich_interfaces_with_dhcp_info(&state, interfaces).await;
+            network_processing::enrich_interfaces_with_dhcp_info(&conn, interfaces).await;
 
         // Detect and mark duplicate MACs on the same network
-        network_processing::detect_and_mark_duplicates(&state, &uuid, &mut enriched_interfaces)
+        network_processing::detect_and_mark_duplicates(&conn, &uuid, &mut enriched_interfaces)
             .await;
 
         // Update the device with IP-enriched network interfaces
         if !enriched_interfaces.is_empty()
-            && let Err(e) = state
-                .director
+            && let Err(e) = director
                 .set_network_interfaces(&uuid, &enriched_interfaces)
                 .await
         {
@@ -296,7 +306,7 @@ async fn update_attributes(
 
         // Complete any pending devices whose MACs match the device's interfaces
         network_processing::complete_pending_devices_for_interfaces(
-            &state,
+            &conn,
             &uuid,
             &enriched_interfaces,
         )
@@ -324,7 +334,13 @@ async fn action_success(
 ) -> Result<NoContent, StatusCode> {
     let uuid = payload.uuid;
 
-    match state.director.mark_action_success(&uuid).await {
+    let conn = match state.connection_factory.open().await {
+        Ok(conn) => conn,
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    let director = Director::new(&conn);
+
+    match director.mark_action_success(&uuid).await {
         Ok(_) => Ok(NoContent),
         Err(e) => {
             warn!("Couldn't mark action success for {uuid}: {e}");
@@ -341,11 +357,13 @@ async fn action_failed(
     let uuid = payload.uuid;
     let error_message = payload.error_message;
 
-    match state
-        .director
-        .mark_action_failed(&uuid, &error_message)
-        .await
-    {
+    let conn = match state.connection_factory.open().await {
+        Ok(conn) => conn,
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    let director = Director::new(&conn);
+
+    match director.mark_action_failed(&uuid, &error_message).await {
         Ok(_) => Ok(NoContent),
         Err(e) => {
             warn!("Couldn't mark action failed for {uuid}: {e}");
@@ -384,8 +402,14 @@ async fn get_bmc_config(
     State(state): State<Arc<AppState>>,
     extract::Path(uuid): extract::Path<Uuid>,
 ) -> Result<extract::Json<BmcConfig>, StatusCode> {
+    let conn = match state.connection_factory.open().await {
+        Ok(conn) => conn,
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    let director = Director::new(&conn);
+
     // Get device
-    let mut device = match state.director.get_device(&uuid).await {
+    let mut device = match director.get_device(&uuid).await {
         Ok(device) => device,
         Err(e) => {
             warn!("Failed to get device {}: {}", uuid, e);
@@ -433,11 +457,7 @@ async fn get_bmc_config(
             }
         };
 
-        if let Err(e) = state
-            .director
-            .update_attributes(&uuid, attributes_json)
-            .await
-        {
+        if let Err(e) = director.update_attributes(&uuid, attributes_json).await {
             warn!("Failed to save BMC config for device {}: {}", uuid, e);
             return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
@@ -463,7 +483,7 @@ async fn get_bmc_config(
 
 #[cfg(test)]
 mod tests {
-    use crate::{database, director::Director, storage::ImageStore};
+    use crate::{director::Director, storage::ImageStore};
 
     use super::*;
     use axum::{
@@ -497,12 +517,10 @@ mod tests {
 
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Note: No default network is created. Tests that need networks should create them explicitly.
 
         // Create image store for testing
-        let _storage_path = temp_dir.path().join("images");
         let image_store = ImageStore::memory("http://localhost:8080");
 
         // Create agent-image directory with mock files for testing
@@ -528,38 +546,47 @@ mod tests {
         let boot_file_provider =
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
+        let conn: Arc<dyn crate::database::ConnectionFactory> = Arc::new(
+            crate::database::DatabaseConnectionFactory::new(db_path.clone()),
+        );
+        // Run migrations; drop the returned connection (file-backed DB persists)
+        let _ = crate::database::run_migrations(conn.as_ref())
+            .await
+            .unwrap();
+
         let state = Arc::new(AppState {
-            director: Director::new(db.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
+            connection_factory: conn,
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
-            roles_store: crate::roles::RolesStore::new(db.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });
         (state, temp_dir)
     }
 
+    /// Open a database connection for test assertions.
+    ///
+    /// Usage: `let db = test_db(&state).await; let director = Director::new(&db);`
+    async fn test_db(state: &AppState) -> crate::database::Connection {
+        state.connection_factory.open().await.unwrap()
+    }
+
     /// Helper to create a test network for tests that need DHCP functionality
     async fn create_test_network(state: &AppState, autodiscovery: bool) -> i64 {
-        let network = state
-            .dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                autodiscovery,
-            )
-            .await
-            .unwrap();
+        let conn = Arc::new(state.connection_factory.open().await.unwrap());
+        let network = crate::dhcp::store::create_network(
+            &conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            autodiscovery,
+        )
+        .await
+        .unwrap();
 
-        state
-            .dhcp_store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        crate::dhcp::store::create_pool(&conn, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
@@ -599,8 +626,8 @@ mod tests {
         let uuid = test_uuid(1);
 
         {
-            state
-                .director
+            let conn = test_db(&state).await;
+            Director::new(&conn)
                 .register_device(&uuid, crate::operating_systems::Architecture::X86_64)
                 .await
                 .unwrap();
@@ -675,18 +702,22 @@ mod tests {
         let test_mac = &test_mac(0x00);
 
         // Create a pending device for this MAC
-        state
-            .director
-            .create_pending_device(test_mac, network_id)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .create_pending_device(test_mac, network_id)
+                .await
+                .unwrap();
+        }
 
         // Verify pending device exists
-        let pending_id = state
-            .director
-            .find_pending_device_by_mac(test_mac)
-            .await
-            .unwrap();
+        let pending_id = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .find_pending_device_by_mac(test_mac)
+                .await
+                .unwrap()
+        };
         assert!(pending_id.is_some());
 
         let app = routes(state.clone()).layer(axum::extract::connect_info::MockConnectInfo(
@@ -704,14 +735,22 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         // Device should be registered
-        assert!(state.director.device_exists(&test_uuid).await.unwrap());
+        assert!({
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .device_exists(&test_uuid)
+                .await
+                .unwrap()
+        });
 
         // Pending device should be completed (removed from pending_devices table)
-        let pending_id = state
-            .director
-            .find_pending_device_by_mac(test_mac)
-            .await
-            .unwrap();
+        let pending_id = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .find_pending_device_by_mac(test_mac)
+                .await
+                .unwrap()
+        };
         assert!(pending_id.is_none(), "Pending device should be completed");
     }
 
@@ -725,12 +764,15 @@ mod tests {
         let plan = crate::plans::Plan::new(test_uuid, actions);
 
         // Register device and create plan
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
-        state.director.create_plan(&plan).await.unwrap();
+        {
+            let conn = test_db(&state).await;
+            let director = Director::new(&conn);
+            director
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+            director.create_plan(&plan).await.unwrap();
+        }
 
         let app = routes(state).layer(axum::extract::connect_info::MockConnectInfo(
             "127.0.0.1:1234".parse::<SocketAddr>().unwrap(),
@@ -759,12 +801,15 @@ mod tests {
         let plan = crate::plans::Plan::new(test_uuid, actions);
 
         // Register device and create plan
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
-        state.director.create_plan(&plan).await.unwrap();
+        {
+            let conn = test_db(&state).await;
+            let director = Director::new(&conn);
+            director
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+            director.create_plan(&plan).await.unwrap();
+        }
 
         let app = routes(state).layer(axum::extract::connect_info::MockConnectInfo(
             "127.0.0.1:1234".parse::<SocketAddr>().unwrap(),
@@ -792,11 +837,13 @@ mod tests {
         let test_uuid = test_uuid(0x05);
 
         // Register device but don't create a plan
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state).layer(axum::extract::connect_info::MockConnectInfo(
             "127.0.0.1:1234".parse::<SocketAddr>().unwrap(),
@@ -821,9 +868,10 @@ mod tests {
         let network_id = create_test_network(&state, true).await;
         let test_uuid = test_uuid(0x99);
         let test_mac = test_mac(0x00);
-        state
-            .dhcp_store
-            .create_or_update_lease_with_network(
+        {
+            let conn = Arc::new(state.connection_factory.open().await.unwrap());
+            crate::dhcp::store::create_or_update_lease_with_network(
+                &conn,
                 &test_mac,
                 &Ipv4Addr::UNSPECIFIED,
                 None,
@@ -833,9 +881,16 @@ mod tests {
             )
             .await
             .unwrap();
+        }
 
         // Verify device doesn't exist yet
-        assert!(!state.director.device_exists(&test_uuid).await.unwrap());
+        assert!({
+            let conn = test_db(&state).await;
+            !Director::new(&conn)
+                .device_exists(&test_uuid)
+                .await
+                .unwrap()
+        });
 
         let app = routes(state.clone()).layer(axum::extract::connect_info::MockConnectInfo(
             "127.0.0.1:1234".parse::<SocketAddr>().unwrap(),
@@ -852,22 +907,32 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         // Device should now exist
-        assert!(state.director.device_exists(&test_uuid).await.unwrap());
+        assert!({
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .device_exists(&test_uuid)
+                .await
+                .unwrap()
+        });
 
         // Device should be in "new" state
-        let lifecycle = state
-            .director
-            .get_device_lifecycle(&test_uuid)
-            .await
-            .unwrap();
+        let lifecycle = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .get_device_lifecycle(&test_uuid)
+                .await
+                .unwrap()
+        };
         assert_eq!(lifecycle, Some(crate::lifecycle::DeviceLifecycle::New));
 
         // Device should have an active discovery plan with 2 actions
-        let active_plan = state
-            .director
-            .get_active_plan_for_device(&test_uuid)
-            .await
-            .unwrap();
+        let active_plan = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .get_active_plan_for_device(&test_uuid)
+                .await
+                .unwrap()
+        };
         assert!(active_plan.is_some());
         let plan = active_plan.unwrap();
         assert_eq!(plan.actions.len(), 2);
@@ -904,20 +969,21 @@ mod tests {
         let test_uuid = test_uuid(0x98);
 
         // Register device and start discovery transition
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
-
-        state
-            .director
-            .start_lifecycle_transition(
-                &test_uuid,
-                crate::lifecycle::DeviceLifecycle::Unprovisioned,
-            )
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            let director = Director::new(&conn);
+            director
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+            director
+                .start_lifecycle_transition(
+                    &test_uuid,
+                    crate::lifecycle::DeviceLifecycle::Unprovisioned,
+                )
+                .await
+                .unwrap();
+        }
 
         // Simulate agent updating attributes
         let update_payload = UpdateAttributesQuery {
@@ -944,7 +1010,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify attributes were updated
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         assert_eq!(
             device.attributes.manufacturer.as_ref().unwrap(),
             "Dell Inc."
@@ -968,11 +1037,13 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify device is still in New state (configure_bmc action still pending)
-        let lifecycle = state
-            .director
-            .get_device_lifecycle(&test_uuid)
-            .await
-            .unwrap();
+        let lifecycle = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .get_device_lifecycle(&test_uuid)
+                .await
+                .unwrap()
+        };
         assert_eq!(lifecycle, Some(crate::lifecycle::DeviceLifecycle::New));
 
         // Simulate agent reporting success for second action (configure_bmc)
@@ -987,22 +1058,26 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify device transitioned to Unprovisioned after both actions complete
-        let lifecycle = state
-            .director
-            .get_device_lifecycle(&test_uuid)
-            .await
-            .unwrap();
+        let lifecycle = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .get_device_lifecycle(&test_uuid)
+                .await
+                .unwrap()
+        };
         assert_eq!(
             lifecycle,
             Some(crate::lifecycle::DeviceLifecycle::Unprovisioned)
         );
 
         // Verify no active plan
-        let active_plan = state
-            .director
-            .get_active_plan_for_device(&test_uuid)
-            .await
-            .unwrap();
+        let active_plan = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .get_active_plan_for_device(&test_uuid)
+                .await
+                .unwrap()
+        };
         assert!(active_plan.is_none());
     }
 
@@ -1103,26 +1178,28 @@ mod tests {
         let test_uuid = test_uuid(0x60);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            let director = Director::new(&conn);
+            director
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
 
-        // Set BMC config without credentials
-        let mut attributes = serde_json::Map::new();
-        attributes.insert(
-            "bmc_config".to_string(),
-            serde_json::json!({
-                "ip_address_source": "dhcp"
-            }),
-        );
+            // Set BMC config without credentials
+            let mut attributes = serde_json::Map::new();
+            attributes.insert(
+                "bmc_config".to_string(),
+                serde_json::json!({
+                    "ip_address_source": "dhcp"
+                }),
+            );
 
-        state
-            .director
-            .update_attributes(&test_uuid, attributes)
-            .await
-            .unwrap();
+            director
+                .update_attributes(&test_uuid, attributes)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1148,7 +1225,10 @@ mod tests {
         assert_eq!(bmc_config.password.unwrap().len(), 16);
 
         // Verify credentials were saved to device
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         assert_eq!(
             device.attributes.bmc_config.as_ref().unwrap().username,
             Some("RACKDIRECTOR".to_string())
@@ -1170,31 +1250,33 @@ mod tests {
         let test_uuid = test_uuid(0x61);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            let director = Director::new(&conn);
+            director
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
 
-        // Set BMC config with existing credentials
-        let mut attributes = serde_json::Map::new();
-        attributes.insert(
-            "bmc_config".to_string(),
-            serde_json::json!({
-                "ip_address_source": "static",
-                "ip_address": "10.0.1.100",
-                "netmask": "255.255.255.0",
-                "gateway": "10.0.1.1",
-                "username": "existing_user",
-                "password": "existing_pass"
-            }),
-        );
+            // Set BMC config with existing credentials
+            let mut attributes = serde_json::Map::new();
+            attributes.insert(
+                "bmc_config".to_string(),
+                serde_json::json!({
+                    "ip_address_source": "static",
+                    "ip_address": "10.0.1.100",
+                    "netmask": "255.255.255.0",
+                    "gateway": "10.0.1.1",
+                    "username": "existing_user",
+                    "password": "existing_pass"
+                }),
+            );
 
-        state
-            .director
-            .update_attributes(&test_uuid, attributes)
-            .await
-            .unwrap();
+            director
+                .update_attributes(&test_uuid, attributes)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1225,11 +1307,13 @@ mod tests {
         let test_uuid = test_uuid(0x62);
 
         // Register device without BMC config
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1255,7 +1339,10 @@ mod tests {
         assert!(bmc_config.password.is_some());
 
         // Verify config was saved to device
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         assert!(device.attributes.bmc_config.is_some());
     }
 }

--- a/rack-director/src/http/cnc/network_processing.rs
+++ b/rack-director/src/http/cnc/network_processing.rs
@@ -177,13 +177,11 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
 
     async fn create_test_state() -> (Arc<AppState>, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(Mutex::new(db));
+        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Note: No default network is created. Tests that need networks should create them explicitly.
 
@@ -201,12 +199,12 @@ mod tests {
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
         let state = Arc::new(AppState {
-            director: Director::new(db_tokio.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db_tokio.clone()),
+            director: Director::new(db.clone()),
+            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
             image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db_tokio.clone()),
-            roles_store: crate::roles::RolesStore::new(db_tokio.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db_tokio),
+            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
+            roles_store: crate::roles::RolesStore::new(db.clone()),
+            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });

--- a/rack-director/src/http/cnc/network_processing.rs
+++ b/rack-director/src/http/cnc/network_processing.rs
@@ -1,7 +1,7 @@
+use crate::database::Connection;
 use crate::director::NetworkInterface;
-use crate::http::AppState;
+use crate::{dhcp, director};
 use log::warn;
-use std::sync::Arc;
 use uuid::Uuid;
 
 /// Enriches network interfaces with IP addresses and network IDs from DHCP leases.
@@ -11,21 +11,21 @@ use uuid::Uuid;
 /// This allows us to associate discovered hardware interfaces with their network assignments.
 ///
 /// # Arguments
-/// * `state` - Application state containing DHCP store
+/// * `conn` - An open database connection
 /// * `interfaces` - Vector of NetworkInterface objects to enrich
 ///
 /// # Returns
 /// A new vector of NetworkInterface objects with IP addresses and network IDs populated
 /// from DHCP lease data where available.
 pub async fn enrich_interfaces_with_dhcp_info(
-    state: &Arc<AppState>,
+    conn: &Connection,
     interfaces: Vec<NetworkInterface>,
 ) -> Vec<NetworkInterface> {
     let mut enriched = Vec::new();
 
     for mut nic in interfaces {
         // Look up DHCP lease for this MAC
-        if let Ok(Some(lease)) = state.dhcp_store.get_lease_by_mac(&nic.mac_address).await {
+        if let Ok(Some(lease)) = dhcp::store::get_lease_by_mac(conn, &nic.mac_address).await {
             log::info!(
                 "Backfilling IP {} and network_id {} for NIC {} (MAC {})",
                 lease.ip_address,
@@ -38,15 +38,14 @@ pub async fn enrich_interfaces_with_dhcp_info(
 
             // Create static reservation for this interface
             if let Some(network_id) = lease.network_id
-                && let Err(e) = state
-                    .dhcp_store
-                    .create_or_update_static_reservation(
-                        network_id,
-                        &nic.mac_address,
-                        &lease.ip_address,
-                        None,
-                    )
-                    .await
+                && let Err(e) = dhcp::store::create_or_update_static_reservation(
+                    conn,
+                    network_id,
+                    &nic.mac_address,
+                    &lease.ip_address,
+                    None,
+                )
+                .await
             {
                 log::warn!(
                     "Couldn't create static reservation for MAC {}: {}",
@@ -68,7 +67,7 @@ pub async fn enrich_interfaces_with_dhcp_info(
 /// to prevent network conflicts.
 ///
 /// # Arguments
-/// * `state` - Application state containing director and DHCP store
+/// * `conn` - An open database connection
 /// * `device_uuid` - UUID of the device being checked
 /// * `interfaces` - Mutable reference to interfaces to check and potentially mark as disabled
 ///
@@ -76,21 +75,24 @@ pub async fn enrich_interfaces_with_dhcp_info(
 /// Modifies interfaces in-place, setting `disabled = true` and `warning_label = Some(...)`
 /// for any interface with a duplicate MAC on the same network.
 pub async fn detect_and_mark_duplicates(
-    state: &Arc<AppState>,
+    conn: &Connection,
     device_uuid: &Uuid,
     interfaces: &mut [NetworkInterface],
 ) {
     for nic in interfaces.iter_mut() {
         // Only check for duplicates if the interface has a network_id
         if let Some(network_id) = nic.network_id {
-            match state
-                .director
-                .find_duplicate_macs_on_network(&nic.mac_address, network_id, device_uuid)
-                .await
+            match director::store::find_duplicate_macs_on_network(
+                conn,
+                &nic.mac_address,
+                network_id,
+                device_uuid,
+            )
+            .await
             {
                 Ok(duplicates) if !duplicates.is_empty() => {
                     // Get network name for warning message
-                    let network_name = match state.dhcp_store.get_network(network_id).await {
+                    let network_name = match dhcp::store::get_network(conn, network_id).await {
                         Ok(network) => network.name,
                         Err(_) => format!("network {}", network_id),
                     };
@@ -136,7 +138,7 @@ pub async fn detect_and_mark_duplicates(
 /// registration yet). If a match is found, links the pending device to this device UUID.
 ///
 /// # Arguments
-/// * `state` - Application state containing director
+/// * `conn` - An open database connection
 /// * `device_uuid` - UUID of the device that owns these interfaces
 /// * `interfaces` - Network interfaces to check against pending devices
 ///
@@ -144,15 +146,13 @@ pub async fn detect_and_mark_duplicates(
 /// Completes pending device registration for any matching MAC addresses, linking them
 /// to the provided device UUID.
 pub async fn complete_pending_devices_for_interfaces(
-    state: &Arc<AppState>,
+    conn: &Connection,
     device_uuid: &Uuid,
     interfaces: &[NetworkInterface],
 ) {
     for nic in interfaces {
-        if let Err(e) = state
-            .director
-            .complete_pending_device(&nic.mac_address, device_uuid)
-            .await
+        if let Err(e) =
+            director::store::complete_pending_device(conn, &nic.mac_address, device_uuid).await
         {
             log::debug!(
                 "Could not complete pending device for MAC {}: {}",
@@ -166,71 +166,37 @@ pub async fn complete_pending_devices_for_interfaces(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
-    use crate::storage::ImageStore;
+    use crate::database::{DatabaseConnectionFactory, run_migrations};
+    use crate::director::Director;
+    use crate::test_database_path;
+    use std::net::Ipv4Addr;
     use uuid::Uuid;
 
     fn test_uuid() -> Uuid {
         Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap()
     }
-    use crate::director::Director;
-    use std::net::Ipv4Addr;
-    use std::sync::Arc;
-    use tempfile::tempdir;
 
-    async fn create_test_state() -> (Arc<AppState>, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-
-        // Note: No default network is created. Tests that need networks should create them explicitly.
-
-        let _storage_path = temp_dir.path().join("images");
-        let image_store = ImageStore::memory("http://localhost:8080");
-
-        let agent_images_path = temp_dir.path().join("agent-image");
-        std::fs::create_dir_all(&agent_images_path).unwrap();
-
-        // Create boot files directory for testing
-        let boot_files_path = temp_dir.path().join("boot");
-        std::fs::create_dir_all(&boot_files_path).unwrap();
-
-        let boot_file_provider =
-            Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
-
-        let state = Arc::new(AppState {
-            director: Director::new(db.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
-            image_store: Arc::new(image_store),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
-            roles_store: crate::roles::RolesStore::new(db.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db),
-            agent_images_path,
-            boot_file_provider,
-        });
-
-        (state, temp_dir)
+    async fn create_test_conn(path: String) -> Connection {
+        let factory = DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        run_migrations(&factory).await.unwrap()
     }
 
     /// Helper to create a test network for tests that need DHCP functionality
-    async fn create_test_network(state: &AppState) -> i64 {
-        let network = state
-            .dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+    async fn create_test_network(conn: &Connection) -> i64 {
+        let network = dhcp::store::create_network(
+            conn,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
-        state
-            .dhcp_store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+        dhcp::store::create_pool(conn, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
             .await
             .unwrap();
 
@@ -239,7 +205,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_enrich_interfaces_with_dhcp_info_no_leases() {
-        let (state, _temp_dir) = create_test_state().await;
+        let conn = create_test_conn(test_database_path!()).await;
 
         let interfaces = vec![NetworkInterface {
             interface_name: "eth0".to_string(),
@@ -251,7 +217,7 @@ mod tests {
             warning_label: None,
         }];
 
-        let enriched = enrich_interfaces_with_dhcp_info(&state, interfaces).await;
+        let enriched = enrich_interfaces_with_dhcp_info(&conn, interfaces).await;
 
         assert_eq!(enriched.len(), 1);
         assert_eq!(enriched[0].interface_name, "eth0");
@@ -261,24 +227,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_enrich_interfaces_with_dhcp_info_with_lease() {
-        let (state, _temp_dir) = create_test_state().await;
-        let network_id = create_test_network(&state).await;
+        let conn = create_test_conn(test_database_path!()).await;
+        let network_id = create_test_network(&conn).await;
 
         // Create a DHCP lease
         let mac = "aa:bb:cc:dd:ee:ff";
         let ip: Ipv4Addr = "10.0.0.100".parse().unwrap();
-        state
-            .dhcp_store
-            .create_or_update_lease_with_network(
-                mac,
-                &ip,
-                None,
-                crate::dhcp::LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_or_update_lease_with_network(
+            &conn,
+            mac,
+            &ip,
+            None,
+            crate::dhcp::LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         let interfaces = vec![NetworkInterface {
             interface_name: "eth0".to_string(),
@@ -290,7 +255,7 @@ mod tests {
             warning_label: None,
         }];
 
-        let enriched = enrich_interfaces_with_dhcp_info(&state, interfaces).await;
+        let enriched = enrich_interfaces_with_dhcp_info(&conn, interfaces).await;
 
         assert_eq!(enriched.len(), 1);
         assert_eq!(enriched[0].interface_name, "eth0");
@@ -300,11 +265,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_detect_and_mark_duplicates_no_duplicates() {
-        let (state, _temp_dir) = create_test_state().await;
+        let conn = create_test_conn(test_database_path!()).await;
 
         let uuid = test_uuid();
-        state
-            .director
+        Director::new(&conn)
             .register_device(&uuid, crate::operating_systems::Architecture::X86_64)
             .await
             .unwrap();
@@ -319,7 +283,7 @@ mod tests {
             warning_label: None,
         }];
 
-        detect_and_mark_duplicates(&state, &uuid, &mut interfaces).await;
+        detect_and_mark_duplicates(&conn, &uuid, &mut interfaces).await;
 
         assert!(!interfaces[0].disabled);
         assert_eq!(interfaces[0].warning_label, None);
@@ -327,7 +291,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_complete_pending_devices_for_interfaces_no_pending() {
-        let (state, _temp_dir) = create_test_state().await;
+        let conn = create_test_conn(test_database_path!()).await;
 
         let uuid = test_uuid();
         let interfaces = vec![NetworkInterface {
@@ -341,37 +305,33 @@ mod tests {
         }];
 
         // Should not panic or error
-        complete_pending_devices_for_interfaces(&state, &uuid, &interfaces).await;
+        complete_pending_devices_for_interfaces(&conn, &uuid, &interfaces).await;
     }
 
     #[tokio::test]
     async fn test_complete_pending_devices_for_interfaces_with_pending() {
-        let (state, _temp_dir) = create_test_state().await;
-        let network_id = create_test_network(&state).await;
+        let conn = create_test_conn(test_database_path!()).await;
+        let network_id = create_test_network(&conn).await;
 
         let mac = "aa:bb:cc:dd:ee:ff";
         let uuid = test_uuid();
 
+        let director = Director::new(&conn);
+
         // Register the device first (required due to foreign key constraint)
-        state
-            .director
+        director
             .register_device(&uuid, crate::operating_systems::Architecture::X86_64)
             .await
             .unwrap();
 
         // Create pending device
-        state
-            .director
+        director
             .create_pending_device(mac, network_id)
             .await
             .unwrap();
 
         // Verify it exists
-        let pending = state
-            .director
-            .find_pending_device_by_mac(mac)
-            .await
-            .unwrap();
+        let pending = director.find_pending_device_by_mac(mac).await.unwrap();
         assert!(pending.is_some());
 
         let interfaces = vec![NetworkInterface {
@@ -384,12 +344,10 @@ mod tests {
             warning_label: None,
         }];
 
-        complete_pending_devices_for_interfaces(&state, &uuid, &interfaces).await;
+        complete_pending_devices_for_interfaces(&conn, &uuid, &interfaces).await;
 
         // Verify pending device was completed (removed)
-        let pending = state
-            .director
-            .find_pending_device_by_mac(mac)
+        let pending = director::store::find_pending_device_by_mac(&conn, mac)
             .await
             .unwrap();
         assert!(pending.is_none());
@@ -397,8 +355,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_enrich_interfaces_creates_static_reservations() {
-        let (state, _temp_dir) = create_test_state().await;
-        let network_id = create_test_network(&state).await;
+        let conn = create_test_conn(test_database_path!()).await;
+        let network_id = create_test_network(&conn).await;
 
         // Create DHCP leases for multiple MACs
         let mac1 = "aa:bb:cc:dd:ee:01";
@@ -406,31 +364,29 @@ mod tests {
         let ip1: Ipv4Addr = "10.0.0.101".parse().unwrap();
         let ip2: Ipv4Addr = "10.0.0.102".parse().unwrap();
 
-        state
-            .dhcp_store
-            .create_or_update_lease_with_network(
-                mac1,
-                &ip1,
-                None,
-                crate::dhcp::LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_or_update_lease_with_network(
+            &conn,
+            mac1,
+            &ip1,
+            None,
+            crate::dhcp::LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
-        state
-            .dhcp_store
-            .create_or_update_lease_with_network(
-                mac2,
-                &ip2,
-                None,
-                crate::dhcp::LeaseState::Active,
-                3600,
-                network_id,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_or_update_lease_with_network(
+            &conn,
+            mac2,
+            &ip2,
+            None,
+            crate::dhcp::LeaseState::Active,
+            3600,
+            network_id,
+        )
+        .await
+        .unwrap();
 
         // Create interfaces without IP info
         let interfaces = vec![
@@ -455,7 +411,7 @@ mod tests {
         ];
 
         // Enrich interfaces - should create static reservations
-        let enriched = enrich_interfaces_with_dhcp_info(&state, interfaces).await;
+        let enriched = enrich_interfaces_with_dhcp_info(&conn, interfaces).await;
 
         // Verify interfaces were enriched
         assert_eq!(enriched.len(), 2);
@@ -463,17 +419,13 @@ mod tests {
         assert_eq!(enriched[1].ip_address, Some("10.0.0.102".to_string()));
 
         // Verify static reservations were created
-        let res1 = state
-            .dhcp_store
-            .get_static_reservation(1, mac1)
+        let res1 = dhcp::store::get_static_reservation(&conn, network_id, mac1)
             .await
             .unwrap();
         assert!(res1.is_some());
         assert_eq!(res1.unwrap().ip_address, "10.0.0.101");
 
-        let res2 = state
-            .dhcp_store
-            .get_static_reservation(1, mac2)
+        let res2 = dhcp::store::get_static_reservation(&conn, network_id, mac2)
             .await
             .unwrap();
         assert!(res2.is_some());

--- a/rack-director/src/http/mod.rs
+++ b/rack-director/src/http/mod.rs
@@ -12,20 +12,17 @@ use axum::Router;
 use tokio::task::JoinHandle;
 
 use crate::boot_files::BootFileProvider;
-use crate::dhcp::DhcpStore;
-use crate::director::Director;
-use crate::operating_systems::OperatingSystemsStore;
-use crate::platforms::PlatformsStore;
-use crate::roles::RolesStore;
+use crate::database::ConnectionFactory;
 use crate::storage::ImageStore;
 
+/// Shared application state for all HTTP handlers.
+///
+/// Handlers open a fresh database connection per request via the `db` factory.
+/// This avoids connection sharing across async tasks and ensures each
+/// request has an independent SQLite connection.
 pub struct AppState {
-    pub director: Director,
-    pub dhcp_store: DhcpStore,
+    pub connection_factory: Arc<dyn ConnectionFactory>,
     pub image_store: Arc<ImageStore>,
-    pub os_store: OperatingSystemsStore,
-    pub roles_store: RolesStore,
-    pub platforms_store: PlatformsStore,
     pub agent_images_path: PathBuf,
     pub boot_file_provider: Arc<dyn BootFileProvider>,
 }
@@ -35,25 +32,17 @@ pub struct StartResult {
     pub port: u16,
 }
 
-pub async fn start<T: Into<SocketAddr>, P: Into<PathBuf>>(
-    director: Director,
-    dhcp_store: DhcpStore,
+pub async fn start<T: Into<SocketAddr>>(
+    connection_factory: Arc<dyn ConnectionFactory>,
     image_store: Arc<ImageStore>,
-    os_store: OperatingSystemsStore,
-    roles_store: RolesStore,
-    platforms_store: PlatformsStore,
     bind: T,
-    agent_images_path: P,
+    agent_images_path: PathBuf,
     boot_file_provider: Arc<dyn BootFileProvider>,
 ) -> Result<StartResult> {
     let state = Arc::new(AppState {
-        director,
-        dhcp_store,
+        connection_factory,
         image_store,
-        os_store,
-        roles_store,
-        platforms_store,
-        agent_images_path: agent_images_path.into(),
+        agent_images_path,
         boot_file_provider,
     });
 

--- a/rack-director/src/http/ui/devices.rs
+++ b/rack-director/src/http/ui/devices.rs
@@ -713,8 +713,7 @@ mod tests {
     async fn setup_test_state() -> (Arc<AppState>, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = database::open(&db_path).unwrap();
-        let db_tokio = Arc::new(tokio::sync::Mutex::new(db));
+        let db = Arc::new(database::open(db_path).await.unwrap());
 
         // Note: No default network is created. Tests that need networks should create them explicitly.
 
@@ -743,12 +742,12 @@ mod tests {
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
         let state = Arc::new(AppState {
-            director: Director::new(db_tokio.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db_tokio.clone()),
+            director: Director::new(db.clone()),
+            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
             image_store: store.into(),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db_tokio.clone()),
-            roles_store: crate::roles::RolesStore::new(db_tokio.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db_tokio),
+            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
+            roles_store: crate::roles::RolesStore::new(db.clone()),
+            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });

--- a/rack-director/src/http/ui/devices.rs
+++ b/rack-director/src/http/ui/devices.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::validation::validate_hostname;
+
 use crate::{
+    director::Director,
     http::{AppState, error::Error as HttpError},
     lifecycle::{DeviceLifecycle, LifecycleTransition},
     operating_systems::Architecture,
@@ -268,8 +270,14 @@ pub fn routes(state: Arc<AppState>) -> Router {
 async fn get_all_devices(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<DevicesIndex>, StatusCode> {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let director = Director::new(&conn);
     // Fetch all devices from Director (single source of truth)
-    let devices = match state.director.get_all_devices().await {
+    let devices = match director.get_all_devices().await {
         Ok(devices) => devices,
         Err(e) => {
             log::error!("Failed to fetch devices: {}", e);
@@ -321,8 +329,14 @@ async fn get_device_by_uuid(
     State(state): State<Arc<AppState>>,
     Path(uuid): Path<Uuid>,
 ) -> Result<Json<DeviceResponse>, StatusCode> {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let director = Director::new(&conn);
     // Get device from Director (single source of truth)
-    let device = match state.director.get_device(&uuid).await {
+    let device = match director.get_device(&uuid).await {
         Ok(device) => device,
         Err(_) => return Err(StatusCode::NOT_FOUND),
     };
@@ -400,12 +414,15 @@ async fn update_device_attributes(
         }
     }
 
-    // Update device attributes
-    match state
-        .director
-        .update_attributes(&uuid, payload.attributes)
+    let conn = state
+        .connection_factory
+        .open()
         .await
-    {
+        .map_err(HttpError::ServerInternalError)?;
+    let director = Director::new(&conn);
+
+    // Update device attributes
+    match director.update_attributes(&uuid, payload.attributes).await {
         Ok(_) => Ok(StatusCode::NO_CONTENT),
         Err(e) => {
             log::error!("Failed to update device attributes for {}: {}", uuid, e);
@@ -418,7 +435,13 @@ async fn get_device_lifecycle(
     State(state): State<Arc<AppState>>,
     Path(uuid): Path<Uuid>,
 ) -> Result<Json<DeviceLifecycle>, StatusCode> {
-    match state.director.get_device_lifecycle(&uuid).await {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let director = Director::new(&conn);
+    match director.get_device_lifecycle(&uuid).await {
         Ok(Some(lifecycle)) => Ok(Json(lifecycle)),
         Ok(None) => Err(StatusCode::NOT_FOUND),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
@@ -447,11 +470,17 @@ async fn start_lifecycle_transition(
         }
     };
 
-    match state
-        .director
-        .start_lifecycle_transition(&uuid, to_state)
-        .await
-    {
+    let conn = state.connection_factory.open().await.map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+    let director = Director::new(&conn);
+
+    match director.start_lifecycle_transition(&uuid, to_state).await {
         Ok(transition_id) => Ok(Json(StartTransitionResponse {
             transition_id,
             message: format!("Started lifecycle transition for device {}", uuid),
@@ -471,9 +500,14 @@ async fn get_device_transitions(
     Query(params): Query<DeviceTransitionsQuery>,
 ) -> Result<Json<Vec<LifecycleTransition>>, StatusCode> {
     let include_completed = params.include_completed.unwrap_or(false);
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let director = Director::new(&conn);
 
-    match state
-        .director
+    match director
         .get_device_transitions(&uuid, include_completed)
         .await
     {
@@ -486,7 +520,13 @@ async fn get_active_transition(
     State(state): State<Arc<AppState>>,
     Path(uuid): Path<Uuid>,
 ) -> Result<Json<Option<LifecycleTransition>>, StatusCode> {
-    match state.director.get_active_transition_for_device(&uuid).await {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let director = Director::new(&conn);
+    match director.get_active_transition_for_device(&uuid).await {
         Ok(transition) => Ok(Json(transition)),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
     }
@@ -496,12 +536,19 @@ async fn get_device_status(
     State(state): State<Arc<AppState>>,
     Path(uuid): Path<Uuid>,
 ) -> Result<Json<DeviceStatusResponse>, StatusCode> {
-    let current_lifecycle = match state.director.get_device_lifecycle(&uuid).await {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let director = Director::new(&conn);
+
+    let current_lifecycle = match director.get_device_lifecycle(&uuid).await {
         Ok(lifecycle) => lifecycle.map(String::from),
         Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
     };
 
-    let active_transition = match state.director.get_active_transition_for_device(&uuid).await {
+    let active_transition = match director.get_active_transition_for_device(&uuid).await {
         Ok(transition) => transition,
         Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
     };
@@ -517,12 +564,22 @@ async fn create_pending_device(
     State(state): State<Arc<AppState>>,
     extract::Json(payload): extract::Json<CreatePendingDeviceRequest>,
 ) -> Result<(StatusCode, Json<PendingDeviceResponse>), (StatusCode, Json<ErrorResponse>)> {
+    let conn = match state.connection_factory.open().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            log::error!("Failed to open database: {}", e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            ));
+        }
+    };
+    let director = Director::new(&conn);
+
     // Validate that the lease exists by MAC address
-    let lease = match state
-        .dhcp_store
-        .get_lease_by_mac(&payload.mac_address)
-        .await
-    {
+    let lease = match crate::dhcp::store::get_lease_by_mac(&conn, &payload.mac_address).await {
         Ok(Some(lease)) => lease,
         Ok(None) => {
             return Err((
@@ -573,8 +630,7 @@ async fn create_pending_device(
     }
 
     // Create the pending device
-    let id = match state
-        .director
+    let id = match director
         .create_pending_device(&payload.mac_address, payload.network_id)
         .await
     {
@@ -607,7 +663,13 @@ async fn create_pending_device(
 async fn get_pending_devices(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<PendingDeviceResponse>>, StatusCode> {
-    match state.director.get_pending_devices().await {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let director = Director::new(&conn);
+    match director.get_pending_devices().await {
         Ok(devices) => {
             let responses: Vec<PendingDeviceResponse> = devices
                 .into_iter()
@@ -633,7 +695,16 @@ async fn delete_pending_device(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    match state.director.delete_pending_device(id).await {
+    let conn = state.connection_factory.open().await.map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+    let director = Director::new(&conn);
+    match director.delete_pending_device(id).await {
         Ok(_) => Ok(StatusCode::NO_CONTENT),
         Err(e) => {
             log::error!("Failed to delete pending device {}: {}", id, e);
@@ -651,7 +722,16 @@ async fn delete_device_by_uuid(
     State(state): State<Arc<AppState>>,
     Path(uuid): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    match state.director.delete_device(&uuid).await {
+    let conn = state.connection_factory.open().await.map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: "Internal server error".to_string(),
+            }),
+        )
+    })?;
+    let director = Director::new(&conn);
+    match director.delete_device(&uuid).await {
         Ok(_) => Ok(StatusCode::NO_CONTENT),
         Err(e) => {
             log::error!("Failed to delete device {}: {}", uuid, e);
@@ -674,32 +754,10 @@ mod tests {
             .expect("test UUID should be valid")
     }
 
-    /// Helper to create a test network for tests that need DHCP functionality
-    async fn create_test_network(state: &AppState) -> i64 {
-        let network = state
-            .dhcp_store
-            .create_network(
-                "Test Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
-
-        state
-            .dhcp_store
-            .create_pool(network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
-            .await
-            .unwrap();
-
-        network.id
-    }
-
-    use crate::{database, director::Director, storage::ImageStore};
+    use crate::{
+        database, database::DatabaseConnectionFactory, director::Director, storage::ImageStore,
+        test_connection_factory,
+    };
 
     use super::*;
     use axum::{
@@ -710,19 +768,21 @@ mod tests {
     use tempfile::tempdir;
     use tower::util::ServiceExt;
 
-    async fn setup_test_state() -> (Arc<AppState>, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-
-        // Note: No default network is created. Tests that need networks should create them explicitly.
-
+    async fn setup_test_state(
+        factory: DatabaseConnectionFactory,
+    ) -> (
+        Arc<AppState>,
+        tempfile::TempDir,
+        crate::database::Connection,
+    ) {
         // Create image store for testing
-        let _storage_path = temp_dir.path().join("images");
         let store = ImageStore::new(crate::storage::ImageStoreConfig::Memory {
             base_url: "http://localhost:8080/images".into(),
         })
         .unwrap();
+
+        // Create temporary directories needed for agent images and boot files
+        let temp_dir = tempdir().unwrap();
 
         // Create agent-image directory with mock files for testing
         let agent_images_path = temp_dir.path().join("agent-image");
@@ -741,30 +801,64 @@ mod tests {
         let boot_file_provider =
             Arc::new(crate::boot_files::FilesystemBootFileProvider::new(boot_files_path).unwrap());
 
+        let conn: Arc<dyn crate::database::ConnectionFactory> = Arc::new(factory);
+        // Run migrations and retain the connection so the in-memory DB persists for the test
+        let migration_conn = database::run_migrations(conn.as_ref()).await.unwrap();
+
         let state = Arc::new(AppState {
-            director: Director::new(db.clone()),
-            dhcp_store: crate::dhcp::DhcpStore::new(db.clone()),
+            connection_factory: conn,
             image_store: store.into(),
-            os_store: crate::operating_systems::OperatingSystemsStore::new(db.clone()),
-            roles_store: crate::roles::RolesStore::new(db.clone()),
-            platforms_store: crate::platforms::PlatformsStore::new(db),
             agent_images_path,
             boot_file_provider,
         });
-        (state, temp_dir)
+        (state, temp_dir, migration_conn)
+    }
+
+    /// Open a database connection for test assertions.
+    ///
+    /// Usage: `let db = test_db(&state).await; let director = Director::new(&db);`
+    /// For one-liners: `{ let db = test_db(&state).await; Director::new(&db).method().await }`
+    async fn test_db(state: &AppState) -> crate::database::Connection {
+        state.connection_factory.open().await.unwrap()
+    }
+
+    /// Helper to create a test network for tests that need DHCP functionality
+    async fn create_test_network(state: &AppState) -> i64 {
+        let db = Arc::new(state.connection_factory.open().await.unwrap());
+        let network = crate::dhcp::store::create_network(
+            &db,
+            "Test Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        crate::dhcp::store::create_pool(&db, network.id, "Test Pool", "10.0.0.100", "10.0.0.200")
+            .await
+            .unwrap();
+
+        network.id
     }
 
     #[tokio::test]
     async fn test_get_device_lifecycle() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x10);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state);
 
@@ -779,15 +873,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_lifecycle_transition() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x11);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state);
 
@@ -808,15 +905,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_device_status() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x12);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state);
 
@@ -831,17 +931,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_pending_device() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let network_id = create_test_network(&state).await;
 
         // Create a pending device directly (bypassing network/lease setup for simplicity)
         let mac = "aa:bb:cc:dd:ee:ff";
 
-        let pending_id = state
-            .director
-            .create_pending_device(mac, network_id)
-            .await
-            .unwrap();
+        let pending_id = {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .create_pending_device(mac, network_id)
+                .await
+                .unwrap()
+        };
 
         let app = routes(state.clone());
 
@@ -856,7 +959,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify it's deleted - should return empty list
-        let pending_devices = state.director.get_pending_devices().await.unwrap();
+        let pending_devices = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_pending_devices().await.unwrap()
+        };
         assert!(
             pending_devices.is_empty(),
             "Pending device should be deleted"
@@ -865,19 +971,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_device() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x20);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         // Verify device exists before deletion
         assert!(
-            state.director.device_exists(&test_uuid).await.unwrap(),
+            {
+                let conn = test_db(&state).await;
+                Director::new(&conn)
+                    .device_exists(&test_uuid)
+                    .await
+                    .unwrap()
+            },
             "Device should exist before deletion"
         );
 
@@ -895,29 +1010,39 @@ mod tests {
 
         // Verify device is deleted
         assert!(
-            !state.director.device_exists(&test_uuid).await.unwrap(),
+            !{
+                let conn = test_db(&state).await;
+                Director::new(&conn)
+                    .device_exists(&test_uuid)
+                    .await
+                    .unwrap()
+            },
             "Device should be deleted"
         );
     }
 
     #[tokio::test]
     async fn test_delete_multiple_devices() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let uuid1 = test_uuid(0x21);
         let uuid2 = test_uuid(0x22);
 
         // Register two devices
-        state
-            .director
-            .register_device(&uuid1, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
-
-        state
-            .director
-            .register_device(&uuid2, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&uuid1, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&uuid2, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -942,13 +1067,20 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify both devices are deleted
-        assert!(!state.director.device_exists(&uuid1).await.unwrap());
-        assert!(!state.director.device_exists(&uuid2).await.unwrap());
+        assert!(!{
+            let conn = test_db(&state).await;
+            Director::new(&conn).device_exists(&uuid1).await.unwrap()
+        });
+        assert!(!{
+            let conn = test_db(&state).await;
+            Director::new(&conn).device_exists(&uuid2).await.unwrap()
+        });
     }
 
     #[tokio::test]
     async fn test_delete_nonexistent_device() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x22);
 
         // Don't register the device - it doesn't exist
@@ -977,15 +1109,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_hostname_valid() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x30);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1009,21 +1144,27 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify hostname was updated
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         assert_eq!(device.attributes.hostname, Some("server-01".to_string()));
     }
 
     #[tokio::test]
     async fn test_update_device_hostname_empty() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x31);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1057,15 +1198,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_hostname_too_long() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x32);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1099,15 +1243,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_hostname_invalid_characters() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x33);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1141,15 +1288,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_hostname_leading_hyphen() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x34);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1183,15 +1333,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_hostname_trailing_hyphen() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x35);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1225,15 +1378,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_hostname_with_dots() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x36);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1257,7 +1413,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify hostname was updated
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         assert_eq!(
             device.attributes.hostname,
             Some("server.example.com".to_string())
@@ -1266,15 +1425,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_hostname_not_string() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x37);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1308,15 +1470,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_device_attributes_without_hostname() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x38);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1340,7 +1505,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify attribute was updated
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         assert_eq!(
             device.attributes.manufacturer,
             Some("Dell Inc.".to_string())
@@ -1349,15 +1517,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_bmc_config_rejects_password() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x39);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1395,15 +1566,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_bmc_config_rejects_username() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x3A);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1440,15 +1614,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_bmc_config_allows_valid_fields() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x3B);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1477,7 +1654,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify bmc_config was updated
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         let bmc_config = device
             .attributes
             .bmc_config
@@ -1490,14 +1670,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_bmc_config_invalid_ip_address() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x3C);
 
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1534,14 +1717,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_bmc_config_invalid_netmask() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x3D);
 
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1578,14 +1764,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_bmc_config_missing_static_fields() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x3E);
 
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1619,14 +1808,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_bmc_config_dhcp_no_validation() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x3F);
 
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1652,7 +1844,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         // Verify bmc_config was updated
-        let device = state.director.get_device(&test_uuid).await.unwrap();
+        let device = {
+            let conn = test_db(&state).await;
+            Director::new(&conn).get_device(&test_uuid).await.unwrap()
+        };
         let bmc_config = device
             .attributes
             .bmc_config
@@ -1733,15 +1928,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_device_sanitizes_password() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x50);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         // Set BMC config with password
         let mut attributes = serde_json::Map::new();
@@ -1755,11 +1953,13 @@ mod tests {
             }),
         );
 
-        state
-            .director
-            .update_attributes(&test_uuid, attributes)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .update_attributes(&test_uuid, attributes)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1795,15 +1995,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_all_devices_sanitizes_passwords() {
-        let (state, _temp_dir) = setup_test_state().await;
+        let (state, _temp_dir, _migration_conn) =
+            setup_test_state(test_connection_factory!()).await;
         let test_uuid = test_uuid(0x51);
 
         // Register device
-        state
-            .director
-            .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .register_device(&test_uuid, crate::operating_systems::Architecture::X86_64)
+                .await
+                .unwrap();
+        }
 
         // Set BMC config with password
         let mut attributes = serde_json::Map::new();
@@ -1817,11 +2020,13 @@ mod tests {
             }),
         );
 
-        state
-            .director
-            .update_attributes(&test_uuid, attributes)
-            .await
-            .unwrap();
+        {
+            let conn = test_db(&state).await;
+            Director::new(&conn)
+                .update_attributes(&test_uuid, attributes)
+                .await
+                .unwrap();
+        }
 
         let app = routes(state.clone());
 
@@ -1866,14 +2071,16 @@ async fn assign_platform(
     Path(uuid): Path<Uuid>,
     Json(req): Json<AssignPlatformRequest>,
 ) -> Result<StatusCode, HttpError> {
+    let conn = state.connection_factory.open().await?;
+    let director = Director::new(&conn);
+
     // Verify platform exists
-    state.platforms_store.get(req.platform_id).await?;
+    crate::platforms::store::get(&conn, req.platform_id).await?;
 
     // Verify device exists
-    state.director.get_device(&uuid).await?;
+    director.get_device(&uuid).await?;
 
-    state
-        .director
+    director
         .assign_platform_to_device(&uuid, req.platform_id)
         .await?;
 
@@ -1884,12 +2091,15 @@ async fn get_device_platform(
     State(state): State<Arc<AppState>>,
     Path(uuid): Path<Uuid>,
 ) -> Result<Json<Option<Platform>>, HttpError> {
+    let conn = state.connection_factory.open().await?;
+    let director = Director::new(&conn);
+
     // Get platform ID from device
-    let platform_id = state.director.get_device_platform_id(&uuid).await?;
+    let platform_id = director.get_device_platform_id(&uuid).await?;
 
     // If device has a platform, fetch full platform details
     if let Some(id) = platform_id {
-        let platform = state.platforms_store.get(id).await?;
+        let platform = crate::platforms::store::get(&conn, id).await?;
         Ok(Json(Some(platform)))
     } else {
         Ok(Json(None))
@@ -1903,16 +2113,16 @@ async fn assign_role(
     Path(uuid): Path<Uuid>,
     Json(req): Json<AssignRoleRequest>,
 ) -> Result<StatusCode, HttpError> {
+    let conn = state.connection_factory.open().await?;
+    let director = Director::new(&conn);
+
     // Verify role exists
-    state.roles_store.get(req.role_id).await?;
+    crate::roles::store::get(&conn, req.role_id).await?;
 
     // Verify device exists
-    state.director.get_device(&uuid).await?;
+    director.get_device(&uuid).await?;
 
-    state
-        .director
-        .assign_role_to_device(&uuid, req.role_id)
-        .await?;
+    director.assign_role_to_device(&uuid, req.role_id).await?;
 
     Ok(StatusCode::OK)
 }
@@ -1921,12 +2131,15 @@ async fn get_device_role(
     State(state): State<Arc<AppState>>,
     Path(uuid): Path<Uuid>,
 ) -> Result<Json<Option<Role>>, HttpError> {
+    let conn = state.connection_factory.open().await?;
+    let director = Director::new(&conn);
+
     // Get role ID from device
-    let role_id = state.director.get_device_role_id(&uuid).await?;
+    let role_id = director.get_device_role_id(&uuid).await?;
 
     // If device has a role, fetch full role details
     if let Some(id) = role_id {
-        let role = state.roles_store.get(id).await?;
+        let role = crate::roles::store::get(&conn, id).await?;
         Ok(Json(Some(role)))
     } else {
         Ok(Json(None))

--- a/rack-director/src/http/ui/dhcp.rs
+++ b/rack-director/src/http/ui/dhcp.rs
@@ -20,7 +20,12 @@ pub fn routes(state: Arc<AppState>) -> Router {
 async fn get_all_dhcp_leases(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<crate::dhcp::Lease>>, StatusCode> {
-    match state.dhcp_store.get_all_leases().await {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match crate::dhcp::store::get_all_leases(&conn).await {
         Ok(leases) => Ok(Json(leases)),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
     }
@@ -30,7 +35,12 @@ async fn get_dhcp_lease_by_mac(
     State(state): State<Arc<AppState>>,
     Path(mac): Path<String>,
 ) -> Result<Json<crate::dhcp::Lease>, StatusCode> {
-    match state.dhcp_store.get_lease_by_mac(&mac).await {
+    let conn = state
+        .connection_factory
+        .open()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    match crate::dhcp::store::get_lease_by_mac(&conn, &mac).await {
         Ok(Some(lease)) => Ok(Json(lease)),
         Ok(None) => Err(StatusCode::NOT_FOUND),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),

--- a/rack-director/src/http/ui/networks.rs
+++ b/rack-director/src/http/ui/networks.rs
@@ -157,7 +157,7 @@ async fn update_network(
     log::debug!("update network request: {:?}", req);
 
     // Open a connection for raw store calls; DhcpStore uses the factory for its own connections
-    let conn = Arc::new(state.connection_factory.open().await?);
+    let mut conn = state.connection_factory.open().await?;
 
     // Validate request
     if let Err(errors) = validate_update_network_request(&conn, id, &req).await {
@@ -165,7 +165,7 @@ async fn update_network(
     }
 
     let network = crate::dhcp::store::update_network(
-        &conn,
+        &mut conn,
         id,
         req.name.as_deref(),
         req.subnet.as_deref(),
@@ -229,9 +229,9 @@ async fn update_pool(
     Path(id): Path<i64>,
     Json(req): Json<UpdatePoolRequest>,
 ) -> Result<Json<DhcpPool>, HttpError> {
-    let conn = state.connection_factory.open().await?;
+    let mut conn = state.connection_factory.open().await?;
     let pool = crate::dhcp::store::update_pool(
-        &conn,
+        &mut conn,
         id,
         req.name.as_deref(),
         req.range_start.as_deref(),

--- a/rack-director/src/http/ui/networks.rs
+++ b/rack-director/src/http/ui/networks.rs
@@ -1,6 +1,6 @@
 use super::super::{AppState, error::Error as HttpError};
 use super::validation::{validate_create_network_request, validate_update_network_request};
-use crate::dhcp::{DhcpNetwork, DhcpPool, Lease, StaticReservation};
+use crate::dhcp::{self, DhcpNetwork, DhcpPool, Lease, StaticReservation};
 use crate::director::Device;
 use axum::{
     Json, Router,
@@ -103,7 +103,8 @@ pub struct MakeStaticRequest {
 async fn list_networks(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<DhcpNetwork>>, HttpError> {
-    let networks = state.dhcp_store.list_networks().await?;
+    let conn = state.connection_factory.open().await?;
+    let networks = crate::dhcp::store::list_networks(&conn).await?;
     Ok(Json(networks))
 }
 
@@ -112,7 +113,8 @@ async fn get_network(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<Json<DhcpNetwork>, HttpError> {
-    let network = state.dhcp_store.get_network(id).await?;
+    let conn = state.connection_factory.open().await?;
+    let network = crate::dhcp::store::get_network(&conn, id).await?;
     Ok(Json(network))
 }
 
@@ -122,23 +124,26 @@ async fn create_network(
     Json(req): Json<CreateNetworkRequest>,
 ) -> Result<(StatusCode, Json<DhcpNetwork>), HttpError> {
     log::debug!("create network request: {:?}", req);
+
+    // Open a connection for raw store calls; DhcpStore uses the factory for its own connections
+    let conn: crate::database::Connection = state.connection_factory.open().await?;
+
     // Validate request
-    if let Err(errors) = validate_create_network_request(&req, &state.dhcp_store).await {
+    if let Err(errors) = validate_create_network_request(&conn, &req).await {
         return Err(HttpError::ValidationError(errors));
     }
 
-    let network = state
-        .dhcp_store
-        .create_network(
-            &req.name,
-            &req.subnet,
-            &req.gateway,
-            &req.dns_servers,
-            req.lease_duration,
-            req.relay_agent_address.as_deref(),
-            req.enable_autodiscovery,
-        )
-        .await?;
+    let network = dhcp::store::create_network(
+        &conn,
+        &req.name,
+        &req.subnet,
+        &req.gateway,
+        &req.dns_servers,
+        req.lease_duration,
+        req.relay_agent_address.as_deref(),
+        req.enable_autodiscovery,
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(network)))
 }
@@ -150,26 +155,29 @@ async fn update_network(
     Json(req): Json<UpdateNetworkRequest>,
 ) -> Result<Json<DhcpNetwork>, HttpError> {
     log::debug!("update network request: {:?}", req);
+
+    // Open a connection for raw store calls; DhcpStore uses the factory for its own connections
+    let conn = Arc::new(state.connection_factory.open().await?);
+
     // Validate request
-    if let Err(errors) = validate_update_network_request(id, &req, &state.dhcp_store).await {
+    if let Err(errors) = validate_update_network_request(&conn, id, &req).await {
         return Err(HttpError::ValidationError(errors));
     }
 
-    let network = state
-        .dhcp_store
-        .update_network(
-            id,
-            req.name.as_deref(),
-            req.subnet.as_deref(),
-            req.gateway.as_deref(),
-            req.dns_servers.as_deref(),
-            req.lease_duration,
-            req.relay_agent_address
-                .as_deref()
-                .map(|opt| if opt.is_empty() { None } else { Some(opt) }),
-            req.enable_autodiscovery,
-        )
-        .await?;
+    let network = crate::dhcp::store::update_network(
+        &conn,
+        id,
+        req.name.as_deref(),
+        req.subnet.as_deref(),
+        req.gateway.as_deref(),
+        req.dns_servers.as_deref(),
+        req.lease_duration,
+        req.relay_agent_address
+            .as_deref()
+            .map(|opt| if opt.is_empty() { None } else { Some(opt) }),
+        req.enable_autodiscovery,
+    )
+    .await?;
 
     Ok(Json(network))
 }
@@ -179,7 +187,8 @@ async fn delete_network(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, HttpError> {
-    state.dhcp_store.delete_network(id).await?;
+    let conn = state.connection_factory.open().await?;
+    crate::dhcp::store::delete_network(&conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -190,7 +199,8 @@ async fn list_pools(
     State(state): State<Arc<AppState>>,
     Path(network_id): Path<i64>,
 ) -> Result<Json<Vec<DhcpPool>>, HttpError> {
-    let pools = state.dhcp_store.list_pools_for_network(network_id).await?;
+    let conn = state.connection_factory.open().await?;
+    let pools = crate::dhcp::store::list_pools_for_network(&conn, network_id).await?;
     Ok(Json(pools))
 }
 
@@ -200,10 +210,15 @@ async fn create_pool(
     Path(network_id): Path<i64>,
     Json(req): Json<CreatePoolRequest>,
 ) -> Result<(StatusCode, Json<DhcpPool>), HttpError> {
-    let pool = state
-        .dhcp_store
-        .create_pool(network_id, &req.name, &req.range_start, &req.range_end)
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let pool = crate::dhcp::store::create_pool(
+        &conn,
+        network_id,
+        &req.name,
+        &req.range_start,
+        &req.range_end,
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(pool)))
 }
@@ -214,15 +229,15 @@ async fn update_pool(
     Path(id): Path<i64>,
     Json(req): Json<UpdatePoolRequest>,
 ) -> Result<Json<DhcpPool>, HttpError> {
-    let pool = state
-        .dhcp_store
-        .update_pool(
-            id,
-            req.name.as_deref(),
-            req.range_start.as_deref(),
-            req.range_end.as_deref(),
-        )
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let pool = crate::dhcp::store::update_pool(
+        &conn,
+        id,
+        req.name.as_deref(),
+        req.range_start.as_deref(),
+        req.range_end.as_deref(),
+    )
+    .await?;
 
     Ok(Json(pool))
 }
@@ -232,7 +247,8 @@ async fn delete_pool(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, HttpError> {
-    state.dhcp_store.delete_pool(id).await?;
+    let conn = state.connection_factory.open().await?;
+    crate::dhcp::store::delete_pool(&conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -243,10 +259,8 @@ async fn list_static_reservations(
     State(state): State<Arc<AppState>>,
     Path(network_id): Path<i64>,
 ) -> Result<Json<Vec<StaticReservation>>, HttpError> {
-    let reservations = state
-        .dhcp_store
-        .list_static_reservations(network_id)
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let reservations = crate::dhcp::store::list_static_reservations(&conn, network_id).await?;
     Ok(Json(reservations))
 }
 
@@ -256,8 +270,10 @@ async fn create_static_reservation(
     Path(network_id): Path<i64>,
     Json(req): Json<CreateStaticReservationRequest>,
 ) -> Result<(StatusCode, Json<StaticReservation>), HttpError> {
+    let conn = state.connection_factory.open().await?;
+
     // Fetch the network to get the subnet
-    let network = state.dhcp_store.get_network(network_id).await?;
+    let network = crate::dhcp::store::get_network(&conn, network_id).await?;
 
     // Validate the IP is within the subnet
     let subnet: Ipv4Subnet = network.subnet.parse()?;
@@ -267,15 +283,14 @@ async fn create_static_reservation(
         ));
     }
 
-    let reservation = state
-        .dhcp_store
-        .create_static_reservation(
-            network_id,
-            &req.mac_address,
-            &req.ip_address,
-            req.hostname.as_deref(),
-        )
-        .await?;
+    let reservation = crate::dhcp::store::create_static_reservation(
+        &conn,
+        network_id,
+        &req.mac_address,
+        &req.ip_address,
+        req.hostname.as_deref(),
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(reservation)))
 }
@@ -285,7 +300,8 @@ async fn delete_static_reservation(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, HttpError> {
-    state.dhcp_store.delete_static_reservation(id).await?;
+    let conn = state.connection_factory.open().await?;
+    crate::dhcp::store::delete_static_reservation(&conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -299,11 +315,13 @@ async fn list_leases_by_network(
     State(state): State<Arc<AppState>>,
     Path(network_id): Path<i64>,
 ) -> Result<Json<Vec<Lease>>, HttpError> {
+    let conn = state.connection_factory.open().await?;
+
     // Fetch leases for the network
-    let mut leases = state.dhcp_store.get_leases_by_network(network_id).await?;
+    let mut leases = crate::dhcp::store::get_leases_by_network(&conn, network_id).await?;
 
     // Fetch all devices for MAC lookup
-    let devices = state.director.get_all_devices().await?;
+    let devices = crate::director::store::get_all_devices(&conn).await?;
 
     // For each lease without a device_uuid, try to find it by MAC address
     for lease in &mut leases {
@@ -324,10 +342,10 @@ async fn make_lease_static(
     Path(lease_id): Path<i64>,
     Json(req): Json<MakeStaticRequest>,
 ) -> Result<(StatusCode, Json<StaticReservation>), HttpError> {
+    let conn = state.connection_factory.open().await?;
+
     // Get the lease by ID
-    let lease = state
-        .dhcp_store
-        .get_lease_by_id(lease_id)
+    let lease = crate::dhcp::store::get_lease_by_id(&conn, lease_id)
         .await?
         .ok_or_else(|| HttpError::NotFound(format!("Lease {} not found", lease_id)))?;
 
@@ -337,7 +355,7 @@ async fn make_lease_static(
         .ok_or_else(|| HttpError::BadRequest("Lease has no associated network".to_string()))?;
 
     // Fetch the network to get the subnet
-    let network = state.dhcp_store.get_network(network_id).await?;
+    let network = crate::dhcp::store::get_network(&conn, network_id).await?;
 
     // Determine the IP address to use (from request or lease)
     let ip_address = req.ip_address.as_deref().unwrap_or(&lease.ip_address);
@@ -354,15 +372,14 @@ async fn make_lease_static(
     let hostname = req.hostname.or(lease.hostname);
 
     // Create static reservation
-    let reservation = state
-        .dhcp_store
-        .create_static_reservation(
-            network_id,
-            &lease.mac_address,
-            ip_address,
-            hostname.as_deref(),
-        )
-        .await?;
+    let reservation = crate::dhcp::store::create_static_reservation(
+        &conn,
+        network_id,
+        &lease.mac_address,
+        ip_address,
+        hostname.as_deref(),
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(reservation)))
 }

--- a/rack-director/src/http/ui/operating_systems.rs
+++ b/rack-director/src/http/ui/operating_systems.rs
@@ -103,10 +103,14 @@ async fn create_os(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateOperatingSystemRequest>,
 ) -> Result<(StatusCode, Json<OperatingSystem>), HttpError> {
-    let os = state
-        .os_store
-        .create(&req.name, &req.version, req.description.as_deref())
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let os = crate::operating_systems::store::create(
+        &conn,
+        &req.name,
+        &req.version,
+        req.description.as_deref(),
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(os)))
 }
@@ -115,7 +119,8 @@ async fn create_os(
 async fn list_os(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<OperatingSystem>>, HttpError> {
-    let systems = state.os_store.list().await?;
+    let conn = state.connection_factory.open().await?;
+    let systems = crate::operating_systems::store::list(&conn).await?;
     Ok(Json(systems))
 }
 
@@ -124,7 +129,8 @@ async fn get_os(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<Json<OperatingSystemWithArchitectures>, HttpError> {
-    let os = state.os_store.get_with_architectures(id).await?;
+    let conn = state.connection_factory.open().await?;
+    let os = crate::operating_systems::store::get_with_architectures(&conn, id).await?;
     Ok(Json(os))
 }
 
@@ -135,15 +141,15 @@ async fn update_os(
     Path(id): Path<i64>,
     Json(req): Json<UpdateOperatingSystemRequest>,
 ) -> Result<Json<OperatingSystem>, HttpError> {
-    let os = state
-        .os_store
-        .update(
-            id,
-            req.name.as_deref(),
-            req.version.as_deref(),
-            req.description.as_deref(),
-        )
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let os = crate::operating_systems::store::update(
+        &conn,
+        id,
+        req.name.as_deref(),
+        req.version.as_deref(),
+        req.description.as_deref(),
+    )
+    .await?;
 
     Ok(Json(os))
 }
@@ -153,7 +159,8 @@ async fn delete_os(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, HttpError> {
-    state.os_store.delete(id).await?;
+    let conn = state.connection_factory.open().await?;
+    crate::operating_systems::store::delete(&conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -171,18 +178,18 @@ async fn create_os_architecture(
         .initramfs_path
         .unwrap_or_else(|| format!("os/{}/arch/{}/initramfs", os_id, req.architecture.as_str()));
 
-    let arch = state
-        .os_store
-        .upsert_architecture(
-            os_id,
-            req.architecture,
-            &kernel_path,
-            &initramfs_path,
-            req.modules.unwrap_or_default(),
-            req.cmdline_args.as_deref(),
-            req.install_script_path.as_deref(),
-        )
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let arch = crate::operating_systems::store::upsert_architecture(
+        &conn,
+        os_id,
+        req.architecture,
+        &kernel_path,
+        &initramfs_path,
+        req.modules.unwrap_or_default(),
+        req.cmdline_args.as_deref(),
+        req.install_script_path.as_deref(),
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(arch)))
 }
@@ -193,7 +200,8 @@ async fn get_os_architecture(
     Path((os_id, arch_str)): Path<(i64, String)>,
 ) -> Result<Json<OsArchitecture>, HttpError> {
     let arch = Architecture::from_str(&arch_str)?;
-    let os_arch = state.os_store.get_architecture(os_id, arch).await?;
+    let conn = state.connection_factory.open().await?;
+    let os_arch = crate::operating_systems::store::get_architecture(&conn, os_id, arch).await?;
     Ok(Json(os_arch))
 }
 
@@ -203,7 +211,8 @@ async fn delete_os_architecture(
     Path((os_id, arch_str)): Path<(i64, String)>,
 ) -> Result<StatusCode, HttpError> {
     let arch = Architecture::from_str(&arch_str)?;
-    state.os_store.delete_architecture(os_id, arch).await?;
+    let conn = state.connection_factory.open().await?;
+    crate::operating_systems::store::delete_architecture(&conn, os_id, arch).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -226,19 +235,28 @@ async fn upload_kernel(
     // Send data to image_store
     state.image_store.upload(&path, Box::pin(stream)).await?;
 
-    state
-        .os_store
-        .update_architecture_field(os_id, arch, "kernel_path", &path)
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    crate::operating_systems::store::update_architecture_field(
+        &conn,
+        os_id,
+        arch,
+        "kernel_path",
+        &path,
+    )
+    .await?;
 
     if let Some(filename) = filename {
-        state
-            .os_store
-            .update_architecture_field(os_id, arch, "kernel_filename", filename)
-            .await?;
+        crate::operating_systems::store::update_architecture_field(
+            &conn,
+            os_id,
+            arch,
+            "kernel_filename",
+            filename,
+        )
+        .await?;
     }
 
-    let os_arch = state.os_store.get_architecture(os_id, arch).await?;
+    let os_arch = crate::operating_systems::store::get_architecture(&conn, os_id, arch).await?;
     Ok(Json(os_arch))
 }
 
@@ -258,19 +276,29 @@ async fn upload_initramfs(
         .into_data_stream()
         .map(|result| result.map_err(std::io::Error::other));
     state.image_store.upload(&path, Box::pin(stream)).await?;
-    state
-        .os_store
-        .update_architecture_field(os_id, arch, "initramfs_path", &path)
-        .await?;
+
+    let conn = state.connection_factory.open().await?;
+    crate::operating_systems::store::update_architecture_field(
+        &conn,
+        os_id,
+        arch,
+        "initramfs_path",
+        &path,
+    )
+    .await?;
 
     if let Some(filename) = filename {
-        state
-            .os_store
-            .update_architecture_field(os_id, arch, "initramfs_filename", filename)
-            .await?;
+        crate::operating_systems::store::update_architecture_field(
+            &conn,
+            os_id,
+            arch,
+            "initramfs_filename",
+            filename,
+        )
+        .await?;
     }
 
-    let os_arch = state.os_store.get_architecture(os_id, arch).await?;
+    let os_arch = crate::operating_systems::store::get_architecture(&conn, os_id, arch).await?;
     Ok(Json(os_arch))
 }
 
@@ -300,17 +328,22 @@ async fn upload_module(
     state.image_store.upload(&path, Box::pin(stream)).await?;
 
     // Add module to the architecture's modules list
-    let mut os_arch = state.os_store.get_architecture(os_id, arch).await?;
+    let conn = state.connection_factory.open().await?;
+    let mut os_arch = crate::operating_systems::store::get_architecture(&conn, os_id, arch).await?;
     if !os_arch.modules.contains(&path) {
         os_arch.modules.push(path.clone());
         let modules_json = serde_json::to_string(&os_arch.modules)?;
-        state
-            .os_store
-            .update_architecture_field(os_id, arch, "modules", &modules_json)
-            .await?;
+        crate::operating_systems::store::update_architecture_field(
+            &conn,
+            os_id,
+            arch,
+            "modules",
+            &modules_json,
+        )
+        .await?;
     }
 
-    let os_arch = state.os_store.get_architecture(os_id, arch).await?;
+    let os_arch = crate::operating_systems::store::get_architecture(&conn, os_id, arch).await?;
     Ok(Json(os_arch))
 }
 
@@ -330,19 +363,29 @@ async fn upload_install_script(
         .into_data_stream()
         .map(|result| result.map_err(std::io::Error::other));
     state.image_store.upload(&path, Box::pin(stream)).await?;
-    state
-        .os_store
-        .update_architecture_field(os_id, arch, "install_script_path", &path)
-        .await?;
+
+    let conn = state.connection_factory.open().await?;
+    crate::operating_systems::store::update_architecture_field(
+        &conn,
+        os_id,
+        arch,
+        "install_script_path",
+        &path,
+    )
+    .await?;
 
     if let Some(filename) = filename {
-        state
-            .os_store
-            .update_architecture_field(os_id, arch, "install_script_filename", filename)
-            .await?;
+        crate::operating_systems::store::update_architecture_field(
+            &conn,
+            os_id,
+            arch,
+            "install_script_filename",
+            filename,
+        )
+        .await?;
     }
 
-    let os_arch = state.os_store.get_architecture(os_id, arch).await?;
+    let os_arch = crate::operating_systems::store::get_architecture(&conn, os_id, arch).await?;
     Ok(Json(os_arch))
 }
 
@@ -352,7 +395,8 @@ async fn download_component(
     Path((os_id, arch_str, component)): Path<(i64, String, String)>,
 ) -> Result<impl IntoResponse, HttpError> {
     let arch = Architecture::from_str(&arch_str)?;
-    let os_arch = state.os_store.get_architecture(os_id, arch).await?;
+    let conn = state.connection_factory.open().await?;
+    let os_arch = crate::operating_systems::store::get_architecture(&conn, os_id, arch).await?;
 
     let path = match component.as_str() {
         "kernel" => os_arch.kernel_path,

--- a/rack-director/src/http/ui/platforms.rs
+++ b/rack-director/src/http/ui/platforms.rs
@@ -284,16 +284,13 @@ mod tests {
         director::Director,
         operating_systems::Architecture,
         platforms::{DiskType, PlatformCpu, PlatformDisk, PlatformNic},
+        test_database_path,
     };
-    use rusqlite::Connection;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
     use uuid::Uuid;
 
-    fn setup_db() -> Arc<Mutex<Connection>> {
-        let conn = Connection::open_in_memory().unwrap();
-        database::run_migrations(&conn).unwrap();
-        Arc::new(Mutex::new(conn))
+    async fn setup_db(path: String) -> Arc<crate::database::Connection> {
+        Arc::new(database::open(path).await.unwrap())
     }
 
     fn test_uuid(n: u8) -> Uuid {
@@ -340,7 +337,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_empty() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let platforms_store = PlatformsStore::new(db.clone());
         let director = Director::new(db);
 
@@ -364,7 +361,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_single_device() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let platforms_store = PlatformsStore::new(db.clone());
         let director = Director::new(db);
 
@@ -412,7 +409,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_multiple_devices() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let platforms_store = PlatformsStore::new(db.clone());
         let director = Director::new(db);
 
@@ -495,7 +492,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_lifecycle_states() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let platforms_store = PlatformsStore::new(db.clone());
         let director = Director::new(db);
 
@@ -541,7 +538,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_nonexistent_platform() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let director = Director::new(db);
 
         // Try to get devices for a nonexistent platform

--- a/rack-director/src/http/ui/platforms.rs
+++ b/rack-director/src/http/ui/platforms.rs
@@ -170,10 +170,14 @@ async fn create_platform(
         return Err(HttpError::ValidationError(errors));
     }
 
-    let platform = state
-        .platforms_store
-        .create(&req.name, req.description.as_deref(), &req.attributes)
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let platform = crate::platforms::store::create(
+        &conn,
+        &req.name,
+        req.description.as_deref(),
+        &req.attributes,
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(platform)))
 }
@@ -182,7 +186,8 @@ async fn create_platform(
 async fn list_platforms(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<Platform>>, HttpError> {
-    let platforms = state.platforms_store.list().await?;
+    let conn = state.connection_factory.open().await?;
+    let platforms = crate::platforms::store::list(&conn).await?;
     Ok(Json(platforms))
 }
 
@@ -191,7 +196,8 @@ async fn get_platform(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<Json<Platform>, HttpError> {
-    let platform = state.platforms_store.get(id).await?;
+    let conn = state.connection_factory.open().await?;
+    let platform = crate::platforms::store::get(&conn, id).await?;
     Ok(Json(platform))
 }
 
@@ -205,15 +211,15 @@ async fn update_platform(
         return Err(HttpError::ValidationError(errors));
     }
 
-    let platform = state
-        .platforms_store
-        .update(
-            id,
-            req.name.as_deref(),
-            req.description.as_deref(),
-            req.attributes.as_ref(),
-        )
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let platform = crate::platforms::store::update(
+        &conn,
+        id,
+        req.name.as_deref(),
+        req.description.as_deref(),
+        req.attributes.as_ref(),
+    )
+    .await?;
 
     Ok(Json(platform))
 }
@@ -223,7 +229,8 @@ async fn delete_platform(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, HttpError> {
-    state.platforms_store.delete(id).await?;
+    let conn = state.connection_factory.open().await?;
+    crate::platforms::store::delete(&conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -232,10 +239,8 @@ async fn list_platform_devices(
     State(state): State<Arc<AppState>>,
     Path(platform_id): Path<i64>,
 ) -> Result<Json<Vec<String>>, HttpError> {
-    let devices = state
-        .director
-        .list_devices_with_platform(platform_id)
-        .await?;
+    let conn = state.connection_factory.open().await?;
+    let devices = crate::director::store::list_devices_with_platform(&conn, platform_id).await?;
     let device_strs: Vec<String> = devices.iter().map(|u| u.to_string()).collect();
     Ok(Json(device_strs))
 }
@@ -255,16 +260,16 @@ async fn get_platform_devices_with_details(
     State(state): State<Arc<AppState>>,
     Path(platform_id): Path<i64>,
 ) -> Result<Json<Vec<PlatformDeviceInfo>>, HttpError> {
-    let device_uuids = state
-        .director
-        .list_devices_with_platform(platform_id)
-        .await?;
+    let conn = state.connection_factory.open().await?;
+
+    let device_uuids =
+        crate::director::store::list_devices_with_platform(&conn, platform_id).await?;
 
     let mut devices_info = Vec::new();
     for uuid in device_uuids {
         // Get device info
-        let device = state.director.get_device(&uuid).await?;
-        let lifecycle = state.director.get_device_lifecycle(&uuid).await?;
+        let device = crate::director::store::get_device(&conn, &uuid).await?;
+        let lifecycle = crate::lifecycle::store::get_device_lifecycle(&conn, &uuid).await?;
 
         devices_info.push(PlatformDeviceInfo {
             uuid: uuid.to_string(),
@@ -289,8 +294,17 @@ mod tests {
     use std::sync::Arc;
     use uuid::Uuid;
 
-    async fn setup_db(path: String) -> Arc<crate::database::Connection> {
-        Arc::new(database::open(path).await.unwrap())
+    async fn setup_db(
+        path: String,
+    ) -> (
+        Arc<crate::database::Connection>,
+        Arc<dyn crate::database::ConnectionFactory>,
+    ) {
+        let factory: Arc<dyn crate::database::ConnectionFactory> = Arc::new(
+            crate::database::DatabaseConnectionFactory::new(std::path::PathBuf::from(path)),
+        );
+        let db = Arc::new(database::run_migrations(factory.as_ref()).await.unwrap());
+        (db, factory)
     }
 
     fn test_uuid(n: u8) -> Uuid {
@@ -337,16 +351,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_empty() {
-        let db = setup_db(test_database_path!()).await;
-        let platforms_store = PlatformsStore::new(db.clone());
-        let director = Director::new(db);
+        let (conn, _factory) = setup_db(test_database_path!()).await;
+        let director = Director::new(&conn);
 
         // Create a platform
         let attrs = sample_platform_attributes();
-        let platform = platforms_store
-            .create("Test Platform", Some("Test Description"), &attrs)
-            .await
-            .unwrap();
+        let platform = crate::platforms::store::create(
+            &conn,
+            "Test Platform",
+            Some("Test Description"),
+            &attrs,
+        )
+        .await
+        .unwrap();
 
         let platform_id = platform.id.unwrap();
 
@@ -361,16 +378,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_single_device() {
-        let db = setup_db(test_database_path!()).await;
-        let platforms_store = PlatformsStore::new(db.clone());
-        let director = Director::new(db);
+        let (conn, _factory) = setup_db(test_database_path!()).await;
+        let director = Director::new(&conn);
 
         // Create a platform
         let attrs = sample_platform_attributes();
-        let platform = platforms_store
-            .create("Test Platform", Some("Test Description"), &attrs)
-            .await
-            .unwrap();
+        let platform = crate::platforms::store::create(
+            &conn,
+            "Test Platform",
+            Some("Test Description"),
+            &attrs,
+        )
+        .await
+        .unwrap();
 
         let platform_id = platform.id.unwrap();
 
@@ -409,16 +429,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_multiple_devices() {
-        let db = setup_db(test_database_path!()).await;
-        let platforms_store = PlatformsStore::new(db.clone());
-        let director = Director::new(db);
+        let (conn, _factory) = setup_db(test_database_path!()).await;
+        let director = Director::new(&conn);
 
         // Create a platform
         let attrs = sample_platform_attributes();
-        let platform = platforms_store
-            .create("Test Platform", Some("Test Description"), &attrs)
-            .await
-            .unwrap();
+        let platform = crate::platforms::store::create(
+            &conn,
+            "Test Platform",
+            Some("Test Description"),
+            &attrs,
+        )
+        .await
+        .unwrap();
 
         let platform_id = platform.id.unwrap();
 
@@ -492,16 +515,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_lifecycle_states() {
-        let db = setup_db(test_database_path!()).await;
-        let platforms_store = PlatformsStore::new(db.clone());
-        let director = Director::new(db);
+        let (conn, _factory) = setup_db(test_database_path!()).await;
+        let director = Director::new(&conn);
 
         // Create a platform
         let attrs = sample_platform_attributes();
-        let platform = platforms_store
-            .create("Test Platform", Some("Test Description"), &attrs)
-            .await
-            .unwrap();
+        let platform = crate::platforms::store::create(
+            &conn,
+            "Test Platform",
+            Some("Test Description"),
+            &attrs,
+        )
+        .await
+        .unwrap();
 
         let platform_id = platform.id.unwrap();
 
@@ -538,8 +564,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_platform_devices_with_details_nonexistent_platform() {
-        let db = setup_db(test_database_path!()).await;
-        let director = Director::new(db);
+        let (conn, _factory) = setup_db(test_database_path!()).await;
+        let director = Director::new(&conn);
 
         // Try to get devices for a nonexistent platform
         let result = director.list_devices_with_platform(999).await;

--- a/rack-director/src/http/ui/roles.rs
+++ b/rack-director/src/http/ui/roles.rs
@@ -24,19 +24,20 @@ async fn create_role(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateRoleRequest>,
 ) -> Result<(StatusCode, Json<Role>), HttpError> {
-    // Verify the OS exists
-    state.os_store.get(req.os_id).await?;
+    let conn = state.connection_factory.open().await?;
 
-    let role = state
-        .roles_store
-        .create(
-            &req.name,
-            req.description.as_deref(),
-            req.os_id,
-            &req.disk_layout,
-            req.config_template.as_ref(),
-        )
-        .await?;
+    // Verify the OS exists
+    crate::operating_systems::store::get(&conn, req.os_id).await?;
+
+    let role = crate::roles::store::create(
+        &conn,
+        &req.name,
+        req.description.as_deref(),
+        req.os_id,
+        &req.disk_layout,
+        req.config_template.as_ref(),
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(role)))
 }
@@ -45,7 +46,8 @@ async fn create_role(
 async fn list_roles(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<RoleWithOs>>, HttpError> {
-    let roles = state.roles_store.list_with_os().await?;
+    let conn = state.connection_factory.open().await?;
+    let roles = crate::roles::store::list_with_os(&conn).await?;
     Ok(Json(roles))
 }
 
@@ -54,7 +56,8 @@ async fn get_role(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<Json<RoleWithOs>, HttpError> {
-    let role = state.roles_store.get_with_os(id).await?;
+    let conn = state.connection_factory.open().await?;
+    let role = crate::roles::store::get_with_os(&conn, id).await?;
     Ok(Json(role))
 }
 
@@ -65,22 +68,23 @@ async fn update_role(
     Path(id): Path<i64>,
     Json(req): Json<UpdateRoleRequest>,
 ) -> Result<Json<Role>, HttpError> {
+    let conn = state.connection_factory.open().await?;
+
     // If updating OS, verify it exists
     if let Some(os_id) = req.os_id {
-        state.os_store.get(os_id).await?;
+        crate::operating_systems::store::get(&conn, os_id).await?;
     }
 
-    let role = state
-        .roles_store
-        .update(
-            id,
-            req.name.as_deref(),
-            req.description.as_deref(),
-            req.os_id,
-            req.disk_layout.as_ref(),
-            req.config_template.as_ref(),
-        )
-        .await?;
+    let role = crate::roles::store::update(
+        &conn,
+        id,
+        req.name.as_deref(),
+        req.description.as_deref(),
+        req.os_id,
+        req.disk_layout.as_ref(),
+        req.config_template.as_ref(),
+    )
+    .await?;
 
     Ok(Json(role))
 }
@@ -90,7 +94,8 @@ async fn delete_role(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, HttpError> {
-    state.roles_store.delete(id).await?;
+    let conn = state.connection_factory.open().await?;
+    crate::roles::store::delete(&conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -99,7 +104,8 @@ async fn list_role_devices(
     State(state): State<Arc<AppState>>,
     Path(role_id): Path<i64>,
 ) -> Result<Json<Vec<String>>, HttpError> {
-    let devices = state.director.list_devices_with_role(role_id).await?;
+    let conn = state.connection_factory.open().await?;
+    let devices = crate::director::store::list_devices_with_role(&conn, role_id).await?;
     let device_strs: Vec<String> = devices.iter().map(|u| u.to_string()).collect();
     Ok(Json(device_strs))
 }

--- a/rack-director/src/http/ui/validation.rs
+++ b/rack-director/src/http/ui/validation.rs
@@ -387,13 +387,12 @@ mod tests {
     use crate::dhcp::DhcpStore;
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
 
     async fn create_test_store() -> (DhcpStore, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let conn = crate::database::open(db_path).unwrap();
-        (DhcpStore::new(Arc::new(Mutex::new(conn))), temp_dir)
+        let db = Arc::new(crate::database::open(db_path).await.unwrap());
+        (DhcpStore::new(db), temp_dir)
     }
 
     // Test generic validators

--- a/rack-director/src/http/ui/validation.rs
+++ b/rack-director/src/http/ui/validation.rs
@@ -165,13 +165,14 @@ impl ValidationErrors {
 // NETWORK-SPECIFIC VALIDATORS
 // ============================================================================
 
+use crate::{database::Connection, dhcp};
+
 use super::networks::{CreateNetworkRequest, UpdateNetworkRequest};
-use crate::dhcp::DhcpStore;
 
 /// Validate create network request using the generic validators
 pub async fn validate_create_network_request(
+    conn: &Connection,
     req: &CreateNetworkRequest,
-    dhcp_store: &DhcpStore,
 ) -> Result<(), HashMap<String, String>> {
     let mut errors = ValidationErrors::new();
 
@@ -183,7 +184,7 @@ pub async fn validate_create_network_request(
     );
 
     // Check for duplicate network name
-    match dhcp_store.get_network_by_name(&req.name).await {
+    match dhcp::store::get_network_by_name(conn, &req.name).await {
         Ok(Some(_)) => {
             errors.add_error(
                 "name",
@@ -235,10 +236,7 @@ pub async fn validate_create_network_request(
         .as_ref()
         .and_then(|r| if r.is_empty() { None } else { Some(r.as_str()) });
 
-    match dhcp_store
-        .get_network_by_relay_string(relay_for_check)
-        .await
-    {
+    match dhcp::store::get_network_by_relay_string(conn, relay_for_check).await {
         Ok(Some(_)) => {
             if relay_for_check.is_none() {
                 errors.add_error(
@@ -264,9 +262,9 @@ pub async fn validate_create_network_request(
 /// Validate update network request using the generic validators
 /// Excludes the network being updated from duplicate checks
 pub async fn validate_update_network_request(
+    conn: &Connection,
     network_id: i64,
     req: &UpdateNetworkRequest,
-    dhcp_store: &DhcpStore,
 ) -> Result<(), HashMap<String, String>> {
     let mut errors = ValidationErrors::new();
 
@@ -276,7 +274,7 @@ pub async fn validate_update_network_request(
         errors.add_if_err("name", validate_string_length(name, 255, "Network name"));
 
         // Check for duplicate network name (excluding current network)
-        match dhcp_store.get_network_by_name(name).await {
+        match dhcp::store::get_network_by_name(conn, name).await {
             Ok(Some(existing_network)) => {
                 if existing_network.id != network_id {
                     errors.add_error(
@@ -295,7 +293,7 @@ pub async fn validate_update_network_request(
     // Validate subnet and gateway together if either is provided
     if req.subnet.is_some() || req.gateway.is_some() {
         // Get the current network to fill in missing values
-        let current_network = match dhcp_store.get_network(network_id).await {
+        let current_network = match dhcp::store::get_network(conn, network_id).await {
             Ok(net) => net,
             Err(e) => {
                 log::warn!("Failed to fetch current network for validation: {}", e);
@@ -348,10 +346,7 @@ pub async fn validate_update_network_request(
             Some(relay.as_str())
         };
 
-        match dhcp_store
-            .get_network_by_relay_string(relay_for_check)
-            .await
-        {
+        match dhcp::store::get_network_by_relay_string(conn, relay_for_check).await {
             Ok(Some(existing_network)) => {
                 if existing_network.id != network_id {
                     if relay_for_check.is_none() {
@@ -383,16 +378,17 @@ pub async fn validate_update_network_request(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::dhcp::DhcpStore;
-    use std::sync::Arc;
-    use tempfile::tempdir;
+    use crate::{database::ConnectionFactory, test_connection_factory};
 
-    async fn create_test_store() -> (DhcpStore, tempfile::TempDir) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(crate::database::open(db_path).await.unwrap());
-        (DhcpStore::new(db), temp_dir)
+    use super::*;
+    use std::sync::Arc;
+
+    async fn create_test_store(factory: Arc<dyn ConnectionFactory>) -> Connection {
+        // Run migrations; drop the returned connection (file-backed DB persists)
+        let conn = crate::database::run_migrations(factory.as_ref())
+            .await
+            .unwrap();
+        conn
     }
 
     // Test generic validators
@@ -453,7 +449,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_valid() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "Test Network".to_string(),
             subnet: "192.168.1.0/24".to_string(),
@@ -464,12 +460,12 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        assert!(validate_create_network_request(&req, &store).await.is_ok());
+        assert!(validate_create_network_request(&conn, &req).await.is_ok());
     }
 
     #[tokio::test]
     async fn test_validate_create_network_request_empty_name() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "".to_string(),
             subnet: "192.168.1.0/24".to_string(),
@@ -480,7 +476,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("name"));
@@ -488,21 +484,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_duplicate_name() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a network with a specific name
-        store
-            .create_network(
-                "Existing Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_network(
+            &conn,
+            "Existing Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Try to create another network with the same name
         let req = CreateNetworkRequest {
@@ -515,7 +511,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("name"));
@@ -524,21 +520,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_duplicate_relay_agent() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a network with a specific relay agent
-        store
-            .create_network(
-                "Network 1",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_network(
+            &conn,
+            "Network 1",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Try to create another network with the same relay agent
         let req = CreateNetworkRequest {
@@ -551,7 +547,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("relay_agent_address"));
@@ -565,21 +561,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_duplicate_local_l2() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a local L2 network (no relay agent) first
-        store
-            .create_network(
-                "Local Network",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                None,
-                false,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_network(
+            &conn,
+            "Local Network",
+            "10.0.0.0/24",
+            "10.0.0.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         // Try to create another local L2 network (no relay agent)
         let req = CreateNetworkRequest {
@@ -592,7 +588,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("relay_agent_address"));
@@ -606,7 +602,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_invalid_subnet() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "Test".to_string(),
             subnet: "invalid".to_string(),
@@ -617,7 +613,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("subnet"));
@@ -625,7 +621,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_gateway_out_of_subnet() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "Test".to_string(),
             subnet: "192.168.1.0/24".to_string(),
@@ -636,7 +632,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("gateway"));
@@ -644,7 +640,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_no_dns() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "Test".to_string(),
             subnet: "192.168.1.0/24".to_string(),
@@ -655,7 +651,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("dns_servers"));
@@ -663,7 +659,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_invalid_lease_duration() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "Test".to_string(),
             subnet: "192.168.1.0/24".to_string(),
@@ -674,7 +670,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("lease_duration"));
@@ -682,7 +678,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_invalid_relay() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "Test".to_string(),
             subnet: "192.168.1.0/24".to_string(),
@@ -693,7 +689,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("relay_agent_address"));
@@ -701,7 +697,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_create_network_request_multiple_errors() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
         let req = CreateNetworkRequest {
             name: "".to_string(),
             subnet: "invalid".to_string(),
@@ -712,7 +708,7 @@ mod tests {
             enable_autodiscovery: false,
         };
 
-        let result = validate_create_network_request(&req, &store).await;
+        let result = validate_create_network_request(&conn, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("name"));
@@ -725,21 +721,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_update_network_request_valid() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a network to update
-        let network = store
-            .create_network(
-                "Original Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        let network = dhcp::store::create_network(
+            &conn,
+            "Original Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
         let req = UpdateNetworkRequest {
             name: Some("Updated Network".to_string()),
@@ -752,7 +748,7 @@ mod tests {
         };
 
         assert!(
-            validate_update_network_request(network.id, &req, &store)
+            validate_update_network_request(&conn, network.id, &req)
                 .await
                 .is_ok()
         );
@@ -760,34 +756,34 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_update_network_request_duplicate_name_different_network() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create two networks
-        let network1 = store
-            .create_network(
-                "Network 1",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        let network1 = dhcp::store::create_network(
+            &conn,
+            "Network 1",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
-        store
-            .create_network(
-                "Network 2",
-                "192.168.2.0/24",
-                "192.168.2.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.3"),
-                false,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_network(
+            &conn,
+            "Network 2",
+            "192.168.2.0/24",
+            "192.168.2.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.3"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Try to update network1 to have the same name as network2
         let req = UpdateNetworkRequest {
@@ -800,7 +796,7 @@ mod tests {
             enable_autodiscovery: None,
         };
 
-        let result = validate_update_network_request(network1.id, &req, &store).await;
+        let result = validate_update_network_request(&conn, network1.id, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("name"));
@@ -812,21 +808,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_update_network_request_same_name_same_network() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a network
-        let network = store
-            .create_network(
-                "Test Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        let network = dhcp::store::create_network(
+            &conn,
+            "Test Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Update with the same name (should be allowed)
         let req = UpdateNetworkRequest {
@@ -840,7 +836,7 @@ mod tests {
         };
 
         assert!(
-            validate_update_network_request(network.id, &req, &store)
+            validate_update_network_request(&conn, network.id, &req)
                 .await
                 .is_ok()
         );
@@ -848,34 +844,34 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_update_network_request_duplicate_relay_agent() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create two networks
-        let network1 = store
-            .create_network(
-                "Network 1",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        let network1 = dhcp::store::create_network(
+            &conn,
+            "Network 1",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
-        store
-            .create_network(
-                "Network 2",
-                "192.168.2.0/24",
-                "192.168.2.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.3"),
-                false,
-            )
-            .await
-            .unwrap();
+        dhcp::store::create_network(
+            &conn,
+            "Network 2",
+            "192.168.2.0/24",
+            "192.168.2.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.3"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Try to update network1 to have the same relay agent as network2
         let req = UpdateNetworkRequest {
@@ -888,7 +884,7 @@ mod tests {
             enable_autodiscovery: None,
         };
 
-        let result = validate_update_network_request(network1.id, &req, &store).await;
+        let result = validate_update_network_request(&conn, network1.id, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("relay_agent_address"));
@@ -896,21 +892,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_update_network_request_same_relay_agent_same_network() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a network
-        let network = store
-            .create_network(
-                "Test Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        let network = dhcp::store::create_network(
+            &conn,
+            "Test Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Update with the same relay agent (should be allowed)
         let req = UpdateNetworkRequest {
@@ -924,7 +920,7 @@ mod tests {
         };
 
         assert!(
-            validate_update_network_request(network.id, &req, &store)
+            validate_update_network_request(&conn, network.id, &req)
                 .await
                 .is_ok()
         );
@@ -932,21 +928,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_update_network_request_gateway_out_of_new_subnet() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a network
-        let network = store
-            .create_network(
-                "Test Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        let network = dhcp::store::create_network(
+            &conn,
+            "Test Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Update subnet to a range that doesn't contain the gateway
         let req = UpdateNetworkRequest {
@@ -959,7 +955,7 @@ mod tests {
             enable_autodiscovery: None,
         };
 
-        let result = validate_update_network_request(network.id, &req, &store).await;
+        let result = validate_update_network_request(&conn, network.id, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("gateway"));
@@ -967,21 +963,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_update_network_request_invalid_dns() {
-        let (store, _temp_dir) = create_test_store().await;
+        let conn = create_test_store(Arc::new(test_connection_factory!())).await;
 
         // Create a network
-        let network = store
-            .create_network(
-                "Test Network",
-                "192.168.1.0/24",
-                "192.168.1.1",
-                &["8.8.8.8".to_string()],
-                86400,
-                Some("10.0.0.2"),
-                false,
-            )
-            .await
-            .unwrap();
+        let network = dhcp::store::create_network(
+            &conn,
+            "Test Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
 
         // Update with invalid DNS
         let req = UpdateNetworkRequest {
@@ -994,7 +990,7 @@ mod tests {
             enable_autodiscovery: None,
         };
 
-        let result = validate_update_network_request(network.id, &req, &store).await;
+        let result = validate_update_network_request(&conn, network.id, &req).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
         assert!(errors.contains_key("dns_servers"));

--- a/rack-director/src/lib.rs
+++ b/rack-director/src/lib.rs
@@ -22,7 +22,7 @@ use anyhow::anyhow;
 use clap::Parser;
 use tokio::task::JoinHandle;
 
-use crate::{director::Director, storage::ImageStore};
+use crate::storage::ImageStore;
 
 const DEFAULT_DATABASE_PATH: &str = env!("RACK_DIRECTOR_DATABASE_PATH");
 const DEFAULT_AGENT_IMAGES_PATH: &str = env!("RACK_DIRECTOR_AGENT_IMAGES_PATH");
@@ -144,13 +144,14 @@ impl RackDirectorHandle {
 pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle, anyhow::Error> {
     let db_file = std::path::PathBuf::from(format!("{}/db.sqlite", args.db_path));
 
-    // HTTP service: one connection shared within the HTTP task
-    let http_db = Arc::new(database::open(db_file.clone()).await?);
-    let os_store = operating_systems::OperatingSystemsStore::new(http_db.clone());
-    let roles_store = roles::RolesStore::new(http_db.clone());
-    let platforms_store = platforms::PlatformsStore::new(http_db.clone());
-    let director: Director = Director::new(http_db.clone());
-    let http_dhcp_store = dhcp::DhcpStore::new(http_db);
+    // Create one shared factory. The factory holds only a PathBuf and opens a
+    // fresh connection on each `.open()` call, so sharing it via Arc::clone
+    // across Director, DhcpStore, DhcpServer, and the HTTP layer is safe.
+    let factory: Arc<dyn database::ConnectionFactory> =
+        Arc::new(database::DatabaseConnectionFactory::new(db_file));
+    // Run migrations once. For a file-backed database the connection can be
+    // dropped immediately after — the schema persists in the file.
+    let _ = database::run_migrations(factory.as_ref()).await?;
 
     // Initialize storage
     let storage_config = build_storage_config(&args)?;
@@ -165,10 +166,8 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
         .http_public_url
         .unwrap_or_else(|| format!("http://{}:{}", server_identifier, args.http_address.port()));
 
-    // Cleanup task: its own connection
-    let cleanup_db = Arc::new(database::open(db_file.clone()).await?);
-    let cleanup_store = dhcp::DhcpStore::new(cleanup_db);
-    let lease_cleanup_handle = dhcp::spawn_lease_cleanup_task(cleanup_store);
+    // Cleanup task uses the shared factory.
+    let lease_cleanup_handle = dhcp::spawn_lease_cleanup_task(factory.clone());
 
     // Determine TFTP public address
     let tftp_public = args.tftp_public_address.unwrap_or_else(|| {
@@ -187,13 +186,9 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
         std::path::PathBuf::from(&args.tftp_path),
     )?);
 
-    // DHCP server: its own connection
-    let dhcp_db = Arc::new(database::open(db_file).await?);
-
-    let dhcp_server = dhcp::DhcpServer::new(
-        dhcp_db,
-        director.clone(),
-        tftp_public,
+    let dhcp_server: dhcp::DhcpServer = dhcp::DhcpServer::new(
+        factory.clone(),
+        tftp_public.clone(),
         http_server,
         boot_file_provider.clone(),
         server_identifier,
@@ -206,16 +201,13 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
     let mut tftp_server = tftp::Server::new(boot_file_provider.clone());
     tftp_server.address(args.tftp_address);
 
-    // Start HTTP Service
+    // Start HTTP Service — each HTTP handler opens its own connection via the
+    // shared factory, keeping it independent of DHCP and Director connections.
     let http_start_result = http::start(
-        director.clone(),
-        http_dhcp_store,
+        factory.clone(),
         image_store.into(),
-        os_store,
-        roles_store,
-        platforms_store,
         args.http_address,
-        args.agent_images_path,
+        std::path::PathBuf::from(&args.agent_images_path),
         boot_file_provider,
     )
     .await?;

--- a/rack-director/src/lib.rs
+++ b/rack-director/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
 
 use anyhow::anyhow;
 use clap::Parser;
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::task::JoinHandle;
 
 use crate::{director::Director, storage::ImageStore};
 
@@ -142,14 +142,15 @@ impl RackDirectorHandle {
 }
 
 pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle, anyhow::Error> {
-    // Initialize database connection
-    let db_file = format!("{}/db.sqlite", args.db_path);
-    let db = Arc::new(Mutex::new(database::open(&db_file).unwrap()));
+    let db_file = std::path::PathBuf::from(format!("{}/db.sqlite", args.db_path));
 
-    // Initialize individual stores
-    let os_store = operating_systems::OperatingSystemsStore::new(db.clone());
-    let roles_store = roles::RolesStore::new(db.clone());
-    let platforms_store = platforms::PlatformsStore::new(db.clone());
+    // HTTP service: one connection shared within the HTTP task
+    let http_db = Arc::new(database::open(db_file.clone()).await?);
+    let os_store = operating_systems::OperatingSystemsStore::new(http_db.clone());
+    let roles_store = roles::RolesStore::new(http_db.clone());
+    let platforms_store = platforms::PlatformsStore::new(http_db.clone());
+    let director: Director = Director::new(http_db.clone());
+    let http_dhcp_store = dhcp::DhcpStore::new(http_db);
 
     // Initialize storage
     let storage_config = build_storage_config(&args)?;
@@ -163,11 +164,11 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
     let public_url = args
         .http_public_url
         .unwrap_or_else(|| format!("http://{}:{}", server_identifier, args.http_address.port()));
-    let director: Director = Director::new(db.clone());
 
-    // Initialize DHCP server and store
-    let dhcp_store = dhcp::DhcpStore::new(db.clone());
-    let lease_cleanup_handle = dhcp::spawn_lease_cleanup_task(dhcp_store.clone());
+    // Cleanup task: its own connection
+    let cleanup_db = Arc::new(database::open(db_file.clone()).await?);
+    let cleanup_store = dhcp::DhcpStore::new(cleanup_db);
+    let lease_cleanup_handle = dhcp::spawn_lease_cleanup_task(cleanup_store);
 
     // Determine TFTP public address
     let tftp_public = args.tftp_public_address.unwrap_or_else(|| {
@@ -186,8 +187,11 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
         std::path::PathBuf::from(&args.tftp_path),
     )?);
 
+    // DHCP server: its own connection
+    let dhcp_db = Arc::new(database::open(db_file).await?);
+
     let dhcp_server = dhcp::DhcpServer::new(
-        db.clone(),
+        dhcp_db,
         director.clone(),
         tftp_public,
         http_server,
@@ -205,7 +209,7 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
     // Start HTTP Service
     let http_start_result = http::start(
         director.clone(),
-        dhcp_store,
+        http_dhcp_store,
         image_store.into(),
         os_store,
         roles_store,

--- a/rack-director/src/lifecycle/mod.rs
+++ b/rack-director/src/lifecycle/mod.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 use crate::database::FromRow;
 
 pub mod store;
-pub use store::LifecycleStore;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]

--- a/rack-director/src/lifecycle/store.rs
+++ b/rack-director/src/lifecycle/store.rs
@@ -2,26 +2,39 @@ use std::sync::Arc;
 
 use crate::lifecycle::{DeviceLifecycle, LifecycleTransition};
 use anyhow::Result;
-use rusqlite::{Connection, params};
-use tokio::sync::Mutex;
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
+
+use crate::database::{Connection, FromRow};
 
 #[derive(Clone)]
 pub struct LifecycleStore {
-    conn: Arc<Mutex<rusqlite::Connection>>,
+    db: Arc<Connection>,
 }
 
 impl LifecycleStore {
-    pub fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
-        Self { conn }
+    pub fn new(db: Arc<Connection>) -> Self {
+        Self { db }
     }
 
     pub async fn get_device_lifecycle(
         &self,
         device_uuid: &Uuid,
     ) -> Result<Option<DeviceLifecycle>> {
-        let conn = self.conn.lock().await;
-        self.get_device_lifecycle_internal(&conn, device_uuid)
+        let result = self
+            .db
+            .query_row(
+                "SELECT lifecycle FROM devices WHERE uuid = ?1",
+                (*device_uuid,),
+                |row| {
+                    let lifecycle_str: String = row.get(0)?;
+                    Ok(DeviceLifecycle::from(lifecycle_str))
+                },
+            )
+            .await
+            .optional()?;
+
+        Ok(result)
     }
 
     pub async fn update_device_lifecycle(
@@ -29,21 +42,51 @@ impl LifecycleStore {
         device_uuid: &Uuid,
         lifecycle: DeviceLifecycle,
     ) -> Result<()> {
-        let conn = self.conn.lock().await;
-        self.update_device_lifecycle_internal(&conn, device_uuid, lifecycle)
+        let lifecycle_str: String = lifecycle.into();
+        self.db
+            .execute(
+                "UPDATE devices SET lifecycle = ?1 WHERE uuid = ?2",
+                (lifecycle_str, *device_uuid),
+            )
+            .await?;
+
+        Ok(())
     }
 
     pub async fn create_transition(&self, transition: &LifecycleTransition) -> Result<i64> {
-        let conn = self.conn.lock().await;
-        self.create_transition_internal(&conn, transition)
+        let from_state_str: String = transition.from_state.clone().into();
+        let to_state_str: String = transition.to_state.clone().into();
+
+        self.db
+            .execute(
+                "INSERT INTO lifecycle_transitions (device_uuid, from_state, to_state, plan_id, created_at)
+                 VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)",
+                (transition.device_uuid, from_state_str, to_state_str, transition.plan_id),
+            )
+            .await?;
+
+        Ok(self.db.last_insert_rowid().await)
     }
 
     pub async fn get_active_transition_for_device(
         &self,
         device_uuid: &Uuid,
     ) -> Result<Option<LifecycleTransition>> {
-        let conn = self.conn.lock().await;
-        self.get_active_transition_for_device_internal(&conn, device_uuid)
+        let transition = self
+            .db
+            .query_row(
+                "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
+                 FROM lifecycle_transitions
+                 WHERE device_uuid = ?1 AND success IS NULL
+                 ORDER BY created_at DESC
+                 LIMIT 1",
+                (*device_uuid,),
+                LifecycleTransition::from_row,
+            )
+            .await
+            .optional()?;
+
+        Ok(transition)
     }
 
     pub async fn complete_transition(
@@ -52,120 +95,18 @@ impl LifecycleStore {
         success: bool,
         error_message: Option<&str>,
     ) -> Result<()> {
-        let conn = self.conn.lock().await;
-        self.complete_transition_internal(&conn, transition_id, success, error_message)
+        self.db
+            .execute(
+                "UPDATE lifecycle_transitions SET success = ?1, error_message = ?2, completed_at = CURRENT_TIMESTAMP WHERE id = ?3",
+                (success, error_message.map(|s| s.to_string()), transition_id),
+            )
+            .await?;
+
+        Ok(())
     }
 
     pub async fn get_transitions_for_device(
         &self,
-        device_uuid: &Uuid,
-        include_completed: bool,
-    ) -> Result<Vec<LifecycleTransition>> {
-        let conn = self.conn.lock().await;
-        self.get_transitions_for_device_internal(&conn, device_uuid, include_completed)
-    }
-
-    pub async fn get_transition_by_plan_id(
-        &self,
-        plan_id: i64,
-    ) -> Result<Option<LifecycleTransition>> {
-        let conn = self.conn.lock().await;
-        self.get_transition_by_plan_id_internal(&conn, plan_id)
-    }
-
-    fn get_device_lifecycle_internal(
-        &self,
-        conn: &Connection,
-        device_uuid: &Uuid,
-    ) -> Result<Option<DeviceLifecycle>> {
-        let mut stmt = conn.prepare("SELECT lifecycle FROM devices WHERE uuid = ?1")?;
-
-        let mut rows = stmt.query_map([device_uuid], |row| {
-            let lifecycle_str: String = row.get(0)?;
-            Ok(DeviceLifecycle::from(lifecycle_str))
-        })?;
-
-        if let Some(lifecycle_result) = rows.next() {
-            return Ok(Some(lifecycle_result?));
-        }
-
-        Ok(None)
-    }
-
-    fn update_device_lifecycle_internal(
-        &self,
-        conn: &Connection,
-        device_uuid: &Uuid,
-        lifecycle: DeviceLifecycle,
-    ) -> Result<()> {
-        let lifecycle_str: String = lifecycle.into();
-
-        conn.execute(
-            "UPDATE devices SET lifecycle = ?1 WHERE uuid = ?2",
-            params![&lifecycle_str, device_uuid],
-        )?;
-
-        Ok(())
-    }
-
-    fn create_transition_internal(
-        &self,
-        conn: &Connection,
-        transition: &LifecycleTransition,
-    ) -> Result<i64> {
-        let from_state_str: String = transition.from_state.clone().into();
-        let to_state_str: String = transition.to_state.clone().into();
-
-        conn.execute(
-            "INSERT INTO lifecycle_transitions (device_uuid, from_state, to_state, plan_id, created_at)
-             VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)",
-            rusqlite::params![
-                transition.device_uuid,
-                from_state_str,
-                to_state_str,
-                transition.plan_id
-            ],
-        )?;
-
-        Ok(conn.last_insert_rowid())
-    }
-
-    fn get_active_transition_for_device_internal(
-        &self,
-        conn: &Connection,
-        device_uuid: &Uuid,
-    ) -> Result<Option<LifecycleTransition>> {
-        let transition = crate::database::query_optional::<LifecycleTransition>(
-            conn,
-            "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
-             FROM lifecycle_transitions
-             WHERE device_uuid = ?1 AND success IS NULL
-             ORDER BY created_at DESC
-             LIMIT 1",
-            &[device_uuid],
-        )?;
-
-        Ok(transition)
-    }
-
-    fn complete_transition_internal(
-        &self,
-        conn: &Connection,
-        transition_id: i64,
-        success: bool,
-        error_message: Option<&str>,
-    ) -> Result<()> {
-        conn.execute(
-            "UPDATE lifecycle_transitions SET success = ?1, error_message = ?2, completed_at = CURRENT_TIMESTAMP WHERE id = ?3",
-            rusqlite::params![success, error_message, transition_id],
-        )?;
-
-        Ok(())
-    }
-
-    fn get_transitions_for_device_internal(
-        &self,
-        conn: &Connection,
         device_uuid: &Uuid,
         include_completed: bool,
     ) -> Result<Vec<LifecycleTransition>> {
@@ -181,24 +122,29 @@ impl LifecycleStore {
              ORDER BY created_at DESC"
         };
 
-        let transitions =
-            crate::database::query_map_all::<LifecycleTransition>(conn, query, &[device_uuid])?;
+        let transitions = self
+            .db
+            .query(query, (*device_uuid,), LifecycleTransition::from_row)
+            .await?;
 
         Ok(transitions)
     }
 
-    fn get_transition_by_plan_id_internal(
+    pub async fn get_transition_by_plan_id(
         &self,
-        conn: &Connection,
         plan_id: i64,
     ) -> Result<Option<LifecycleTransition>> {
-        let transition = crate::database::query_optional::<LifecycleTransition>(
-            conn,
-            "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
-             FROM lifecycle_transitions
-             WHERE plan_id = ?1",
-            &[&plan_id],
-        )?;
+        let transition = self
+            .db
+            .query_row(
+                "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
+                 FROM lifecycle_transitions
+                 WHERE plan_id = ?1",
+                (plan_id,),
+                LifecycleTransition::from_row,
+            )
+            .await
+            .optional()?;
 
         Ok(transition)
     }

--- a/rack-director/src/lifecycle/store.rs
+++ b/rack-director/src/lifecycle/store.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::lifecycle::{DeviceLifecycle, LifecycleTransition};
 use anyhow::Result;
 use rusqlite::OptionalExtension;
@@ -7,145 +5,132 @@ use uuid::Uuid;
 
 use crate::database::{Connection, FromRow};
 
-#[derive(Clone)]
-pub struct LifecycleStore {
-    db: Arc<Connection>,
+pub async fn get_device_lifecycle(
+    conn: &Connection,
+    device_uuid: &Uuid,
+) -> Result<Option<DeviceLifecycle>> {
+    let result = conn
+        .query_row(
+            "SELECT lifecycle FROM devices WHERE uuid = ?1",
+            (*device_uuid,),
+            |row| {
+                let lifecycle_str: String = row.get(0)?;
+                Ok(DeviceLifecycle::from(lifecycle_str))
+            },
+        )
+        .await
+        .optional()?;
+
+    Ok(result)
 }
 
-impl LifecycleStore {
-    pub fn new(db: Arc<Connection>) -> Self {
-        Self { db }
-    }
+pub async fn update_device_lifecycle(
+    conn: &Connection,
+    device_uuid: &Uuid,
+    lifecycle: DeviceLifecycle,
+) -> Result<()> {
+    let lifecycle_str: String = lifecycle.into();
+    conn.execute(
+        "UPDATE devices SET lifecycle = ?1 WHERE uuid = ?2",
+        (lifecycle_str, *device_uuid),
+    )
+    .await?;
 
-    pub async fn get_device_lifecycle(
-        &self,
-        device_uuid: &Uuid,
-    ) -> Result<Option<DeviceLifecycle>> {
-        let result = self
-            .db
-            .query_row(
-                "SELECT lifecycle FROM devices WHERE uuid = ?1",
-                (*device_uuid,),
-                |row| {
-                    let lifecycle_str: String = row.get(0)?;
-                    Ok(DeviceLifecycle::from(lifecycle_str))
-                },
-            )
-            .await
-            .optional()?;
+    Ok(())
+}
 
-        Ok(result)
-    }
+pub async fn create_transition(conn: &Connection, transition: &LifecycleTransition) -> Result<i64> {
+    let from_state_str: String = transition.from_state.clone().into();
+    let to_state_str: String = transition.to_state.clone().into();
 
-    pub async fn update_device_lifecycle(
-        &self,
-        device_uuid: &Uuid,
-        lifecycle: DeviceLifecycle,
-    ) -> Result<()> {
-        let lifecycle_str: String = lifecycle.into();
-        self.db
-            .execute(
-                "UPDATE devices SET lifecycle = ?1 WHERE uuid = ?2",
-                (lifecycle_str, *device_uuid),
-            )
-            .await?;
+    conn.execute(
+        "INSERT INTO lifecycle_transitions (device_uuid, from_state, to_state, plan_id, created_at)
+         VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)",
+        (
+            transition.device_uuid,
+            from_state_str,
+            to_state_str,
+            transition.plan_id,
+        ),
+    )
+    .await?;
 
-        Ok(())
-    }
+    Ok(conn.last_insert_rowid().await)
+}
 
-    pub async fn create_transition(&self, transition: &LifecycleTransition) -> Result<i64> {
-        let from_state_str: String = transition.from_state.clone().into();
-        let to_state_str: String = transition.to_state.clone().into();
-
-        self.db
-            .execute(
-                "INSERT INTO lifecycle_transitions (device_uuid, from_state, to_state, plan_id, created_at)
-                 VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)",
-                (transition.device_uuid, from_state_str, to_state_str, transition.plan_id),
-            )
-            .await?;
-
-        Ok(self.db.last_insert_rowid().await)
-    }
-
-    pub async fn get_active_transition_for_device(
-        &self,
-        device_uuid: &Uuid,
-    ) -> Result<Option<LifecycleTransition>> {
-        let transition = self
-            .db
-            .query_row(
-                "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
-                 FROM lifecycle_transitions
-                 WHERE device_uuid = ?1 AND success IS NULL
-                 ORDER BY created_at DESC
-                 LIMIT 1",
-                (*device_uuid,),
-                LifecycleTransition::from_row,
-            )
-            .await
-            .optional()?;
-
-        Ok(transition)
-    }
-
-    pub async fn complete_transition(
-        &self,
-        transition_id: i64,
-        success: bool,
-        error_message: Option<&str>,
-    ) -> Result<()> {
-        self.db
-            .execute(
-                "UPDATE lifecycle_transitions SET success = ?1, error_message = ?2, completed_at = CURRENT_TIMESTAMP WHERE id = ?3",
-                (success, error_message.map(|s| s.to_string()), transition_id),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn get_transitions_for_device(
-        &self,
-        device_uuid: &Uuid,
-        include_completed: bool,
-    ) -> Result<Vec<LifecycleTransition>> {
-        let query = if include_completed {
-            "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
-             FROM lifecycle_transitions
-             WHERE device_uuid = ?1
-             ORDER BY created_at DESC"
-        } else {
+pub async fn get_active_transition_for_device(
+    conn: &Connection,
+    device_uuid: &Uuid,
+) -> Result<Option<LifecycleTransition>> {
+    let transition = conn
+        .query_row(
             "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
              FROM lifecycle_transitions
              WHERE device_uuid = ?1 AND success IS NULL
-             ORDER BY created_at DESC"
-        };
+             ORDER BY created_at DESC
+             LIMIT 1",
+            (*device_uuid,),
+            LifecycleTransition::from_row,
+        )
+        .await
+        .optional()?;
 
-        let transitions = self
-            .db
-            .query(query, (*device_uuid,), LifecycleTransition::from_row)
-            .await?;
+    Ok(transition)
+}
 
-        Ok(transitions)
-    }
+pub async fn complete_transition(
+    conn: &Connection,
+    transition_id: i64,
+    success: bool,
+    error_message: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE lifecycle_transitions SET success = ?1, error_message = ?2, completed_at = CURRENT_TIMESTAMP WHERE id = ?3",
+        (success, error_message.map(|s| s.to_string()), transition_id),
+    )
+    .await?;
 
-    pub async fn get_transition_by_plan_id(
-        &self,
-        plan_id: i64,
-    ) -> Result<Option<LifecycleTransition>> {
-        let transition = self
-            .db
-            .query_row(
-                "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
-                 FROM lifecycle_transitions
-                 WHERE plan_id = ?1",
-                (plan_id,),
-                LifecycleTransition::from_row,
-            )
-            .await
-            .optional()?;
+    Ok(())
+}
 
-        Ok(transition)
-    }
+pub async fn get_transitions_for_device(
+    conn: &Connection,
+    device_uuid: &Uuid,
+    include_completed: bool,
+) -> Result<Vec<LifecycleTransition>> {
+    let query = if include_completed {
+        "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
+         FROM lifecycle_transitions
+         WHERE device_uuid = ?1
+         ORDER BY created_at DESC"
+    } else {
+        "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
+         FROM lifecycle_transitions
+         WHERE device_uuid = ?1 AND success IS NULL
+         ORDER BY created_at DESC"
+    };
+
+    let transitions = conn
+        .query(query, (*device_uuid,), LifecycleTransition::from_row)
+        .await?;
+
+    Ok(transitions)
+}
+
+pub async fn get_transition_by_plan_id(
+    conn: &Connection,
+    plan_id: i64,
+) -> Result<Option<LifecycleTransition>> {
+    let transition = conn
+        .query_row(
+            "SELECT id, device_uuid, from_state, to_state, plan_id, created_at, completed_at, success, error_message
+             FROM lifecycle_transitions
+             WHERE plan_id = ?1",
+            (plan_id,),
+            LifecycleTransition::from_row,
+        )
+        .await
+        .optional()?;
+
+    Ok(transition)
 }

--- a/rack-director/src/operating_systems/mod.rs
+++ b/rack-director/src/operating_systems/mod.rs
@@ -1,7 +1,5 @@
 pub mod store;
 
-pub use store::OperatingSystemsStore;
-
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/rack-director/src/operating_systems/store.rs
+++ b/rack-director/src/operating_systems/store.rs
@@ -1,12 +1,12 @@
 use super::{Architecture, OperatingSystem, OsArchitecture};
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use rusqlite::{Connection, params};
 use serde::Serialize;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
-/// Complete operating system with all architecture configurations
+use crate::database::Connection;
+
+/// Complete operating system with all architecture configurations.
 #[derive(Debug, Serialize)]
 pub struct OperatingSystemWithArchitectures {
     #[serde(flatten)]
@@ -16,32 +16,39 @@ pub struct OperatingSystemWithArchitectures {
 
 #[derive(Clone)]
 pub struct OperatingSystemsStore {
-    db: Arc<Mutex<Connection>>,
+    db: Arc<Connection>,
 }
 
 impl OperatingSystemsStore {
-    pub fn new(db: Arc<Mutex<Connection>>) -> Self {
+    pub fn new(db: Arc<Connection>) -> Self {
         Self { db }
     }
 
-    /// Create a new operating system
+    /// Create a new operating system.
     pub async fn create(
         &self,
         name: &str,
         version: &str,
         description: Option<&str>,
     ) -> Result<OperatingSystem> {
-        let conn = self.db.lock().await;
         let now = Utc::now();
 
-        conn.execute(
-            "INSERT INTO operating_systems (name, version, description, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![name, version, description, now, now],
-        )
-        .context("Failed to insert operating system")?;
+        self.db
+            .execute(
+                "INSERT INTO operating_systems (name, version, description, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                (
+                    name.to_string(),
+                    version.to_string(),
+                    description.map(|s| s.to_string()),
+                    now,
+                    now,
+                ),
+            )
+            .await
+            .context("Failed to insert operating system")?;
 
-        let id = conn.last_insert_rowid();
+        let id = self.db.last_insert_rowid().await;
 
         Ok(OperatingSystem {
             id: Some(id),
@@ -53,32 +60,32 @@ impl OperatingSystemsStore {
         })
     }
 
-    /// Get an operating system by ID
+    /// Get an operating system by ID.
     pub async fn get(&self, id: i64) -> Result<OperatingSystem> {
-        let conn = self.db.lock().await;
-
-        let mut stmt = conn.prepare(
-            "SELECT id, name, version, description, created_at, updated_at
-             FROM operating_systems WHERE id = ?1",
-        )?;
-
-        let os = stmt
-            .query_row(params![id], |row| {
-                Ok(OperatingSystem {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    version: row.get(2)?,
-                    description: row.get(3)?,
-                    created_at: row.get(4)?,
-                    updated_at: row.get(5)?,
-                })
-            })
+        let os = self
+            .db
+            .query_one(
+                "SELECT id, name, version, description, created_at, updated_at
+                 FROM operating_systems WHERE id = ?1",
+                (id,),
+                |row| {
+                    Ok(OperatingSystem {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        version: row.get(2)?,
+                        description: row.get(3)?,
+                        created_at: row.get(4)?,
+                        updated_at: row.get(5)?,
+                    })
+                },
+            )
+            .await
             .context("Operating system not found")?;
 
         Ok(os)
     }
 
-    /// Get an operating system with all its architecture configurations
+    /// Get an operating system with all its architecture configurations.
     pub async fn get_with_architectures(
         &self,
         id: i64,
@@ -89,35 +96,31 @@ impl OperatingSystemsStore {
         Ok(OperatingSystemWithArchitectures { os, architectures })
     }
 
-    /// List all operating systems
+    /// List all operating systems.
     pub async fn list(&self) -> Result<Vec<OperatingSystem>> {
-        let conn = self.db.lock().await;
-
-        let mut stmt = conn.prepare(
-            "SELECT id, name, version, description, created_at, updated_at
-             FROM operating_systems ORDER BY name, version",
-        )?;
-
-        let rows = stmt.query_map(params![], |row| {
-            Ok(OperatingSystem {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                version: row.get(2)?,
-                description: row.get(3)?,
-                created_at: row.get(4)?,
-                updated_at: row.get(5)?,
-            })
-        })?;
-
-        let mut systems = Vec::new();
-        for row in rows {
-            systems.push(row?);
-        }
+        let systems = self
+            .db
+            .query(
+                "SELECT id, name, version, description, created_at, updated_at
+                 FROM operating_systems ORDER BY name, version",
+                (),
+                |row| {
+                    Ok(OperatingSystem {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        version: row.get(2)?,
+                        description: row.get(3)?,
+                        created_at: row.get(4)?,
+                        updated_at: row.get(5)?,
+                    })
+                },
+            )
+            .await?;
 
         Ok(systems)
     }
 
-    /// Update an operating system
+    /// Update an operating system.
     pub async fn update(
         &self,
         id: i64,
@@ -125,57 +128,50 @@ impl OperatingSystemsStore {
         version: Option<&str>,
         description: Option<&str>,
     ) -> Result<OperatingSystem> {
-        let needs_update = {
-            let conn = self.db.lock().await;
-            let now = Utc::now();
+        let now = Utc::now();
 
-            // Build dynamic update query
-            let mut updates = Vec::new();
-            let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        let mut updates = Vec::new();
+        let mut values: Vec<rusqlite::types::Value> = Vec::new();
 
-            if let Some(name) = name {
-                updates.push("name = ?");
-                params.push(Box::new(name.to_string()));
-            }
-            if let Some(version) = version {
-                updates.push("version = ?");
-                params.push(Box::new(version.to_string()));
-            }
-            if let Some(description) = description {
-                updates.push("description = ?");
-                params.push(Box::new(description.to_string()));
-            }
+        if let Some(name) = name {
+            updates.push("name = ?");
+            values.push(rusqlite::types::Value::Text(name.to_string()));
+        }
+        if let Some(version) = version {
+            updates.push("version = ?");
+            values.push(rusqlite::types::Value::Text(version.to_string()));
+        }
+        if let Some(description) = description {
+            updates.push("description = ?");
+            values.push(rusqlite::types::Value::Text(description.to_string()));
+        }
 
-            if updates.is_empty() {
-                false
-            } else {
-                updates.push("updated_at = ?");
-                params.push(Box::new(now));
-                params.push(Box::new(id));
-
-                let query = format!(
-                    "UPDATE operating_systems SET {} WHERE id = ?",
-                    updates.join(", ")
-                );
-
-                conn.execute(&query, rusqlite::params_from_iter(params.iter()))?;
-                true
-            }
-        };
-
-        if !needs_update {
+        if updates.is_empty() {
             return self.get(id).await;
         }
+
+        updates.push("updated_at = ?");
+        values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
+        values.push(rusqlite::types::Value::Integer(id));
+
+        let query = format!(
+            "UPDATE operating_systems SET {} WHERE id = ?",
+            updates.join(", ")
+        );
+
+        self.db
+            .execute(query, rusqlite::params_from_iter(values))
+            .await?;
 
         self.get(id).await
     }
 
-    /// Delete an operating system (and all its architectures due to CASCADE)
+    /// Delete an operating system (and all its architectures due to CASCADE).
     pub async fn delete(&self, id: i64) -> Result<()> {
-        let conn = self.db.lock().await;
-
-        let rows_affected = conn
-            .execute("DELETE FROM operating_systems WHERE id = ?1", params![id])
+        let rows_affected = self
+            .db
+            .execute("DELETE FROM operating_systems WHERE id = ?1", (id,))
+            .await
             .context("Failed to delete operating system")?;
 
         if rows_affected == 0 {
@@ -185,7 +181,7 @@ impl OperatingSystemsStore {
         Ok(())
     }
 
-    /// Create or update an architecture configuration for an OS
+    /// Create or update an architecture configuration for an OS.
     #[allow(clippy::too_many_arguments)]
     pub async fn upsert_architecture(
         &self,
@@ -197,13 +193,12 @@ impl OperatingSystemsStore {
         cmdline_args: Option<&str>,
         install_script_path: Option<&str>,
     ) -> Result<OsArchitecture> {
-        {
-            let conn = self.db.lock().await;
-            let now = Utc::now();
-            let modules_json = serde_json::to_string(&modules)?;
-            let arch_str = architecture.as_str();
+        let now = Utc::now();
+        let modules_json = serde_json::to_string(&modules)?;
+        let arch_str = architecture.as_str().to_string();
 
-            conn.execute(
+        self.db
+            .execute(
                 "INSERT INTO os_architectures
                  (os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, created_at, updated_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
@@ -214,106 +209,102 @@ impl OperatingSystemsStore {
                  cmdline_args = ?6,
                  install_script_path = ?7,
                  updated_at = ?9",
-                params![
+                (
                     os_id,
                     arch_str,
-                    kernel_path,
-                    initramfs_path,
+                    kernel_path.to_string(),
+                    initramfs_path.to_string(),
                     modules_json,
-                    cmdline_args,
-                    install_script_path,
+                    cmdline_args.map(|s| s.to_string()),
+                    install_script_path.map(|s| s.to_string()),
                     now,
-                    now
-                ],
+                    now,
+                ),
             )
+            .await
             .context("Failed to upsert OS architecture")?;
-            // Lock is automatically dropped here
-        }
 
         self.get_architecture(os_id, architecture).await
     }
 
-    /// Get a specific architecture configuration
+    /// Get a specific architecture configuration.
     pub async fn get_architecture(
         &self,
         os_id: i64,
         architecture: Architecture,
     ) -> Result<OsArchitecture> {
-        let conn = self.db.lock().await;
-        let arch_str = architecture.as_str();
+        let arch_str = architecture.as_str().to_string();
 
-        let mut stmt = conn.prepare(
-            "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
-             FROM os_architectures WHERE os_id = ?1 AND architecture = ?2",
-        )?;
+        let arch = self
+            .db
+            .query_one(
+                "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
+                 FROM os_architectures WHERE os_id = ?1 AND architecture = ?2",
+                (os_id, arch_str),
+                move |row| {
+                    let modules_json: String = row.get(5)?;
+                    let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
 
-        let arch = stmt
-            .query_row(params![os_id, arch_str], |row| {
-                let modules_json: String = row.get(5)?;
-                let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
-
-                Ok(OsArchitecture {
-                    id: row.get(0)?,
-                    os_id: row.get(1)?,
-                    architecture,
-                    kernel_path: row.get(3)?,
-                    initramfs_path: row.get(4)?,
-                    modules,
-                    cmdline_args: row.get(6)?,
-                    install_script_path: row.get(7)?,
-                    kernel_filename: row.get(8)?,
-                    initramfs_filename: row.get(9)?,
-                    install_script_filename: row.get(10)?,
-                    created_at: row.get(11)?,
-                    updated_at: row.get(12)?,
-                })
-            })
+                    Ok(OsArchitecture {
+                        id: row.get(0)?,
+                        os_id: row.get(1)?,
+                        architecture,
+                        kernel_path: row.get(3)?,
+                        initramfs_path: row.get(4)?,
+                        modules,
+                        cmdline_args: row.get(6)?,
+                        install_script_path: row.get(7)?,
+                        kernel_filename: row.get(8)?,
+                        initramfs_filename: row.get(9)?,
+                        install_script_filename: row.get(10)?,
+                        created_at: row.get(11)?,
+                        updated_at: row.get(12)?,
+                    })
+                },
+            )
+            .await
             .context("OS architecture not found")?;
 
         Ok(arch)
     }
 
-    /// List all architecture configurations for an OS
+    /// List all architecture configurations for an OS.
     pub async fn list_architectures(&self, os_id: i64) -> Result<Vec<OsArchitecture>> {
-        let conn = self.db.lock().await;
+        let architectures = self
+            .db
+            .query(
+                "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
+                 FROM os_architectures WHERE os_id = ?1 ORDER BY architecture",
+                (os_id,),
+                |row| {
+                    let arch_str: String = row.get(2)?;
+                    let architecture = Architecture::from_str(&arch_str).unwrap();
+                    let modules_json: String = row.get(5)?;
+                    let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
 
-        let mut stmt = conn.prepare(
-            "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
-             FROM os_architectures WHERE os_id = ?1 ORDER BY architecture",
-        )?;
-
-        let rows = stmt.query_map(params![os_id], |row| {
-            let arch_str: String = row.get(2)?;
-            let architecture = Architecture::from_str(&arch_str).unwrap();
-            let modules_json: String = row.get(5)?;
-            let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
-
-            Ok(OsArchitecture {
-                id: row.get(0)?,
-                os_id: row.get(1)?,
-                architecture,
-                kernel_path: row.get(3)?,
-                initramfs_path: row.get(4)?,
-                modules,
-                cmdline_args: row.get(6)?,
-                install_script_path: row.get(7)?,
-                kernel_filename: row.get(8)?,
-                initramfs_filename: row.get(9)?,
-                install_script_filename: row.get(10)?,
-                created_at: row.get(11)?,
-                updated_at: row.get(12)?,
-            })
-        })?;
-
-        let mut architectures = Vec::new();
-        for row in rows {
-            architectures.push(row?);
-        }
+                    Ok(OsArchitecture {
+                        id: row.get(0)?,
+                        os_id: row.get(1)?,
+                        architecture,
+                        kernel_path: row.get(3)?,
+                        initramfs_path: row.get(4)?,
+                        modules,
+                        cmdline_args: row.get(6)?,
+                        install_script_path: row.get(7)?,
+                        kernel_filename: row.get(8)?,
+                        initramfs_filename: row.get(9)?,
+                        install_script_filename: row.get(10)?,
+                        created_at: row.get(11)?,
+                        updated_at: row.get(12)?,
+                    })
+                },
+            )
+            .await?;
 
         Ok(architectures)
     }
 
-    /// Update specific fields of an OS architecture
+    /// Update specific fields of an OS architecture.
     pub async fn update_architecture_field(
         &self,
         os_id: i64,
@@ -321,32 +312,35 @@ impl OperatingSystemsStore {
         field: &str,
         value: &str,
     ) -> Result<OsArchitecture> {
-        let conn = self.db.lock().await;
         let now = Utc::now();
-        let arch_str = architecture.as_str();
+        let arch_str = architecture.as_str().to_string();
+        let field = field.to_string();
+        let value = value.to_string();
 
         let query = format!(
             "UPDATE os_architectures SET {} = ?1, updated_at = ?2 WHERE os_id = ?3 AND architecture = ?4",
             field
         );
 
-        conn.execute(&query, params![value, now, os_id, arch_str])
+        self.db
+            .execute(query, (value, now, os_id, arch_str))
+            .await
             .context("Failed to update OS architecture")?;
 
-        drop(conn);
         self.get_architecture(os_id, architecture).await
     }
 
-    /// Delete an architecture configuration
+    /// Delete an architecture configuration.
     pub async fn delete_architecture(&self, os_id: i64, architecture: Architecture) -> Result<()> {
-        let conn = self.db.lock().await;
-        let arch_str = architecture.as_str();
+        let arch_str = architecture.as_str().to_string();
 
-        let rows_affected = conn
+        let rows_affected = self
+            .db
             .execute(
                 "DELETE FROM os_architectures WHERE os_id = ?1 AND architecture = ?2",
-                params![os_id, arch_str],
+                (os_id, arch_str),
             )
+            .await
             .context("Failed to delete OS architecture")?;
 
         if rows_affected == 0 {
@@ -359,18 +353,17 @@ impl OperatingSystemsStore {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::database;
+    use crate::test_database_path;
 
-    fn setup_db() -> Arc<Mutex<Connection>> {
-        let conn = Connection::open_in_memory().unwrap();
-        database::run_migrations(&conn).unwrap();
-        Arc::new(Mutex::new(conn))
+    use super::*;
+
+    async fn setup_db(path: String) -> Arc<Connection> {
+        Arc::new(crate::database::open(path).await.unwrap())
     }
 
     #[tokio::test]
     async fn test_create_and_get_os() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = OperatingSystemsStore::new(db);
 
         let os = store
@@ -388,7 +381,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_os() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = OperatingSystemsStore::new(db);
 
         store.create("Ubuntu", "24.04", None).await.unwrap();
@@ -400,7 +393,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_os() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = OperatingSystemsStore::new(db);
 
         let os = store.create("Ubuntu", "24.04", None).await.unwrap();
@@ -414,7 +407,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_os() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = OperatingSystemsStore::new(db);
 
         let os = store.create("Ubuntu", "24.04", None).await.unwrap();
@@ -425,7 +418,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_architecture() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = OperatingSystemsStore::new(db);
 
         let os = store.create("Ubuntu", "24.04", None).await.unwrap();
@@ -467,7 +460,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_architectures() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = OperatingSystemsStore::new(db);
 
         let os = store.create("Ubuntu", "24.04", None).await.unwrap();

--- a/rack-director/src/operating_systems/store.rs
+++ b/rack-director/src/operating_systems/store.rs
@@ -2,7 +2,6 @@ use super::{Architecture, OperatingSystem, OsArchitecture};
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use serde::Serialize;
-use std::sync::Arc;
 
 use crate::database::Connection;
 
@@ -14,341 +13,324 @@ pub struct OperatingSystemWithArchitectures {
     pub architectures: Vec<OsArchitecture>,
 }
 
-#[derive(Clone)]
-pub struct OperatingSystemsStore {
-    db: Arc<Connection>,
+/// Create a new operating system.
+pub async fn create(
+    conn: &Connection,
+    name: &str,
+    version: &str,
+    description: Option<&str>,
+) -> Result<OperatingSystem> {
+    let now = Utc::now();
+
+    conn.execute(
+        "INSERT INTO operating_systems (name, version, description, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        (
+            name.to_string(),
+            version.to_string(),
+            description.map(|s| s.to_string()),
+            now,
+            now,
+        ),
+    )
+    .await
+    .context("Failed to insert operating system")?;
+
+    let id = conn.last_insert_rowid().await;
+
+    Ok(OperatingSystem {
+        id: Some(id),
+        name: name.to_string(),
+        version: version.to_string(),
+        description: description.map(|s| s.to_string()),
+        created_at: Some(now),
+        updated_at: Some(now),
+    })
 }
 
-impl OperatingSystemsStore {
-    pub fn new(db: Arc<Connection>) -> Self {
-        Self { db }
+/// Get an operating system by ID.
+pub async fn get(conn: &Connection, id: i64) -> Result<OperatingSystem> {
+    let os = conn
+        .query_one(
+            "SELECT id, name, version, description, created_at, updated_at
+             FROM operating_systems WHERE id = ?1",
+            (id,),
+            |row| {
+                Ok(OperatingSystem {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    version: row.get(2)?,
+                    description: row.get(3)?,
+                    created_at: row.get(4)?,
+                    updated_at: row.get(5)?,
+                })
+            },
+        )
+        .await
+        .context("Operating system not found")?;
+
+    Ok(os)
+}
+
+/// Get an operating system with all its architecture configurations.
+pub async fn get_with_architectures(
+    conn: &Connection,
+    id: i64,
+) -> Result<OperatingSystemWithArchitectures> {
+    let os = get(conn, id).await?;
+    let architectures = list_architectures(conn, id).await?;
+
+    Ok(OperatingSystemWithArchitectures { os, architectures })
+}
+
+/// List all operating systems.
+pub async fn list(conn: &Connection) -> Result<Vec<OperatingSystem>> {
+    let systems = conn
+        .query(
+            "SELECT id, name, version, description, created_at, updated_at
+             FROM operating_systems ORDER BY name, version",
+            (),
+            |row| {
+                Ok(OperatingSystem {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    version: row.get(2)?,
+                    description: row.get(3)?,
+                    created_at: row.get(4)?,
+                    updated_at: row.get(5)?,
+                })
+            },
+        )
+        .await?;
+
+    Ok(systems)
+}
+
+/// Update an operating system.
+pub async fn update(
+    conn: &Connection,
+    id: i64,
+    name: Option<&str>,
+    version: Option<&str>,
+    description: Option<&str>,
+) -> Result<OperatingSystem> {
+    let now = Utc::now();
+
+    let mut updates = Vec::new();
+    let mut values: Vec<rusqlite::types::Value> = Vec::new();
+
+    if let Some(name) = name {
+        updates.push("name = ?");
+        values.push(rusqlite::types::Value::Text(name.to_string()));
+    }
+    if let Some(version) = version {
+        updates.push("version = ?");
+        values.push(rusqlite::types::Value::Text(version.to_string()));
+    }
+    if let Some(description) = description {
+        updates.push("description = ?");
+        values.push(rusqlite::types::Value::Text(description.to_string()));
     }
 
-    /// Create a new operating system.
-    pub async fn create(
-        &self,
-        name: &str,
-        version: &str,
-        description: Option<&str>,
-    ) -> Result<OperatingSystem> {
-        let now = Utc::now();
-
-        self.db
-            .execute(
-                "INSERT INTO operating_systems (name, version, description, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                (
-                    name.to_string(),
-                    version.to_string(),
-                    description.map(|s| s.to_string()),
-                    now,
-                    now,
-                ),
-            )
-            .await
-            .context("Failed to insert operating system")?;
-
-        let id = self.db.last_insert_rowid().await;
-
-        Ok(OperatingSystem {
-            id: Some(id),
-            name: name.to_string(),
-            version: version.to_string(),
-            description: description.map(|s| s.to_string()),
-            created_at: Some(now),
-            updated_at: Some(now),
-        })
+    if updates.is_empty() {
+        return get(conn, id).await;
     }
 
-    /// Get an operating system by ID.
-    pub async fn get(&self, id: i64) -> Result<OperatingSystem> {
-        let os = self
-            .db
-            .query_one(
-                "SELECT id, name, version, description, created_at, updated_at
-                 FROM operating_systems WHERE id = ?1",
-                (id,),
-                |row| {
-                    Ok(OperatingSystem {
-                        id: row.get(0)?,
-                        name: row.get(1)?,
-                        version: row.get(2)?,
-                        description: row.get(3)?,
-                        created_at: row.get(4)?,
-                        updated_at: row.get(5)?,
-                    })
-                },
-            )
-            .await
-            .context("Operating system not found")?;
+    updates.push("updated_at = ?");
+    values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
+    values.push(rusqlite::types::Value::Integer(id));
 
-        Ok(os)
+    let query = format!(
+        "UPDATE operating_systems SET {} WHERE id = ?",
+        updates.join(", ")
+    );
+
+    conn.execute(query, rusqlite::params_from_iter(values))
+        .await?;
+
+    get(conn, id).await
+}
+
+/// Delete an operating system (and all its architectures due to CASCADE).
+pub async fn delete(conn: &Connection, id: i64) -> Result<()> {
+    let rows_affected = conn
+        .execute("DELETE FROM operating_systems WHERE id = ?1", (id,))
+        .await
+        .context("Failed to delete operating system")?;
+
+    if rows_affected == 0 {
+        return Err(anyhow!("Operating system not found"));
     }
 
-    /// Get an operating system with all its architecture configurations.
-    pub async fn get_with_architectures(
-        &self,
-        id: i64,
-    ) -> Result<OperatingSystemWithArchitectures> {
-        let os = self.get(id).await?;
-        let architectures = self.list_architectures(id).await?;
+    Ok(())
+}
 
-        Ok(OperatingSystemWithArchitectures { os, architectures })
+/// Create or update an architecture configuration for an OS.
+#[allow(clippy::too_many_arguments)]
+pub async fn upsert_architecture(
+    conn: &Connection,
+    os_id: i64,
+    architecture: Architecture,
+    kernel_path: &str,
+    initramfs_path: &str,
+    modules: Vec<String>,
+    cmdline_args: Option<&str>,
+    install_script_path: Option<&str>,
+) -> Result<OsArchitecture> {
+    let now = Utc::now();
+    let modules_json = serde_json::to_string(&modules)?;
+    let arch_str = architecture.as_str().to_string();
+
+    conn.execute(
+        "INSERT INTO os_architectures
+         (os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(os_id, architecture) DO UPDATE SET
+         kernel_path = ?3,
+         initramfs_path = ?4,
+         modules = ?5,
+         cmdline_args = ?6,
+         install_script_path = ?7,
+         updated_at = ?9",
+        (
+            os_id,
+            arch_str,
+            kernel_path.to_string(),
+            initramfs_path.to_string(),
+            modules_json,
+            cmdline_args.map(|s| s.to_string()),
+            install_script_path.map(|s| s.to_string()),
+            now,
+            now,
+        ),
+    )
+    .await
+    .context("Failed to upsert OS architecture")?;
+
+    get_architecture(conn, os_id, architecture).await
+}
+
+/// Get a specific architecture configuration.
+pub async fn get_architecture(
+    conn: &Connection,
+    os_id: i64,
+    architecture: Architecture,
+) -> Result<OsArchitecture> {
+    let arch_str = architecture.as_str().to_string();
+
+    let arch = conn
+        .query_one(
+            "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
+             FROM os_architectures WHERE os_id = ?1 AND architecture = ?2",
+            (os_id, arch_str),
+            move |row| {
+                let modules_json: String = row.get(5)?;
+                let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
+
+                Ok(OsArchitecture {
+                    id: row.get(0)?,
+                    os_id: row.get(1)?,
+                    architecture,
+                    kernel_path: row.get(3)?,
+                    initramfs_path: row.get(4)?,
+                    modules,
+                    cmdline_args: row.get(6)?,
+                    install_script_path: row.get(7)?,
+                    kernel_filename: row.get(8)?,
+                    initramfs_filename: row.get(9)?,
+                    install_script_filename: row.get(10)?,
+                    created_at: row.get(11)?,
+                    updated_at: row.get(12)?,
+                })
+            },
+        )
+        .await
+        .context("OS architecture not found")?;
+
+    Ok(arch)
+}
+
+/// List all architecture configurations for an OS.
+pub async fn list_architectures(conn: &Connection, os_id: i64) -> Result<Vec<OsArchitecture>> {
+    let architectures = conn
+        .query(
+            "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
+             FROM os_architectures WHERE os_id = ?1 ORDER BY architecture",
+            (os_id,),
+            |row| {
+                let arch_str: String = row.get(2)?;
+                let architecture = Architecture::from_str(&arch_str).unwrap();
+                let modules_json: String = row.get(5)?;
+                let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
+
+                Ok(OsArchitecture {
+                    id: row.get(0)?,
+                    os_id: row.get(1)?,
+                    architecture,
+                    kernel_path: row.get(3)?,
+                    initramfs_path: row.get(4)?,
+                    modules,
+                    cmdline_args: row.get(6)?,
+                    install_script_path: row.get(7)?,
+                    kernel_filename: row.get(8)?,
+                    initramfs_filename: row.get(9)?,
+                    install_script_filename: row.get(10)?,
+                    created_at: row.get(11)?,
+                    updated_at: row.get(12)?,
+                })
+            },
+        )
+        .await?;
+
+    Ok(architectures)
+}
+
+/// Update specific fields of an OS architecture.
+pub async fn update_architecture_field(
+    conn: &Connection,
+    os_id: i64,
+    architecture: Architecture,
+    field: &str,
+    value: &str,
+) -> Result<OsArchitecture> {
+    let now = Utc::now();
+    let arch_str = architecture.as_str().to_string();
+    let field = field.to_string();
+    let value = value.to_string();
+
+    let query = format!(
+        "UPDATE os_architectures SET {} = ?1, updated_at = ?2 WHERE os_id = ?3 AND architecture = ?4",
+        field
+    );
+
+    conn.execute(query, (value, now, os_id, arch_str))
+        .await
+        .context("Failed to update OS architecture")?;
+
+    get_architecture(conn, os_id, architecture).await
+}
+
+/// Delete an architecture configuration.
+pub async fn delete_architecture(
+    conn: &Connection,
+    os_id: i64,
+    architecture: Architecture,
+) -> Result<()> {
+    let arch_str = architecture.as_str().to_string();
+
+    let rows_affected = conn
+        .execute(
+            "DELETE FROM os_architectures WHERE os_id = ?1 AND architecture = ?2",
+            (os_id, arch_str),
+        )
+        .await
+        .context("Failed to delete OS architecture")?;
+
+    if rows_affected == 0 {
+        return Err(anyhow!("OS architecture not found"));
     }
 
-    /// List all operating systems.
-    pub async fn list(&self) -> Result<Vec<OperatingSystem>> {
-        let systems = self
-            .db
-            .query(
-                "SELECT id, name, version, description, created_at, updated_at
-                 FROM operating_systems ORDER BY name, version",
-                (),
-                |row| {
-                    Ok(OperatingSystem {
-                        id: row.get(0)?,
-                        name: row.get(1)?,
-                        version: row.get(2)?,
-                        description: row.get(3)?,
-                        created_at: row.get(4)?,
-                        updated_at: row.get(5)?,
-                    })
-                },
-            )
-            .await?;
-
-        Ok(systems)
-    }
-
-    /// Update an operating system.
-    pub async fn update(
-        &self,
-        id: i64,
-        name: Option<&str>,
-        version: Option<&str>,
-        description: Option<&str>,
-    ) -> Result<OperatingSystem> {
-        let now = Utc::now();
-
-        let mut updates = Vec::new();
-        let mut values: Vec<rusqlite::types::Value> = Vec::new();
-
-        if let Some(name) = name {
-            updates.push("name = ?");
-            values.push(rusqlite::types::Value::Text(name.to_string()));
-        }
-        if let Some(version) = version {
-            updates.push("version = ?");
-            values.push(rusqlite::types::Value::Text(version.to_string()));
-        }
-        if let Some(description) = description {
-            updates.push("description = ?");
-            values.push(rusqlite::types::Value::Text(description.to_string()));
-        }
-
-        if updates.is_empty() {
-            return self.get(id).await;
-        }
-
-        updates.push("updated_at = ?");
-        values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
-        values.push(rusqlite::types::Value::Integer(id));
-
-        let query = format!(
-            "UPDATE operating_systems SET {} WHERE id = ?",
-            updates.join(", ")
-        );
-
-        self.db
-            .execute(query, rusqlite::params_from_iter(values))
-            .await?;
-
-        self.get(id).await
-    }
-
-    /// Delete an operating system (and all its architectures due to CASCADE).
-    pub async fn delete(&self, id: i64) -> Result<()> {
-        let rows_affected = self
-            .db
-            .execute("DELETE FROM operating_systems WHERE id = ?1", (id,))
-            .await
-            .context("Failed to delete operating system")?;
-
-        if rows_affected == 0 {
-            return Err(anyhow!("Operating system not found"));
-        }
-
-        Ok(())
-    }
-
-    /// Create or update an architecture configuration for an OS.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn upsert_architecture(
-        &self,
-        os_id: i64,
-        architecture: Architecture,
-        kernel_path: &str,
-        initramfs_path: &str,
-        modules: Vec<String>,
-        cmdline_args: Option<&str>,
-        install_script_path: Option<&str>,
-    ) -> Result<OsArchitecture> {
-        let now = Utc::now();
-        let modules_json = serde_json::to_string(&modules)?;
-        let arch_str = architecture.as_str().to_string();
-
-        self.db
-            .execute(
-                "INSERT INTO os_architectures
-                 (os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-                 ON CONFLICT(os_id, architecture) DO UPDATE SET
-                 kernel_path = ?3,
-                 initramfs_path = ?4,
-                 modules = ?5,
-                 cmdline_args = ?6,
-                 install_script_path = ?7,
-                 updated_at = ?9",
-                (
-                    os_id,
-                    arch_str,
-                    kernel_path.to_string(),
-                    initramfs_path.to_string(),
-                    modules_json,
-                    cmdline_args.map(|s| s.to_string()),
-                    install_script_path.map(|s| s.to_string()),
-                    now,
-                    now,
-                ),
-            )
-            .await
-            .context("Failed to upsert OS architecture")?;
-
-        self.get_architecture(os_id, architecture).await
-    }
-
-    /// Get a specific architecture configuration.
-    pub async fn get_architecture(
-        &self,
-        os_id: i64,
-        architecture: Architecture,
-    ) -> Result<OsArchitecture> {
-        let arch_str = architecture.as_str().to_string();
-
-        let arch = self
-            .db
-            .query_one(
-                "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
-                 FROM os_architectures WHERE os_id = ?1 AND architecture = ?2",
-                (os_id, arch_str),
-                move |row| {
-                    let modules_json: String = row.get(5)?;
-                    let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
-
-                    Ok(OsArchitecture {
-                        id: row.get(0)?,
-                        os_id: row.get(1)?,
-                        architecture,
-                        kernel_path: row.get(3)?,
-                        initramfs_path: row.get(4)?,
-                        modules,
-                        cmdline_args: row.get(6)?,
-                        install_script_path: row.get(7)?,
-                        kernel_filename: row.get(8)?,
-                        initramfs_filename: row.get(9)?,
-                        install_script_filename: row.get(10)?,
-                        created_at: row.get(11)?,
-                        updated_at: row.get(12)?,
-                    })
-                },
-            )
-            .await
-            .context("OS architecture not found")?;
-
-        Ok(arch)
-    }
-
-    /// List all architecture configurations for an OS.
-    pub async fn list_architectures(&self, os_id: i64) -> Result<Vec<OsArchitecture>> {
-        let architectures = self
-            .db
-            .query(
-                "SELECT id, os_id, architecture, kernel_path, initramfs_path, modules, cmdline_args, install_script_path, kernel_filename, initramfs_filename, install_script_filename, created_at, updated_at
-                 FROM os_architectures WHERE os_id = ?1 ORDER BY architecture",
-                (os_id,),
-                |row| {
-                    let arch_str: String = row.get(2)?;
-                    let architecture = Architecture::from_str(&arch_str).unwrap();
-                    let modules_json: String = row.get(5)?;
-                    let modules: Vec<String> = serde_json::from_str(&modules_json).unwrap_or_default();
-
-                    Ok(OsArchitecture {
-                        id: row.get(0)?,
-                        os_id: row.get(1)?,
-                        architecture,
-                        kernel_path: row.get(3)?,
-                        initramfs_path: row.get(4)?,
-                        modules,
-                        cmdline_args: row.get(6)?,
-                        install_script_path: row.get(7)?,
-                        kernel_filename: row.get(8)?,
-                        initramfs_filename: row.get(9)?,
-                        install_script_filename: row.get(10)?,
-                        created_at: row.get(11)?,
-                        updated_at: row.get(12)?,
-                    })
-                },
-            )
-            .await?;
-
-        Ok(architectures)
-    }
-
-    /// Update specific fields of an OS architecture.
-    pub async fn update_architecture_field(
-        &self,
-        os_id: i64,
-        architecture: Architecture,
-        field: &str,
-        value: &str,
-    ) -> Result<OsArchitecture> {
-        let now = Utc::now();
-        let arch_str = architecture.as_str().to_string();
-        let field = field.to_string();
-        let value = value.to_string();
-
-        let query = format!(
-            "UPDATE os_architectures SET {} = ?1, updated_at = ?2 WHERE os_id = ?3 AND architecture = ?4",
-            field
-        );
-
-        self.db
-            .execute(query, (value, now, os_id, arch_str))
-            .await
-            .context("Failed to update OS architecture")?;
-
-        self.get_architecture(os_id, architecture).await
-    }
-
-    /// Delete an architecture configuration.
-    pub async fn delete_architecture(&self, os_id: i64, architecture: Architecture) -> Result<()> {
-        let arch_str = architecture.as_str().to_string();
-
-        let rows_affected = self
-            .db
-            .execute(
-                "DELETE FROM os_architectures WHERE os_id = ?1 AND architecture = ?2",
-                (os_id, arch_str),
-            )
-            .await
-            .context("Failed to delete OS architecture")?;
-
-        if rows_affected == 0 {
-            return Err(anyhow!("OS architecture not found"));
-        }
-
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -357,17 +339,17 @@ mod tests {
 
     use super::*;
 
-    async fn setup_db(path: String) -> Arc<Connection> {
-        Arc::new(crate::database::open(path).await.unwrap())
+    async fn setup_db(path: String) -> Connection {
+        let factory =
+            crate::database::DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        crate::database::run_migrations(&factory).await.unwrap()
     }
 
     #[tokio::test]
     async fn test_create_and_get_os() {
         let db = setup_db(test_database_path!()).await;
-        let store = OperatingSystemsStore::new(db);
 
-        let os = store
-            .create("Ubuntu Server", "24.04", Some("Ubuntu 24.04 LTS"))
+        let os = create(&db, "Ubuntu Server", "24.04", Some("Ubuntu 24.04 LTS"))
             .await
             .unwrap();
 
@@ -375,30 +357,27 @@ mod tests {
         assert_eq!(os.name, "Ubuntu Server");
         assert_eq!(os.version, "24.04");
 
-        let retrieved = store.get(os.id.unwrap()).await.unwrap();
+        let retrieved = get(&db, os.id.unwrap()).await.unwrap();
         assert_eq!(retrieved.name, os.name);
     }
 
     #[tokio::test]
     async fn test_list_os() {
         let db = setup_db(test_database_path!()).await;
-        let store = OperatingSystemsStore::new(db);
 
-        store.create("Ubuntu", "24.04", None).await.unwrap();
-        store.create("Debian", "12", None).await.unwrap();
+        create(&db, "Ubuntu", "24.04", None).await.unwrap();
+        create(&db, "Debian", "12", None).await.unwrap();
 
-        let list = store.list().await.unwrap();
-        assert_eq!(list.len(), 2);
+        let systems = list(&db).await.unwrap();
+        assert_eq!(systems.len(), 2);
     }
 
     #[tokio::test]
     async fn test_update_os() {
         let db = setup_db(test_database_path!()).await;
-        let store = OperatingSystemsStore::new(db);
 
-        let os = store.create("Ubuntu", "24.04", None).await.unwrap();
-        let updated = store
-            .update(os.id.unwrap(), None, None, Some("New description"))
+        let os = create(&db, "Ubuntu", "24.04", None).await.unwrap();
+        let updated = update(&db, os.id.unwrap(), None, None, Some("New description"))
             .await
             .unwrap();
 
@@ -408,49 +387,47 @@ mod tests {
     #[tokio::test]
     async fn test_delete_os() {
         let db = setup_db(test_database_path!()).await;
-        let store = OperatingSystemsStore::new(db);
 
-        let os = store.create("Ubuntu", "24.04", None).await.unwrap();
-        store.delete(os.id.unwrap()).await.unwrap();
+        let os = create(&db, "Ubuntu", "24.04", None).await.unwrap();
+        delete(&db, os.id.unwrap()).await.unwrap();
 
-        assert!(store.get(os.id.unwrap()).await.is_err());
+        assert!(get(&db, os.id.unwrap()).await.is_err());
     }
 
     #[tokio::test]
     async fn test_upsert_architecture() {
         let db = setup_db(test_database_path!()).await;
-        let store = OperatingSystemsStore::new(db);
 
-        let os = store.create("Ubuntu", "24.04", None).await.unwrap();
-        let arch = store
-            .upsert_architecture(
-                os.id.unwrap(),
-                Architecture::X86_64,
-                "os/1/kernel",
-                "os/1/initramfs",
-                vec![],
-                Some("console=ttyS0"),
-                None,
-            )
-            .await
-            .unwrap();
+        let os = create(&db, "Ubuntu", "24.04", None).await.unwrap();
+        let arch = upsert_architecture(
+            &db,
+            os.id.unwrap(),
+            Architecture::X86_64,
+            "os/1/kernel",
+            "os/1/initramfs",
+            vec![],
+            Some("console=ttyS0"),
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(arch.architecture, Architecture::X86_64);
         assert_eq!(arch.kernel_path, "os/1/kernel");
 
         // Update
-        let updated = store
-            .upsert_architecture(
-                os.id.unwrap(),
-                Architecture::X86_64,
-                "os/1/kernel-new",
-                "os/1/initramfs",
-                vec![],
-                Some("console=ttyS0"),
-                None,
-            )
-            .await
-            .unwrap();
+        let updated = upsert_architecture(
+            &db,
+            os.id.unwrap(),
+            Architecture::X86_64,
+            "os/1/kernel-new",
+            "os/1/initramfs",
+            vec![],
+            Some("console=ttyS0"),
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(updated.kernel_path, "os/1/kernel-new");
 
@@ -461,23 +438,22 @@ mod tests {
     #[tokio::test]
     async fn test_list_architectures() {
         let db = setup_db(test_database_path!()).await;
-        let store = OperatingSystemsStore::new(db);
 
-        let os = store.create("Ubuntu", "24.04", None).await.unwrap();
-        store
-            .upsert_architecture(
-                os.id.unwrap(),
-                Architecture::X86_64,
-                "kernel",
-                "initramfs",
-                vec![],
-                None,
-                None,
-            )
-            .await
-            .unwrap();
+        let os = create(&db, "Ubuntu", "24.04", None).await.unwrap();
+        upsert_architecture(
+            &db,
+            os.id.unwrap(),
+            Architecture::X86_64,
+            "kernel",
+            "initramfs",
+            vec![],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
 
-        let archs = store.list_architectures(os.id.unwrap()).await.unwrap();
+        let archs = list_architectures(&db, os.id.unwrap()).await.unwrap();
         assert_eq!(archs.len(), 1);
     }
 }

--- a/rack-director/src/plans/actions/mod.rs
+++ b/rack-director/src/plans/actions/mod.rs
@@ -134,19 +134,18 @@ mod tests {
     use crate::{database, operating_systems::OperatingSystemsStore, roles::RolesStore};
     use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Mutex;
     use uuid::Uuid;
 
     /// Helper to create test database and stores for ActionContext
     async fn setup_test_stores() -> (
-        Arc<Mutex<rusqlite::Connection>>,
+        Arc<crate::database::Connection>,
         OperatingSystemsStore,
         RolesStore,
         tempfile::TempDir,
     ) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(Mutex::new(database::open(&db_path).unwrap()));
+        let db = Arc::new(database::open(db_path).await.unwrap());
         let os_store = OperatingSystemsStore::new(db.clone());
         let roles_store = RolesStore::new(db.clone());
         (db, os_store, roles_store, temp_dir)
@@ -258,14 +257,12 @@ mod tests {
 
         // Create and register device with role
         let device_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440003").unwrap();
-        {
-            let conn = db.lock().await;
-            conn.execute(
-                "INSERT INTO devices (uuid, architecture, lifecycle, role_id) VALUES (?1, 'x86-64', 'new', ?2)",
-                rusqlite::params![device_uuid, role_id],
-            )
-            .unwrap();
-        }
+        db.execute(
+            "INSERT INTO devices (uuid, architecture, lifecycle, role_id) VALUES (?1, 'x86-64', 'new', ?2)",
+            (device_uuid, role_id),
+        )
+        .await
+        .unwrap();
 
         let device = Device {
             uuid: device_uuid,
@@ -383,14 +380,12 @@ mod tests {
 
         // Create and register device with role
         let device_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440005").unwrap();
-        {
-            let conn = db.lock().await;
-            conn.execute(
-                "INSERT INTO devices (uuid, architecture, lifecycle, role_id) VALUES (?1, 'x86-64', 'new', ?2)",
-                rusqlite::params![device_uuid, role_id],
-            )
-            .unwrap();
-        }
+        db.execute(
+            "INSERT INTO devices (uuid, architecture, lifecycle, role_id) VALUES (?1, 'x86-64', 'new', ?2)",
+            (device_uuid, role_id),
+        )
+        .await
+        .unwrap();
 
         let device = Device {
             uuid: device_uuid,

--- a/rack-director/src/plans/actions/mod.rs
+++ b/rack-director/src/plans/actions/mod.rs
@@ -6,9 +6,8 @@ pub use boot_target::BootTarget;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+use crate::database::Connection;
 use crate::director::Device;
-use crate::operating_systems::OperatingSystemsStore;
-use crate::roles::RolesStore;
 
 // TODO: Define common AgentAction enum.
 
@@ -26,9 +25,8 @@ pub enum Action {
 /// Context required for converting Actions to BootTargets
 pub struct ActionContext<'a> {
     pub device: &'a Device,
-    pub os_store: &'a OperatingSystemsStore,
-    pub roles_store: &'a RolesStore,
-    pub director: Option<&'a crate::director::Director>,
+    pub conn: &'a Connection,
+    pub director: Option<&'a crate::director::Director<'a>>,
 }
 
 impl Action {
@@ -107,13 +105,12 @@ async fn generate_os_install_boot_target(ctx: &ActionContext<'_>) -> Result<Boot
         .role_id
         .ok_or_else(|| anyhow::anyhow!("role not assigned to device {}", ctx.device.uuid))?;
 
-    let role = ctx.roles_store.get(role_id).await?;
+    let role = crate::roles::store::get(ctx.conn, role_id).await?;
 
     // Get OS architecture configuration
-    let os_arch = ctx
-        .os_store
-        .get_architecture(role.os_id, architecture)
-        .await?;
+    let os_arch =
+        crate::operating_systems::store::get_architecture(ctx.conn, role.os_id, architecture)
+            .await?;
 
     let cmdline = os_arch.cmdline_args.unwrap_or_default();
 
@@ -131,24 +128,16 @@ mod tests {
     use crate::director::Device;
     use crate::operating_systems::Architecture;
     use crate::roles::DiskLayout;
-    use crate::{database, operating_systems::OperatingSystemsStore, roles::RolesStore};
+    use crate::{
+        database, database::DatabaseConnectionFactory, operating_systems::store as os_store,
+        roles::store as roles_store, test_connection_factory,
+    };
     use std::sync::Arc;
-    use tempfile::tempdir;
     use uuid::Uuid;
 
-    /// Helper to create test database and stores for ActionContext
-    async fn setup_test_stores() -> (
-        Arc<crate::database::Connection>,
-        OperatingSystemsStore,
-        RolesStore,
-        tempfile::TempDir,
-    ) {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-        let db = Arc::new(database::open(db_path).await.unwrap());
-        let os_store = OperatingSystemsStore::new(db.clone());
-        let roles_store = RolesStore::new(db.clone());
-        (db, os_store, roles_store, temp_dir)
+    /// Helper to create test database for ActionContext
+    async fn setup_test_db(factory: DatabaseConnectionFactory) -> Arc<crate::database::Connection> {
+        Arc::new(database::run_migrations(&factory).await.unwrap())
     }
 
     #[test]
@@ -218,46 +207,45 @@ mod tests {
 
     #[tokio::test]
     async fn test_install_os_action_to_boot_target_success() {
-        let (db, os_store, roles_store, _temp_dir) = setup_test_stores().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
 
         // Create an OS with architecture
-        let os = os_store
-            .create("Ubuntu", "24.04", Some("Ubuntu 24.04 LTS"))
+        let os = os_store::create(&conn, "Ubuntu", "24.04", Some("Ubuntu 24.04 LTS"))
             .await
             .unwrap();
         let os_id = os.id.unwrap();
 
         // Add architecture configuration with cmdline template
-        os_store
-            .upsert_architecture(
-                os_id,
-                Architecture::X86_64,
-                "installer/ubuntu-24.04/vmlinuz",
-                "installer/ubuntu-24.04/initrd.img",
-                vec![],
-                Some("console=ttyS0 autoinstall ds=nocloud-net;s={{install_script_url}}"),
-                None,
-            )
-            .await
-            .unwrap();
+        os_store::upsert_architecture(
+            &conn,
+            os_id,
+            Architecture::X86_64,
+            "installer/ubuntu-24.04/vmlinuz",
+            "installer/ubuntu-24.04/initrd.img",
+            vec![],
+            Some("console=ttyS0 autoinstall ds=nocloud-net;s={{install_script_url}}"),
+            None,
+        )
+        .await
+        .unwrap();
 
         // Create a role
         let disk_layout = DiskLayout { partitions: vec![] };
-        let role = roles_store
-            .create(
-                "web-server",
-                Some("Web server role"),
-                os_id,
-                &disk_layout,
-                None,
-            )
-            .await
-            .unwrap();
+        let role = roles_store::create(
+            &conn,
+            "web-server",
+            Some("Web server role"),
+            os_id,
+            &disk_layout,
+            None,
+        )
+        .await
+        .unwrap();
         let role_id = role.id.unwrap();
 
         // Create and register device with role
         let device_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440003").unwrap();
-        db.execute(
+        conn.execute(
             "INSERT INTO devices (uuid, architecture, lifecycle, role_id) VALUES (?1, 'x86-64', 'new', ?2)",
             (device_uuid, role_id),
         )
@@ -278,8 +266,7 @@ mod tests {
 
         let ctx = ActionContext {
             device: &device,
-            os_store: &os_store,
-            roles_store: &roles_store,
+            conn: &conn,
             director: None,
         };
 
@@ -305,7 +292,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_install_os_action_missing_role_error() {
-        let (_db, os_store, roles_store, _temp_dir) = setup_test_stores().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
 
         // Create device without a role
         let device = Device {
@@ -322,8 +309,7 @@ mod tests {
 
         let ctx = ActionContext {
             device: &device,
-            os_store: &os_store,
-            roles_store: &roles_store,
+            conn: &conn,
             director: None,
         };
 
@@ -341,46 +327,45 @@ mod tests {
 
     #[tokio::test]
     async fn test_install_os_action_with_no_cmdline_template() {
-        let (db, os_store, roles_store, _temp_dir) = setup_test_stores().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
 
         // Create an OS with architecture but NO cmdline template
-        let os = os_store
-            .create("Debian", "12", Some("Debian 12"))
+        let os = os_store::create(&conn, "Debian", "12", Some("Debian 12"))
             .await
             .unwrap();
         let os_id = os.id.unwrap();
 
         // Add architecture configuration WITHOUT cmdline template
-        os_store
-            .upsert_architecture(
-                os_id,
-                Architecture::X86_64,
-                "installer/debian-12/vmlinuz",
-                "installer/debian-12/initrd.img",
-                vec![],
-                None, // No cmdline template
-                None,
-            )
-            .await
-            .unwrap();
+        os_store::upsert_architecture(
+            &conn,
+            os_id,
+            Architecture::X86_64,
+            "installer/debian-12/vmlinuz",
+            "installer/debian-12/initrd.img",
+            vec![],
+            None, // No cmdline template
+            None,
+        )
+        .await
+        .unwrap();
 
         // Create a role
         let disk_layout = DiskLayout { partitions: vec![] };
-        let role = roles_store
-            .create(
-                "database-server",
-                Some("Database server role"),
-                os_id,
-                &disk_layout,
-                None,
-            )
-            .await
-            .unwrap();
+        let role = roles_store::create(
+            &conn,
+            "database-server",
+            Some("Database server role"),
+            os_id,
+            &disk_layout,
+            None,
+        )
+        .await
+        .unwrap();
         let role_id = role.id.unwrap();
 
         // Create and register device with role
         let device_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440005").unwrap();
-        db.execute(
+        conn.execute(
             "INSERT INTO devices (uuid, architecture, lifecycle, role_id) VALUES (?1, 'x86-64', 'new', ?2)",
             (device_uuid, role_id),
         )
@@ -401,8 +386,7 @@ mod tests {
 
         let ctx = ActionContext {
             device: &device,
-            os_store: &os_store,
-            roles_store: &roles_store,
+            conn: &conn,
             director: None,
         };
 
@@ -459,7 +443,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_reboot_device_start() {
-        let (_db, os_store, roles_store, _temp_dir) = setup_test_stores().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
 
         let device = Device {
             uuid: Uuid::parse_str("550e8400-e29b-41d4-a716-446655440007").unwrap(),
@@ -475,8 +459,7 @@ mod tests {
 
         let ctx = ActionContext {
             device: &device,
-            os_store: &os_store,
-            roles_store: &roles_store,
+            conn: &conn,
             director: None,
         };
 
@@ -488,7 +471,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_reboot_device_boot_target() {
-        let (_db, os_store, roles_store, _temp_dir) = setup_test_stores().await;
+        let conn = setup_test_db(test_connection_factory!()).await;
 
         let device = Device {
             uuid: Uuid::parse_str("550e8400-e29b-41d4-a716-446655440008").unwrap(),
@@ -504,8 +487,7 @@ mod tests {
 
         let ctx = ActionContext {
             device: &device,
-            os_store: &os_store,
-            roles_store: &roles_store,
+            conn: &conn,
             director: None,
         };
 

--- a/rack-director/src/plans/mod.rs
+++ b/rack-director/src/plans/mod.rs
@@ -8,7 +8,6 @@ pub mod actions;
 pub mod store;
 
 pub use actions::Action;
-pub use store::PlansStore;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum PlanStatus {

--- a/rack-director/src/plans/store.rs
+++ b/rack-director/src/plans/store.rs
@@ -1,112 +1,96 @@
-use std::sync::Arc;
-
 use crate::database::{Connection, FromRow};
 use crate::plans::{Plan, PlanStatus};
 use anyhow::Result;
 use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
-#[derive(Clone)]
-pub struct PlansStore {
-    db: Arc<Connection>,
+pub async fn create_plan(conn: &Connection, plan: &Plan) -> Result<i64> {
+    let actions_json = serde_json::to_string(&plan.actions)?;
+    let status_str: String = plan.status.clone().into();
+
+    // Check if there's already an active plan for this device
+    if get_active_plan_for_device(conn, &plan.device_uuid)
+        .await?
+        .is_some()
+    {
+        return Err(anyhow::anyhow!(
+            "Cannot create new plan for device {}: an active plan already exists",
+            plan.device_uuid
+        ));
+    }
+
+    conn.execute(
+        "INSERT INTO plans (device_uuid, status, current_step, total_steps, actions, error_message, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)",
+        (
+            plan.device_uuid,
+            status_str,
+            plan.current_step,
+            plan.total_steps,
+            actions_json,
+            plan.error_message.clone(),
+        ),
+    )
+    .await?;
+
+    Ok(conn.last_insert_rowid().await)
 }
 
-impl PlansStore {
-    pub fn new(db: Arc<Connection>) -> Self {
-        Self { db }
-    }
+pub async fn get_active_plan_for_device(
+    conn: &Connection,
+    device_uuid: &Uuid,
+) -> Result<Option<Plan>> {
+    let plan = conn
+        .query_row(
+            "SELECT id, device_uuid, status, current_step, total_steps, actions, error_message,
+                    created_at, started_at, completed_at
+             FROM plans
+             WHERE device_uuid = ?1 AND status IN ('pending', 'running')
+             ORDER BY created_at DESC
+             LIMIT 1",
+            (*device_uuid,),
+            Plan::from_row,
+        )
+        .await
+        .optional()?;
 
-    pub async fn create_plan(&self, plan: &Plan) -> Result<i64> {
-        let actions_json = serde_json::to_string(&plan.actions)?;
-        let status_str: String = plan.status.clone().into();
+    Ok(plan)
+}
 
-        // Check if there's already an active plan for this device
-        if self
-            .get_active_plan_for_device(&plan.device_uuid)
-            .await?
-            .is_some()
-        {
-            return Err(anyhow::anyhow!(
-                "Cannot create new plan for device {}: an active plan already exists",
-                plan.device_uuid
-            ));
-        }
+pub async fn update_plan_status(
+    conn: &Connection,
+    plan_id: i64,
+    status: PlanStatus,
+    current_step: i32,
+    error_message: Option<&str>,
+) -> Result<()> {
+    let status_str: String = status.clone().into();
+    let now = chrono::Utc::now();
+    let error_owned = error_message.map(|s| s.to_string());
 
-        self.db
-            .execute(
-                "INSERT INTO plans (device_uuid, status, current_step, total_steps, actions, error_message, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)",
-                (
-                    plan.device_uuid,
-                    status_str,
-                    plan.current_step,
-                    plan.total_steps,
-                    actions_json,
-                    plan.error_message.clone(),
-                ),
+    match status {
+        PlanStatus::Running => {
+            conn.execute(
+                "UPDATE plans SET status = ?1, current_step = ?2, started_at = ?3 WHERE id = ?4",
+                (status_str, current_step, now, plan_id),
             )
             .await?;
-
-        Ok(self.db.last_insert_rowid().await)
-    }
-
-    pub async fn get_active_plan_for_device(&self, device_uuid: &Uuid) -> Result<Option<Plan>> {
-        let plan = self
-            .db
-            .query_row(
-                "SELECT id, device_uuid, status, current_step, total_steps, actions, error_message,
-                        created_at, started_at, completed_at
-                 FROM plans
-                 WHERE device_uuid = ?1 AND status IN ('pending', 'running')
-                 ORDER BY created_at DESC
-                 LIMIT 1",
-                (*device_uuid,),
-                Plan::from_row,
-            )
-            .await
-            .optional()?;
-
-        Ok(plan)
-    }
-
-    pub async fn update_plan_status(
-        &self,
-        plan_id: i64,
-        status: PlanStatus,
-        current_step: i32,
-        error_message: Option<&str>,
-    ) -> Result<()> {
-        let status_str: String = status.clone().into();
-        let now = chrono::Utc::now();
-        let error_owned = error_message.map(|s| s.to_string());
-
-        match status {
-            PlanStatus::Running => {
-                self.db
-                    .execute(
-                        "UPDATE plans SET status = ?1, current_step = ?2, started_at = ?3 WHERE id = ?4",
-                        (status_str, current_step, now, plan_id),
-                    )
-                    .await?;
-            }
-            PlanStatus::Success | PlanStatus::Failed => {
-                self.db
-                    .execute(
-                        "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3, completed_at = ?4 WHERE id = ?5",
-                        (status_str, current_step, error_owned, now, plan_id),
-                    )
-                    .await?;
-            }
-            _ => {
-                self.db
-                    .execute(
-                        "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3 WHERE id = ?4",
-                        (status_str, current_step, error_owned, plan_id),
-                    )
-                    .await?;
-            }
         }
-
-        Ok(())
+        PlanStatus::Success | PlanStatus::Failed => {
+            conn.execute(
+                "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3, completed_at = ?4 WHERE id = ?5",
+                (status_str, current_step, error_owned, now, plan_id),
+            )
+            .await?;
+        }
+        _ => {
+            conn.execute(
+                "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3 WHERE id = ?4",
+                (status_str, current_step, error_owned, plan_id),
+            )
+            .await?;
+        }
     }
+
+    Ok(())
 }

--- a/rack-director/src/plans/store.rs
+++ b/rack-director/src/plans/store.rs
@@ -1,29 +1,72 @@
 use std::sync::Arc;
 
+use crate::database::{Connection, FromRow};
 use crate::plans::{Plan, PlanStatus};
 use anyhow::Result;
-use rusqlite::Connection;
-use tokio::sync::Mutex;
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct PlansStore {
-    conn: Arc<Mutex<rusqlite::Connection>>,
+    db: Arc<Connection>,
 }
 
 impl PlansStore {
-    pub fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
-        Self { conn }
+    pub fn new(db: Arc<Connection>) -> Self {
+        Self { db }
     }
 
     pub async fn create_plan(&self, plan: &Plan) -> Result<i64> {
-        let conn = self.conn.lock().await;
-        self.create_plan_internal(&conn, plan)
+        let actions_json = serde_json::to_string(&plan.actions)?;
+        let status_str: String = plan.status.clone().into();
+
+        // Check if there's already an active plan for this device
+        if self
+            .get_active_plan_for_device(&plan.device_uuid)
+            .await?
+            .is_some()
+        {
+            return Err(anyhow::anyhow!(
+                "Cannot create new plan for device {}: an active plan already exists",
+                plan.device_uuid
+            ));
+        }
+
+        self.db
+            .execute(
+                "INSERT INTO plans (device_uuid, status, current_step, total_steps, actions, error_message, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)",
+                (
+                    plan.device_uuid,
+                    status_str,
+                    plan.current_step,
+                    plan.total_steps,
+                    actions_json,
+                    plan.error_message.clone(),
+                ),
+            )
+            .await?;
+
+        Ok(self.db.last_insert_rowid().await)
     }
 
     pub async fn get_active_plan_for_device(&self, device_uuid: &Uuid) -> Result<Option<Plan>> {
-        let conn = self.conn.lock().await;
-        self.get_active_plan_for_device_internal(&conn, device_uuid)
+        let plan = self
+            .db
+            .query_row(
+                "SELECT id, device_uuid, status, current_step, total_steps, actions, error_message,
+                        created_at, started_at, completed_at
+                 FROM plans
+                 WHERE device_uuid = ?1 AND status IN ('pending', 'running')
+                 ORDER BY created_at DESC
+                 LIMIT 1",
+                (*device_uuid,),
+                Plan::from_row,
+            )
+            .await
+            .optional()?;
+
+        Ok(plan)
     }
 
     pub async fn update_plan_status(
@@ -33,88 +76,34 @@ impl PlansStore {
         current_step: i32,
         error_message: Option<&str>,
     ) -> Result<()> {
-        let conn = self.conn.lock().await;
-        self.update_plan_status_internal(&conn, plan_id, status, current_step, error_message)
-    }
-
-    fn create_plan_internal(&self, conn: &Connection, plan: &Plan) -> Result<i64> {
-        let actions_json = serde_json::to_string(&plan.actions)?;
-        let status_str: String = plan.status.clone().into();
-
-        // Check if there's already an active plan for this device
-        if let Some(_existing_plan) =
-            self.get_active_plan_for_device_internal(conn, &plan.device_uuid)?
-        {
-            return Err(anyhow::anyhow!(
-                "Cannot create new plan for device {}: an active plan already exists",
-                plan.device_uuid
-            ));
-        }
-
-        conn.execute(
-            "INSERT INTO plans (device_uuid, status, current_step, total_steps, actions, error_message, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)",
-            rusqlite::params![
-                plan.device_uuid,
-                status_str,
-                plan.current_step,
-                plan.total_steps,
-                actions_json,
-                plan.error_message
-            ],
-        )?;
-
-        Ok(conn.last_insert_rowid())
-    }
-
-    fn get_active_plan_for_device_internal(
-        &self,
-        conn: &Connection,
-        device_uuid: &Uuid,
-    ) -> Result<Option<Plan>> {
-        let plan = crate::database::query_optional::<Plan>(
-            conn,
-            "SELECT id, device_uuid, status, current_step, total_steps, actions, error_message,
-                    created_at, started_at, completed_at
-             FROM plans
-             WHERE device_uuid = ?1 AND status IN ('pending', 'running')
-             ORDER BY created_at DESC
-             LIMIT 1",
-            &[device_uuid],
-        )?;
-
-        Ok(plan)
-    }
-
-    fn update_plan_status_internal(
-        &self,
-        conn: &Connection,
-        plan_id: i64,
-        status: PlanStatus,
-        current_step: i32,
-        error_message: Option<&str>,
-    ) -> Result<()> {
         let status_str: String = status.clone().into();
         let now = chrono::Utc::now();
+        let error_owned = error_message.map(|s| s.to_string());
 
         match status {
             PlanStatus::Running => {
-                conn.execute(
-                    "UPDATE plans SET status = ?1, current_step = ?2, started_at = ?3 WHERE id = ?4",
-                    rusqlite::params![status_str, current_step, now, plan_id],
-                )?;
+                self.db
+                    .execute(
+                        "UPDATE plans SET status = ?1, current_step = ?2, started_at = ?3 WHERE id = ?4",
+                        (status_str, current_step, now, plan_id),
+                    )
+                    .await?;
             }
             PlanStatus::Success | PlanStatus::Failed => {
-                conn.execute(
-                    "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3, completed_at = ?4 WHERE id = ?5",
-                    rusqlite::params![status_str, current_step, error_message, now, plan_id],
-                )?;
+                self.db
+                    .execute(
+                        "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3, completed_at = ?4 WHERE id = ?5",
+                        (status_str, current_step, error_owned, now, plan_id),
+                    )
+                    .await?;
             }
             _ => {
-                conn.execute(
-                    "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3 WHERE id = ?4",
-                    rusqlite::params![status_str, current_step, error_message, plan_id],
-                )?;
+                self.db
+                    .execute(
+                        "UPDATE plans SET status = ?1, current_step = ?2, error_message = ?3 WHERE id = ?4",
+                        (status_str, current_step, error_owned, plan_id),
+                    )
+                    .await?;
             }
         }
 

--- a/rack-director/src/platforms/detection.rs
+++ b/rack-director/src/platforms/detection.rs
@@ -334,15 +334,11 @@ fn generate_platform_name(attrs: &PlatformAttributes) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
-    use rusqlite::Connection;
+    use crate::{database, test_database_path};
     use std::sync::Arc;
-    use tokio::sync::Mutex;
 
-    fn setup_db() -> Arc<Mutex<Connection>> {
-        let conn = Connection::open_in_memory().unwrap();
-        database::run_migrations(&conn).unwrap();
-        Arc::new(Mutex::new(conn))
+    async fn setup_db(path: String) -> Arc<crate::database::Connection> {
+        Arc::new(database::open(path).await.unwrap())
     }
 
     fn sample_platform_attributes() -> PlatformAttributes {
@@ -620,7 +616,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_matching_platform_exact_match() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -635,7 +631,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_matching_platform_with_size_tolerance() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -653,7 +649,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_matching_platform_with_memory_tolerance() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -670,7 +666,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_matching_platform_no_match_disk_count() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -687,7 +683,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_matching_platform_no_match_disk_type() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -704,7 +700,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_matching_platform_no_match_nic_count() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -721,7 +717,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_matching_platform_no_match_cpu_config() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();

--- a/rack-director/src/platforms/detection.rs
+++ b/rack-director/src/platforms/detection.rs
@@ -1,6 +1,7 @@
+use crate::database::Connection;
 use crate::platforms::cpu_model::platform_name_processor_version;
 
-use super::{DiskType, PlatformAttributes, PlatformCpu, PlatformDisk, PlatformNic, PlatformsStore};
+use super::{DiskType, PlatformAttributes, PlatformCpu, PlatformDisk, PlatformNic};
 use anyhow::Result;
 use common::device_attributes::{CpuInfo, DiskInfo, MemoryInfo, NetworkInterface};
 
@@ -14,7 +15,7 @@ use common::device_attributes::{CpuInfo, DiskInfo, MemoryInfo, NetworkInterface}
 ///
 /// Returns the platform ID
 pub async fn detect_or_create_platform(
-    store: &PlatformsStore,
+    conn: &Connection,
     disks: &[DiskInfo],
     nics: &[NetworkInterface],
     cpus: &[CpuInfo],
@@ -28,7 +29,7 @@ pub async fn detect_or_create_platform(
     assign_nic_labels(&mut platform_attrs.nics);
 
     // Try to find existing matching platform
-    if let Some(platform_id) = find_matching_platform(store, &platform_attrs).await? {
+    if let Some(platform_id) = find_matching_platform(conn, &platform_attrs).await? {
         log::info!("Found matching platform ID: {}", platform_id);
         return Ok(platform_id);
     }
@@ -37,13 +38,13 @@ pub async fn detect_or_create_platform(
     let platform_name = generate_platform_name(&platform_attrs);
     log::info!("Creating new platform: {}", platform_name);
 
-    let platform = store
-        .create(
-            &platform_name,
-            Some("Auto-detected platform"),
-            &platform_attrs,
-        )
-        .await?;
+    let platform = super::store::create(
+        conn,
+        &platform_name,
+        Some("Auto-detected platform"),
+        &platform_attrs,
+    )
+    .await?;
 
     Ok(platform.id.unwrap())
 }
@@ -52,10 +53,10 @@ pub async fn detect_or_create_platform(
 /// Used for auto-detection during hardware discovery
 /// Returns platform ID if a match is found
 pub async fn find_matching_platform(
-    store: &PlatformsStore,
+    conn: &Connection,
     device_attrs: &PlatformAttributes,
 ) -> Result<Option<i64>> {
-    let platforms = store.list().await?;
+    let platforms = super::store::list(conn).await?;
 
     for platform in platforms {
         if is_platform_match(&platform.attributes, device_attrs) {
@@ -338,7 +339,8 @@ mod tests {
     use std::sync::Arc;
 
     async fn setup_db(path: String) -> Arc<crate::database::Connection> {
-        Arc::new(database::open(path).await.unwrap())
+        let factory = database::DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        Arc::new(database::run_migrations(&factory).await.unwrap())
     }
 
     fn sample_platform_attributes() -> PlatformAttributes {
@@ -617,14 +619,15 @@ mod tests {
     #[tokio::test]
     async fn test_find_matching_platform_exact_match() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        let platform = store.create("Test Platform", None, &attrs).await.unwrap();
+        let platform = crate::platforms::store::create(&db, "Test Platform", None::<&str>, &attrs)
+            .await
+            .unwrap();
 
         // Search with exact same attributes
         let device_attrs = sample_platform_attributes();
-        let found = find_matching_platform(&store, &device_attrs).await.unwrap();
+        let found = find_matching_platform(&db, &device_attrs).await.unwrap();
 
         assert_eq!(found, platform.id);
     }
@@ -632,17 +635,18 @@ mod tests {
     #[tokio::test]
     async fn test_find_matching_platform_with_size_tolerance() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        let platform = store.create("Test Platform", None, &attrs).await.unwrap();
+        let platform = crate::platforms::store::create(&db, "Test Platform", None::<&str>, &attrs)
+            .await
+            .unwrap();
 
         // Device with slightly different disk size (within 5% tolerance)
         let mut device_attrs = sample_platform_attributes();
         device_attrs.disks[0].size_gb = 475; // 480 - 5 = within 5%
         device_attrs.disks[1].size_gb = 2050; // 2000 + 50 = within 5%
 
-        let found = find_matching_platform(&store, &device_attrs).await.unwrap();
+        let found = find_matching_platform(&db, &device_attrs).await.unwrap();
 
         assert_eq!(found, platform.id);
     }
@@ -650,16 +654,17 @@ mod tests {
     #[tokio::test]
     async fn test_find_matching_platform_with_memory_tolerance() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        let platform = store.create("Test Platform", None, &attrs).await.unwrap();
+        let platform = crate::platforms::store::create(&db, "Test Platform", None::<&str>, &attrs)
+            .await
+            .unwrap();
 
         // Device with slightly different memory (within 1 GiB tolerance)
         let mut device_attrs = sample_platform_attributes();
         device_attrs.memory_gib = 33; // 32 + 1 = within tolerance
 
-        let found = find_matching_platform(&store, &device_attrs).await.unwrap();
+        let found = find_matching_platform(&db, &device_attrs).await.unwrap();
 
         assert_eq!(found, platform.id);
     }
@@ -667,16 +672,17 @@ mod tests {
     #[tokio::test]
     async fn test_find_matching_platform_no_match_disk_count() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        store.create("Test Platform", None, &attrs).await.unwrap();
+        crate::platforms::store::create(&db, "Test Platform", None::<&str>, &attrs)
+            .await
+            .unwrap();
 
         // Device with different number of disks
         let mut device_attrs = sample_platform_attributes();
         device_attrs.disks.pop();
 
-        let found = find_matching_platform(&store, &device_attrs).await.unwrap();
+        let found = find_matching_platform(&db, &device_attrs).await.unwrap();
 
         assert!(found.is_none());
     }
@@ -684,16 +690,17 @@ mod tests {
     #[tokio::test]
     async fn test_find_matching_platform_no_match_disk_type() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        store.create("Test Platform", None, &attrs).await.unwrap();
+        crate::platforms::store::create(&db, "Test Platform", None::<&str>, &attrs)
+            .await
+            .unwrap();
 
         // Device with different disk type
         let mut device_attrs = sample_platform_attributes();
         device_attrs.disks[0].disk_type = DiskType::Nvme;
 
-        let found = find_matching_platform(&store, &device_attrs).await.unwrap();
+        let found = find_matching_platform(&db, &device_attrs).await.unwrap();
 
         assert!(found.is_none());
     }
@@ -701,16 +708,17 @@ mod tests {
     #[tokio::test]
     async fn test_find_matching_platform_no_match_nic_count() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        store.create("Test Platform", None, &attrs).await.unwrap();
+        crate::platforms::store::create(&db, "Test Platform", None::<&str>, &attrs)
+            .await
+            .unwrap();
 
         // Device with different number of NICs
         let mut device_attrs = sample_platform_attributes();
         device_attrs.nics.pop();
 
-        let found = find_matching_platform(&store, &device_attrs).await.unwrap();
+        let found = find_matching_platform(&db, &device_attrs).await.unwrap();
 
         assert!(found.is_none());
     }
@@ -718,16 +726,17 @@ mod tests {
     #[tokio::test]
     async fn test_find_matching_platform_no_match_cpu_config() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        store.create("Test Platform", None, &attrs).await.unwrap();
+        crate::platforms::store::create(&db, "Test Platform", None::<&str>, &attrs)
+            .await
+            .unwrap();
 
         // Device with different CPU cores
         let mut device_attrs = sample_platform_attributes();
         device_attrs.cpus[0].cores = 8;
 
-        let found = find_matching_platform(&store, &device_attrs).await.unwrap();
+        let found = find_matching_platform(&db, &device_attrs).await.unwrap();
 
         assert!(found.is_none());
     }

--- a/rack-director/src/platforms/mod.rs
+++ b/rack-director/src/platforms/mod.rs
@@ -1,9 +1,8 @@
 mod cpu_model;
 mod detection;
-mod store;
+pub mod store;
 
 pub use detection::detect_or_create_platform;
-pub use store::PlatformsStore;
 
 // Re-export types for convenience
 pub use common::device_attributes::DiskType;

--- a/rack-director/src/platforms/store.rs
+++ b/rack-director/src/platforms/store.rs
@@ -1,39 +1,46 @@
 use super::{Platform, PlatformAttributes};
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use rusqlite::{Connection, params};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+
+use crate::database::{Connection, FromRow};
 
 #[derive(Clone)]
 pub struct PlatformsStore {
-    db: Arc<Mutex<Connection>>,
+    db: Arc<Connection>,
 }
 
 impl PlatformsStore {
-    pub fn new(db: Arc<Mutex<Connection>>) -> Self {
+    pub fn new(db: Arc<Connection>) -> Self {
         Self { db }
     }
 
-    /// Create a new platform
+    /// Create a new platform.
     pub async fn create(
         &self,
         name: &str,
         description: Option<&str>,
         attributes: &PlatformAttributes,
     ) -> Result<Platform> {
-        let conn = self.db.lock().await;
         let now = Utc::now();
         let attributes_json = serde_json::to_string(attributes)?;
 
-        conn.execute(
-            "INSERT INTO platforms (name, description, attributes, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![name, description, attributes_json, now, now],
-        )
-        .context("Failed to insert platform")?;
+        self.db
+            .execute(
+                "INSERT INTO platforms (name, description, attributes, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                (
+                    name.to_string(),
+                    description.map(|s| s.to_string()),
+                    attributes_json,
+                    now,
+                    now,
+                ),
+            )
+            .await
+            .context("Failed to insert platform")?;
 
-        let id = conn.last_insert_rowid();
+        let id = self.db.last_insert_rowid().await;
 
         Ok(Platform {
             id: Some(id),
@@ -45,36 +52,38 @@ impl PlatformsStore {
         })
     }
 
-    /// Get a platform by ID
+    /// Get a platform by ID.
     pub async fn get(&self, id: i64) -> Result<Platform> {
-        let conn = self.db.lock().await;
-
-        let platform = crate::database::query_one::<Platform>(
-            &conn,
-            "SELECT id, name, description, attributes, created_at, updated_at
-             FROM platforms WHERE id = ?1",
-            &[&id],
-        )
-        .context("Platform not found")?;
+        let platform = self
+            .db
+            .query_one(
+                "SELECT id, name, description, attributes, created_at, updated_at
+                 FROM platforms WHERE id = ?1",
+                (id,),
+                Platform::from_row,
+            )
+            .await
+            .context("Platform not found")?;
 
         Ok(platform)
     }
 
-    /// List all platforms
+    /// List all platforms.
     pub async fn list(&self) -> Result<Vec<Platform>> {
-        let conn = self.db.lock().await;
-
-        let platforms = crate::database::query_map_all::<Platform>(
-            &conn,
-            "SELECT id, name, description, attributes, created_at, updated_at
-             FROM platforms ORDER BY name",
-            &[],
-        )?;
+        let platforms = self
+            .db
+            .query(
+                "SELECT id, name, description, attributes, created_at, updated_at
+                 FROM platforms ORDER BY name",
+                (),
+                Platform::from_row,
+            )
+            .await?;
 
         Ok(platforms)
     }
 
-    /// Update a platform
+    /// Update a platform.
     pub async fn update(
         &self,
         id: i64,
@@ -82,95 +91,78 @@ impl PlatformsStore {
         description: Option<&str>,
         attributes: Option<&PlatformAttributes>,
     ) -> Result<Platform> {
-        let needs_update = {
-            let conn = self.db.lock().await;
-            let now = Utc::now();
+        let now = Utc::now();
 
-            let mut updates = Vec::new();
-            let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        let mut updates = Vec::new();
+        let mut values: Vec<rusqlite::types::Value> = Vec::new();
 
-            if let Some(name) = name {
-                updates.push("name = ?");
-                params.push(Box::new(name.to_string()));
-            }
-            if let Some(description) = description {
-                updates.push("description = ?");
-                params.push(Box::new(description.to_string()));
-            }
-            if let Some(attributes) = attributes {
-                updates.push("attributes = ?");
-                let json = serde_json::to_string(attributes)?;
-                params.push(Box::new(json));
-            }
+        if let Some(name) = name {
+            updates.push("name = ?");
+            values.push(rusqlite::types::Value::Text(name.to_string()));
+        }
+        if let Some(description) = description {
+            updates.push("description = ?");
+            values.push(rusqlite::types::Value::Text(description.to_string()));
+        }
+        if let Some(attributes) = attributes {
+            updates.push("attributes = ?");
+            let json = serde_json::to_string(attributes)?;
+            values.push(rusqlite::types::Value::Text(json));
+        }
 
-            if updates.is_empty() {
-                false
-            } else {
-                updates.push("updated_at = ?");
-                params.push(Box::new(now));
-                params.push(Box::new(id));
-
-                let query = format!("UPDATE platforms SET {} WHERE id = ?", updates.join(", "));
-
-                conn.execute(&query, rusqlite::params_from_iter(params.iter()))?;
-                true
-            }
-        };
-
-        if !needs_update {
+        if updates.is_empty() {
             return self.get(id).await;
         }
+
+        updates.push("updated_at = ?");
+        values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
+        values.push(rusqlite::types::Value::Integer(id));
+
+        let query = format!("UPDATE platforms SET {} WHERE id = ?", updates.join(", "));
+
+        self.db
+            .execute(query, rusqlite::params_from_iter(values))
+            .await?;
 
         self.get(id).await
     }
 
-    /// Delete a platform
-    /// Returns an error if devices are assigned to this platform
+    /// Delete a platform.
+    ///
+    /// Returns an error if devices are assigned to this platform.
     pub async fn delete(&self, id: i64) -> Result<()> {
-        let conn = self.db.lock().await;
-
-        // Use IMMEDIATE transaction to prevent race condition between check and delete
-        conn.execute("BEGIN IMMEDIATE", [])
-            .context("Failed to begin transaction")?;
-
-        // Check if any devices are assigned to this platform
-        let device_count: i64 = match conn.query_row(
-            "SELECT COUNT(*) FROM devices WHERE platform_id = ?1",
-            params![id],
-            |row| row.get(0),
-        ) {
-            Ok(count) => count,
-            Err(e) => {
-                let _ = conn.execute("ROLLBACK", []);
-                return Err(e.into());
-            }
-        };
-
-        if device_count > 0 {
-            let _ = conn.execute("ROLLBACK", []);
-            return Err(anyhow!(
-                "Cannot delete platform: {} device(s) are assigned to it",
-                device_count
-            ));
-        }
-
-        // Perform the delete
-        let rows_affected = match conn.execute("DELETE FROM platforms WHERE id = ?1", params![id]) {
-            Ok(rows) => rows,
-            Err(e) => {
-                let _ = conn.execute("ROLLBACK", []);
-                return Err(anyhow::Error::from(e).context("Failed to delete platform"));
-            }
-        };
+        // Atomic check-and-delete: only deletes if no devices are assigned.
+        // Using NOT EXISTS in the WHERE clause makes the check and delete a single
+        // atomic SQL statement, preventing race conditions.
+        let rows_affected = self
+            .db
+            .execute(
+                "DELETE FROM platforms WHERE id = ?1 AND NOT EXISTS (SELECT 1 FROM devices WHERE platform_id = ?1)",
+                (id,),
+            )
+            .await
+            .context("Failed to delete platform")?;
 
         if rows_affected == 0 {
-            let _ = conn.execute("ROLLBACK", []);
+            // Either platform doesn't exist, or devices are assigned — distinguish for caller
+            let device_count: i64 = self
+                .db
+                .query_one(
+                    "SELECT COUNT(*) FROM devices WHERE platform_id = ?1",
+                    (id,),
+                    |row| row.get(0),
+                )
+                .await
+                .unwrap_or(0);
+
+            if device_count > 0 {
+                return Err(anyhow!(
+                    "Cannot delete platform: {} device(s) are assigned to it",
+                    device_count
+                ));
+            }
             return Err(anyhow!("Platform not found"));
         }
-
-        // Commit the transaction
-        conn.execute("COMMIT", [])
-            .context("Failed to commit transaction")?;
 
         Ok(())
     }
@@ -179,15 +171,13 @@ impl PlatformsStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
     use crate::operating_systems::Architecture;
     use crate::platforms::{DiskType, PlatformCpu, PlatformDisk, PlatformNic};
+    use crate::test_database_path;
     use uuid::Uuid;
 
-    fn setup_db() -> Arc<Mutex<Connection>> {
-        let conn = Connection::open_in_memory().unwrap();
-        database::run_migrations(&conn).unwrap();
-        Arc::new(Mutex::new(conn))
+    async fn setup_db(path: String) -> Arc<Connection> {
+        Arc::new(crate::database::open(path).await.unwrap())
     }
 
     fn sample_platform_attributes() -> PlatformAttributes {
@@ -229,7 +219,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_and_get_platform() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -253,7 +243,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_platforms() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -266,7 +256,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_platform() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -288,7 +278,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_platform() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
@@ -300,7 +290,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_platform_with_devices_fails() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db.clone());
         let director_store = crate::director::store::DirectorStore::new(db.clone());
 
@@ -310,14 +300,12 @@ mod tests {
 
         // Create device and assign platform
         let device_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440020").unwrap();
-        {
-            let conn = db.lock().await;
-            conn.execute(
-                "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
-                params![device_uuid, Architecture::X86_64.as_str()],
-            )
-            .unwrap();
-        }
+        db.execute(
+            "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
+            (device_uuid, Architecture::X86_64.as_str().to_string()),
+        )
+        .await
+        .unwrap();
 
         director_store
             .assign_platform_to_device(&device_uuid, platform.id.unwrap())
@@ -332,7 +320,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_delete_and_assign_protection() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let store = PlatformsStore::new(db.clone());
         let director_store = crate::director::store::DirectorStore::new(db.clone());
 
@@ -343,14 +331,12 @@ mod tests {
 
         // Create device (without assigning platform yet)
         let device_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440021").unwrap();
-        {
-            let conn = db.lock().await;
-            conn.execute(
-                "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
-                params![device_uuid, Architecture::X86_64.as_str()],
-            )
-            .unwrap();
-        }
+        db.execute(
+            "INSERT INTO devices (uuid, lifecycle, architecture) VALUES (?1, 'new', ?2)",
+            (device_uuid, Architecture::X86_64.as_str().to_string()),
+        )
+        .await
+        .unwrap();
 
         // Spawn two concurrent tasks that race to complete:
         // Task A: Delete the platform

--- a/rack-director/src/platforms/store.rs
+++ b/rack-director/src/platforms/store.rs
@@ -1,171 +1,153 @@
 use super::{Platform, PlatformAttributes};
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use std::sync::Arc;
 
 use crate::database::{Connection, FromRow};
 
-#[derive(Clone)]
-pub struct PlatformsStore {
-    db: Arc<Connection>,
+/// Create a new platform.
+pub async fn create(
+    conn: &Connection,
+    name: &str,
+    description: Option<&str>,
+    attributes: &PlatformAttributes,
+) -> Result<Platform> {
+    let now = Utc::now();
+    let attributes_json = serde_json::to_string(attributes)?;
+
+    conn.execute(
+        "INSERT INTO platforms (name, description, attributes, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        (
+            name.to_string(),
+            description.map(|s| s.to_string()),
+            attributes_json,
+            now,
+            now,
+        ),
+    )
+    .await
+    .context("Failed to insert platform")?;
+
+    let id = conn.last_insert_rowid().await;
+
+    Ok(Platform {
+        id: Some(id),
+        name: name.to_string(),
+        description: description.map(|s| s.to_string()),
+        attributes: attributes.clone(),
+        created_at: Some(now),
+        updated_at: Some(now),
+    })
 }
 
-impl PlatformsStore {
-    pub fn new(db: Arc<Connection>) -> Self {
-        Self { db }
+/// Get a platform by ID.
+pub async fn get(conn: &Connection, id: i64) -> Result<Platform> {
+    let platform = conn
+        .query_one(
+            "SELECT id, name, description, attributes, created_at, updated_at
+             FROM platforms WHERE id = ?1",
+            (id,),
+            Platform::from_row,
+        )
+        .await
+        .context("Platform not found")?;
+
+    Ok(platform)
+}
+
+/// List all platforms.
+pub async fn list(conn: &Connection) -> Result<Vec<Platform>> {
+    let platforms = conn
+        .query(
+            "SELECT id, name, description, attributes, created_at, updated_at
+             FROM platforms ORDER BY name",
+            (),
+            Platform::from_row,
+        )
+        .await?;
+
+    Ok(platforms)
+}
+
+/// Update a platform.
+pub async fn update(
+    conn: &Connection,
+    id: i64,
+    name: Option<&str>,
+    description: Option<&str>,
+    attributes: Option<&PlatformAttributes>,
+) -> Result<Platform> {
+    let now = Utc::now();
+
+    let mut updates = Vec::new();
+    let mut values: Vec<rusqlite::types::Value> = Vec::new();
+
+    if let Some(name) = name {
+        updates.push("name = ?");
+        values.push(rusqlite::types::Value::Text(name.to_string()));
+    }
+    if let Some(description) = description {
+        updates.push("description = ?");
+        values.push(rusqlite::types::Value::Text(description.to_string()));
+    }
+    if let Some(attributes) = attributes {
+        updates.push("attributes = ?");
+        let json = serde_json::to_string(attributes)?;
+        values.push(rusqlite::types::Value::Text(json));
     }
 
-    /// Create a new platform.
-    pub async fn create(
-        &self,
-        name: &str,
-        description: Option<&str>,
-        attributes: &PlatformAttributes,
-    ) -> Result<Platform> {
-        let now = Utc::now();
-        let attributes_json = serde_json::to_string(attributes)?;
-
-        self.db
-            .execute(
-                "INSERT INTO platforms (name, description, attributes, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                (
-                    name.to_string(),
-                    description.map(|s| s.to_string()),
-                    attributes_json,
-                    now,
-                    now,
-                ),
-            )
-            .await
-            .context("Failed to insert platform")?;
-
-        let id = self.db.last_insert_rowid().await;
-
-        Ok(Platform {
-            id: Some(id),
-            name: name.to_string(),
-            description: description.map(|s| s.to_string()),
-            attributes: attributes.clone(),
-            created_at: Some(now),
-            updated_at: Some(now),
-        })
+    if updates.is_empty() {
+        return get(conn, id).await;
     }
 
-    /// Get a platform by ID.
-    pub async fn get(&self, id: i64) -> Result<Platform> {
-        let platform = self
-            .db
+    updates.push("updated_at = ?");
+    values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
+    values.push(rusqlite::types::Value::Integer(id));
+
+    let query = format!("UPDATE platforms SET {} WHERE id = ?", updates.join(", "));
+
+    conn.execute(query, rusqlite::params_from_iter(values))
+        .await?;
+
+    get(conn, id).await
+}
+
+/// Delete a platform.
+///
+/// Returns an error if devices are assigned to this platform.
+pub async fn delete(conn: &Connection, id: i64) -> Result<()> {
+    // Atomic check-and-delete: only deletes if no devices are assigned.
+    // Using NOT EXISTS in the WHERE clause makes the check and delete a single
+    // atomic SQL statement, preventing race conditions.
+    let rows_affected = conn
+        .execute(
+            "DELETE FROM platforms WHERE id = ?1 AND NOT EXISTS (SELECT 1 FROM devices WHERE platform_id = ?1)",
+            (id,),
+        )
+        .await
+        .context("Failed to delete platform")?;
+
+    if rows_affected == 0 {
+        // Either platform doesn't exist, or devices are assigned — distinguish for caller
+        let device_count: i64 = conn
             .query_one(
-                "SELECT id, name, description, attributes, created_at, updated_at
-                 FROM platforms WHERE id = ?1",
+                "SELECT COUNT(*) FROM devices WHERE platform_id = ?1",
                 (id,),
-                Platform::from_row,
+                |row| row.get(0),
             )
             .await
-            .context("Platform not found")?;
+            .unwrap_or(0);
 
-        Ok(platform)
+        if device_count > 0 {
+            return Err(anyhow!(
+                "Cannot delete platform: {} device(s) are assigned to it",
+                device_count
+            ));
+        }
+        return Err(anyhow!("Platform not found"));
     }
 
-    /// List all platforms.
-    pub async fn list(&self) -> Result<Vec<Platform>> {
-        let platforms = self
-            .db
-            .query(
-                "SELECT id, name, description, attributes, created_at, updated_at
-                 FROM platforms ORDER BY name",
-                (),
-                Platform::from_row,
-            )
-            .await?;
-
-        Ok(platforms)
-    }
-
-    /// Update a platform.
-    pub async fn update(
-        &self,
-        id: i64,
-        name: Option<&str>,
-        description: Option<&str>,
-        attributes: Option<&PlatformAttributes>,
-    ) -> Result<Platform> {
-        let now = Utc::now();
-
-        let mut updates = Vec::new();
-        let mut values: Vec<rusqlite::types::Value> = Vec::new();
-
-        if let Some(name) = name {
-            updates.push("name = ?");
-            values.push(rusqlite::types::Value::Text(name.to_string()));
-        }
-        if let Some(description) = description {
-            updates.push("description = ?");
-            values.push(rusqlite::types::Value::Text(description.to_string()));
-        }
-        if let Some(attributes) = attributes {
-            updates.push("attributes = ?");
-            let json = serde_json::to_string(attributes)?;
-            values.push(rusqlite::types::Value::Text(json));
-        }
-
-        if updates.is_empty() {
-            return self.get(id).await;
-        }
-
-        updates.push("updated_at = ?");
-        values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
-        values.push(rusqlite::types::Value::Integer(id));
-
-        let query = format!("UPDATE platforms SET {} WHERE id = ?", updates.join(", "));
-
-        self.db
-            .execute(query, rusqlite::params_from_iter(values))
-            .await?;
-
-        self.get(id).await
-    }
-
-    /// Delete a platform.
-    ///
-    /// Returns an error if devices are assigned to this platform.
-    pub async fn delete(&self, id: i64) -> Result<()> {
-        // Atomic check-and-delete: only deletes if no devices are assigned.
-        // Using NOT EXISTS in the WHERE clause makes the check and delete a single
-        // atomic SQL statement, preventing race conditions.
-        let rows_affected = self
-            .db
-            .execute(
-                "DELETE FROM platforms WHERE id = ?1 AND NOT EXISTS (SELECT 1 FROM devices WHERE platform_id = ?1)",
-                (id,),
-            )
-            .await
-            .context("Failed to delete platform")?;
-
-        if rows_affected == 0 {
-            // Either platform doesn't exist, or devices are assigned — distinguish for caller
-            let device_count: i64 = self
-                .db
-                .query_one(
-                    "SELECT COUNT(*) FROM devices WHERE platform_id = ?1",
-                    (id,),
-                    |row| row.get(0),
-                )
-                .await
-                .unwrap_or(0);
-
-            if device_count > 0 {
-                return Err(anyhow!(
-                    "Cannot delete platform: {} device(s) are assigned to it",
-                    device_count
-                ));
-            }
-            return Err(anyhow!("Platform not found"));
-        }
-
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -176,8 +158,10 @@ mod tests {
     use crate::test_database_path;
     use uuid::Uuid;
 
-    async fn setup_db(path: String) -> Arc<Connection> {
-        Arc::new(crate::database::open(path).await.unwrap())
+    async fn setup_db(path: String) -> Connection {
+        let factory =
+            crate::database::DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        crate::database::run_migrations(&factory).await.unwrap()
     }
 
     fn sample_platform_attributes() -> PlatformAttributes {
@@ -220,11 +204,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_and_get_platform() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        let platform = store
-            .create("PowerEdge R640", Some("Dell server"), &attrs)
+        let platform = create(&db, "PowerEdge R640", Some("Dell server"), &attrs)
             .await
             .unwrap();
 
@@ -236,7 +218,7 @@ mod tests {
         assert_eq!(platform.attributes.cpus.len(), 1);
         assert_eq!(platform.attributes.memory_gib, 32);
 
-        let retrieved = store.get(platform.id.unwrap()).await.unwrap();
+        let retrieved = get(&db, platform.id.unwrap()).await.unwrap();
         assert_eq!(retrieved.name, platform.name);
         assert_eq!(retrieved.attributes.disks.len(), 2);
     }
@@ -244,33 +226,31 @@ mod tests {
     #[tokio::test]
     async fn test_list_platforms() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        store.create("Platform 1", None, &attrs).await.unwrap();
-        store.create("Platform 2", None, &attrs).await.unwrap();
+        create(&db, "Platform 1", None, &attrs).await.unwrap();
+        create(&db, "Platform 2", None, &attrs).await.unwrap();
 
-        let list = store.list().await.unwrap();
-        assert_eq!(list.len(), 2);
+        let platforms = list(&db).await.unwrap();
+        assert_eq!(platforms.len(), 2);
     }
 
     #[tokio::test]
     async fn test_update_platform() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        let platform = store.create("Original Name", None, &attrs).await.unwrap();
+        let platform = create(&db, "Original Name", None, &attrs).await.unwrap();
 
-        let updated = store
-            .update(
-                platform.id.unwrap(),
-                Some("Updated Name"),
-                Some("New description"),
-                None,
-            )
-            .await
-            .unwrap();
+        let updated = update(
+            &db,
+            platform.id.unwrap(),
+            Some("Updated Name"),
+            Some("New description"),
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(updated.name, "Updated Name");
         assert_eq!(updated.description, Some("New description".to_string()));
@@ -279,24 +259,21 @@ mod tests {
     #[tokio::test]
     async fn test_delete_platform() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db);
 
         let attrs = sample_platform_attributes();
-        let platform = store.create("Test Platform", None, &attrs).await.unwrap();
+        let platform = create(&db, "Test Platform", None, &attrs).await.unwrap();
 
-        store.delete(platform.id.unwrap()).await.unwrap();
-        assert!(store.get(platform.id.unwrap()).await.is_err());
+        delete(&db, platform.id.unwrap()).await.unwrap();
+        assert!(get(&db, platform.id.unwrap()).await.is_err());
     }
 
     #[tokio::test]
     async fn test_delete_platform_with_devices_fails() {
         let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db.clone());
-        let director_store = crate::director::store::DirectorStore::new(db.clone());
 
         // Create platform
         let attrs = sample_platform_attributes();
-        let platform = store.create("Test Platform", None, &attrs).await.unwrap();
+        let platform = create(&db, "Test Platform", None, &attrs).await.unwrap();
 
         // Create device and assign platform
         let device_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440020").unwrap();
@@ -307,26 +284,25 @@ mod tests {
         .await
         .unwrap();
 
-        director_store
-            .assign_platform_to_device(&device_uuid, platform.id.unwrap())
+        crate::director::store::assign_platform_to_device(&db, &device_uuid, platform.id.unwrap())
             .await
             .unwrap();
 
         // Try to delete platform - should fail
-        let result = store.delete(platform.id.unwrap()).await;
+        let result = delete(&db, platform.id.unwrap()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Cannot delete"));
     }
 
     #[tokio::test]
     async fn test_concurrent_delete_and_assign_protection() {
-        let db = setup_db(test_database_path!()).await;
-        let store = PlatformsStore::new(db.clone());
-        let director_store = crate::director::store::DirectorStore::new(db.clone());
+        use std::sync::Arc;
+
+        let db = Arc::new(setup_db(test_database_path!()).await);
 
         // Create platform
         let attrs = sample_platform_attributes();
-        let platform = store.create("Test Platform", None, &attrs).await.unwrap();
+        let platform = create(&db, "Test Platform", None, &attrs).await.unwrap();
         let platform_id = platform.id.unwrap();
 
         // Create device (without assigning platform yet)
@@ -341,47 +317,34 @@ mod tests {
         // Spawn two concurrent tasks that race to complete:
         // Task A: Delete the platform
         // Task B: Assign the platform to the device
-        let store_clone = store.clone();
-        let director_store_clone = director_store.clone();
+        let db_delete = db.clone();
+        let db_assign = db.clone();
 
         let delete_task = tokio::spawn(async move {
-            // Add small delay to increase chance of real race condition
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-            store_clone.delete(platform_id).await
+            delete(&db_delete, platform_id).await
         });
 
         let assign_task = tokio::spawn(async move {
-            // Add small delay to increase chance of real race condition
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-            director_store_clone
-                .assign_platform_to_device(&device_uuid, platform_id)
+            crate::director::store::assign_platform_to_device(&db_assign, &device_uuid, platform_id)
                 .await
         });
 
-        // Wait for both tasks to complete
         let (delete_result, assign_result) = tokio::join!(delete_task, assign_task);
 
-        // Unwrap the JoinHandle results to get the actual operation results
         let delete_result = delete_result.expect("Delete task panicked");
         let assign_result = assign_result.expect("Assign task panicked");
 
-        // CRITICAL: Only one should succeed
-        // Either:
-        // - Delete succeeds and assign fails (platform doesn't exist)
-        // - Assign succeeds and delete fails (device is assigned)
-        //
-        // Both should NEVER succeed (that would be a data integrity violation)
         match (delete_result, assign_result) {
             (Ok(_), Err(_)) => {
-                // Delete succeeded, assign failed - verify platform is gone
-                let platform_check = store.get(platform_id).await;
+                let platform_check = get(&db, platform_id).await;
                 assert!(
                     platform_check.is_err(),
                     "Platform should not exist after successful delete"
                 );
             }
             (Err(e), Ok(_)) => {
-                // Assign succeeded, delete failed - verify error message
                 let err_msg = e.to_string();
                 assert!(
                     err_msg.contains("Cannot delete") || err_msg.contains("device(s) are assigned"),
@@ -389,11 +352,10 @@ mod tests {
                     err_msg
                 );
 
-                // Verify device has the platform assigned
-                let device_platform = director_store
-                    .get_device_platform_id(&device_uuid)
-                    .await
-                    .unwrap();
+                let device_platform =
+                    crate::director::store::get_device_platform_id(&db, &device_uuid)
+                        .await
+                        .unwrap();
                 assert_eq!(
                     device_platform,
                     Some(platform_id),
@@ -406,8 +368,6 @@ mod tests {
                 );
             }
             (Err(e1), Err(e2)) => {
-                // Both failed - this shouldn't happen in normal operation but isn't a data integrity issue
-                // One of them should succeed since they're operating on valid data
                 panic!(
                     "Both operations failed unexpectedly:\nDelete error: {}\nAssign error: {}",
                     e1, e2

--- a/rack-director/src/roles/mod.rs
+++ b/rack-director/src/roles/mod.rs
@@ -1,6 +1,4 @@
-mod store;
-
-pub use store::RolesStore;
+pub mod store;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/rack-director/src/roles/store.rs
+++ b/rack-director/src/roles/store.rs
@@ -1,257 +1,222 @@
 use super::{DiskLayout, Role, RoleWithOs};
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use std::sync::Arc;
 
 use crate::database::{Connection, FromRow};
 
-#[derive(Clone)]
-pub struct RolesStore {
-    db: Arc<Connection>,
+/// Create a new role.
+pub async fn create(
+    conn: &Connection,
+    name: &str,
+    description: Option<&str>,
+    os_id: i64,
+    disk_layout: &DiskLayout,
+    config_template: Option<&serde_json::Value>,
+) -> Result<Role> {
+    let now = Utc::now();
+    let disk_layout_json = serde_json::to_string(disk_layout)?;
+    let config_json = config_template.map(serde_json::to_string).transpose()?;
+
+    conn.execute(
+        "INSERT INTO roles (name, description, os_id, disk_layout, config_template, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        (name.to_string(), description.map(|s| s.to_string()), os_id, disk_layout_json, config_json, now, now),
+    )
+    .await
+    .context("Failed to insert role")?;
+
+    let id = conn.last_insert_rowid().await;
+
+    Ok(Role {
+        id: Some(id),
+        name: name.to_string(),
+        description: description.map(|s| s.to_string()),
+        os_id,
+        disk_layout: disk_layout.clone(),
+        config_template: config_template.cloned(),
+        created_at: Some(now),
+        updated_at: Some(now),
+    })
 }
 
-impl RolesStore {
-    pub fn new(db: Arc<Connection>) -> Self {
-        Self { db }
+/// Get a role by ID.
+pub async fn get(conn: &Connection, id: i64) -> Result<Role> {
+    let role = conn
+        .query_one(
+            "SELECT id, name, description, os_id, disk_layout, config_template, created_at, updated_at
+             FROM roles WHERE id = ?1",
+            (id,),
+            Role::from_row,
+        )
+        .await
+        .context("Role not found")?;
+
+    Ok(role)
+}
+
+/// Get a role with its associated OS information.
+pub async fn get_with_os(conn: &Connection, id: i64) -> Result<RoleWithOs> {
+    let role = conn
+        .query_one(
+            "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
+                    r.created_at, r.updated_at, o.name, o.version
+             FROM roles r
+             JOIN operating_systems o ON r.os_id = o.id
+             WHERE r.id = ?1",
+            (id,),
+            |row| {
+                let disk_layout_json: String = row.get(4)?;
+                let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
+                let config_json: Option<String> = row.get(5)?;
+                let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
+
+                Ok(RoleWithOs {
+                    role: Role {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        description: row.get(2)?,
+                        os_id: row.get(3)?,
+                        disk_layout,
+                        config_template,
+                        created_at: row.get(6)?,
+                        updated_at: row.get(7)?,
+                    },
+                    os_name: row.get(8)?,
+                    os_version: row.get(9)?,
+                })
+            },
+        )
+        .await
+        .context("Role not found")?;
+
+    Ok(role)
+}
+
+/// List all roles with their OS information.
+pub async fn list_with_os(conn: &Connection) -> Result<Vec<RoleWithOs>> {
+    let roles = conn
+        .query(
+            "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
+                    r.created_at, r.updated_at, o.name, o.version
+             FROM roles r
+             JOIN operating_systems o ON r.os_id = o.id
+             ORDER BY r.name",
+            (),
+            |row| {
+                let disk_layout_json: String = row.get(4)?;
+                let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
+                let config_json: Option<String> = row.get(5)?;
+                let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
+
+                Ok(RoleWithOs {
+                    role: Role {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        description: row.get(2)?,
+                        os_id: row.get(3)?,
+                        disk_layout,
+                        config_template,
+                        created_at: row.get(6)?,
+                        updated_at: row.get(7)?,
+                    },
+                    os_name: row.get(8)?,
+                    os_version: row.get(9)?,
+                })
+            },
+        )
+        .await?;
+
+    Ok(roles)
+}
+
+/// Update a role.
+pub async fn update(
+    conn: &Connection,
+    id: i64,
+    name: Option<&str>,
+    description: Option<&str>,
+    os_id: Option<i64>,
+    disk_layout: Option<&DiskLayout>,
+    config_template: Option<&serde_json::Value>,
+) -> Result<Role> {
+    let now = Utc::now();
+
+    let mut updates = Vec::new();
+    let mut values: Vec<rusqlite::types::Value> = Vec::new();
+
+    if let Some(name) = name {
+        updates.push("name = ?");
+        values.push(rusqlite::types::Value::Text(name.to_string()));
+    }
+    if let Some(description) = description {
+        updates.push("description = ?");
+        values.push(rusqlite::types::Value::Text(description.to_string()));
+    }
+    if let Some(os_id) = os_id {
+        updates.push("os_id = ?");
+        values.push(rusqlite::types::Value::Integer(os_id));
+    }
+    if let Some(disk_layout) = disk_layout {
+        updates.push("disk_layout = ?");
+        let json = serde_json::to_string(disk_layout)?;
+        values.push(rusqlite::types::Value::Text(json));
+    }
+    if let Some(config_template) = config_template {
+        updates.push("config_template = ?");
+        let json = serde_json::to_string(config_template)?;
+        values.push(rusqlite::types::Value::Text(json));
     }
 
-    /// Create a new role.
-    pub async fn create(
-        &self,
-        name: &str,
-        description: Option<&str>,
-        os_id: i64,
-        disk_layout: &DiskLayout,
-        config_template: Option<&serde_json::Value>,
-    ) -> Result<Role> {
-        let now = Utc::now();
-        let disk_layout_json = serde_json::to_string(disk_layout)?;
-        let config_json = config_template.map(serde_json::to_string).transpose()?;
-
-        self.db
-            .execute(
-                "INSERT INTO roles (name, description, os_id, disk_layout, config_template, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                (name.to_string(), description.map(|s| s.to_string()), os_id, disk_layout_json, config_json, now, now),
-            )
-            .await
-            .context("Failed to insert role")?;
-
-        let id = self.db.last_insert_rowid().await;
-
-        Ok(Role {
-            id: Some(id),
-            name: name.to_string(),
-            description: description.map(|s| s.to_string()),
-            os_id,
-            disk_layout: disk_layout.clone(),
-            config_template: config_template.cloned(),
-            created_at: Some(now),
-            updated_at: Some(now),
-        })
+    if updates.is_empty() {
+        return get(conn, id).await;
     }
 
-    /// Get a role by ID.
-    pub async fn get(&self, id: i64) -> Result<Role> {
-        let role = self
-            .db
-            .query_one(
-                "SELECT id, name, description, os_id, disk_layout, config_template, created_at, updated_at
-                 FROM roles WHERE id = ?1",
-                (id,),
-                Role::from_row,
-            )
-            .await
-            .context("Role not found")?;
+    updates.push("updated_at = ?");
+    values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
+    values.push(rusqlite::types::Value::Integer(id));
 
-        Ok(role)
+    let query = format!("UPDATE roles SET {} WHERE id = ?", updates.join(", "));
+
+    conn.execute(query, rusqlite::params_from_iter(values))
+        .await?;
+
+    get(conn, id).await
+}
+
+/// Delete a role.
+pub async fn delete(conn: &Connection, id: i64) -> Result<()> {
+    let rows_affected = conn
+        .execute("DELETE FROM roles WHERE id = ?1", (id,))
+        .await
+        .context("Failed to delete role")?;
+
+    if rows_affected == 0 {
+        return Err(anyhow!("Role not found"));
     }
 
-    /// Get a role with its associated OS information.
-    pub async fn get_with_os(&self, id: i64) -> Result<RoleWithOs> {
-        let role = self
-            .db
-            .query_one(
-                "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
-                        r.created_at, r.updated_at, o.name, o.version
-                 FROM roles r
-                 JOIN operating_systems o ON r.os_id = o.id
-                 WHERE r.id = ?1",
-                (id,),
-                |row| {
-                    let disk_layout_json: String = row.get(4)?;
-                    let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
-                    let config_json: Option<String> = row.get(5)?;
-                    let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
-
-                    Ok(RoleWithOs {
-                        role: Role {
-                            id: row.get(0)?,
-                            name: row.get(1)?,
-                            description: row.get(2)?,
-                            os_id: row.get(3)?,
-                            disk_layout,
-                            config_template,
-                            created_at: row.get(6)?,
-                            updated_at: row.get(7)?,
-                        },
-                        os_name: row.get(8)?,
-                        os_version: row.get(9)?,
-                    })
-                },
-            )
-            .await
-            .context("Role not found")?;
-
-        Ok(role)
-    }
-
-    /// List all roles (only used in tests).
-    #[cfg(test)]
-    pub async fn list(&self) -> Result<Vec<Role>> {
-        let roles = self
-            .db
-            .query(
-                "SELECT id, name, description, os_id, disk_layout, config_template, created_at, updated_at
-                 FROM roles ORDER BY name",
-                (),
-                Role::from_row,
-            )
-            .await?;
-
-        Ok(roles)
-    }
-
-    /// List all roles with their OS information.
-    pub async fn list_with_os(&self) -> Result<Vec<RoleWithOs>> {
-        let roles = self
-            .db
-            .query(
-                "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
-                        r.created_at, r.updated_at, o.name, o.version
-                 FROM roles r
-                 JOIN operating_systems o ON r.os_id = o.id
-                 ORDER BY r.name",
-                (),
-                |row| {
-                    let disk_layout_json: String = row.get(4)?;
-                    let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
-                    let config_json: Option<String> = row.get(5)?;
-                    let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
-
-                    Ok(RoleWithOs {
-                        role: Role {
-                            id: row.get(0)?,
-                            name: row.get(1)?,
-                            description: row.get(2)?,
-                            os_id: row.get(3)?,
-                            disk_layout,
-                            config_template,
-                            created_at: row.get(6)?,
-                            updated_at: row.get(7)?,
-                        },
-                        os_name: row.get(8)?,
-                        os_version: row.get(9)?,
-                    })
-                },
-            )
-            .await?;
-
-        Ok(roles)
-    }
-
-    /// Update a role.
-    pub async fn update(
-        &self,
-        id: i64,
-        name: Option<&str>,
-        description: Option<&str>,
-        os_id: Option<i64>,
-        disk_layout: Option<&DiskLayout>,
-        config_template: Option<&serde_json::Value>,
-    ) -> Result<Role> {
-        let now = Utc::now();
-
-        let mut updates = Vec::new();
-        // Collect params as rusqlite Values for Send + 'static compatibility
-        let mut values: Vec<rusqlite::types::Value> = Vec::new();
-
-        if let Some(name) = name {
-            updates.push("name = ?");
-            values.push(rusqlite::types::Value::Text(name.to_string()));
-        }
-        if let Some(description) = description {
-            updates.push("description = ?");
-            values.push(rusqlite::types::Value::Text(description.to_string()));
-        }
-        if let Some(os_id) = os_id {
-            updates.push("os_id = ?");
-            values.push(rusqlite::types::Value::Integer(os_id));
-        }
-        if let Some(disk_layout) = disk_layout {
-            updates.push("disk_layout = ?");
-            let json = serde_json::to_string(disk_layout)?;
-            values.push(rusqlite::types::Value::Text(json));
-        }
-        if let Some(config_template) = config_template {
-            updates.push("config_template = ?");
-            let json = serde_json::to_string(config_template)?;
-            values.push(rusqlite::types::Value::Text(json));
-        }
-
-        if updates.is_empty() {
-            return self.get(id).await;
-        }
-
-        updates.push("updated_at = ?");
-        values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
-        values.push(rusqlite::types::Value::Integer(id));
-
-        let query = format!("UPDATE roles SET {} WHERE id = ?", updates.join(", "));
-
-        // Use execute with params_from_iter for dynamic query
-        self.db
-            .execute(query, rusqlite::params_from_iter(values))
-            .await?;
-
-        self.get(id).await
-    }
-
-    /// Delete a role.
-    pub async fn delete(&self, id: i64) -> Result<()> {
-        let rows_affected = self
-            .db
-            .execute("DELETE FROM roles WHERE id = ?1", (id,))
-            .await
-            .context("Failed to delete role")?;
-
-        if rows_affected == 0 {
-            return Err(anyhow!("Role not found"));
-        }
-
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::operating_systems::OperatingSystemsStore;
     use crate::roles::{DiskLayout, Partition};
     use crate::test_database_path;
 
-    async fn setup_db(path: String) -> Arc<Connection> {
-        Arc::new(crate::database::open(path).await.unwrap())
+    async fn setup_db(path: String) -> Connection {
+        let factory =
+            crate::database::DatabaseConnectionFactory::new(std::path::PathBuf::from(path));
+        crate::database::run_migrations(&factory).await.unwrap()
     }
 
     #[tokio::test]
     async fn test_create_and_get_role() {
         let db = setup_db(test_database_path!()).await;
-        let os_store = OperatingSystemsStore::new(db.clone());
-        let role_store = RolesStore::new(db);
 
         // Create OS first
-        let os = os_store.create("Ubuntu", "24.04", None).await.unwrap();
+        let os = crate::operating_systems::store::create(&db, "Ubuntu", "24.04", None)
+            .await
+            .unwrap();
 
         // Create role
         let disk_layout = DiskLayout {
@@ -264,21 +229,21 @@ mod tests {
             }],
         };
 
-        let role = role_store
-            .create(
-                "web-server",
-                Some("Web server role"),
-                os.id.unwrap(),
-                &disk_layout,
-                None,
-            )
-            .await
-            .unwrap();
+        let role = create(
+            &db,
+            "web-server",
+            Some("Web server role"),
+            os.id.unwrap(),
+            &disk_layout,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert!(role.id.is_some());
         assert_eq!(role.name, "web-server");
 
-        let retrieved = role_store.get(role.id.unwrap()).await.unwrap();
+        let retrieved = get(&db, role.id.unwrap()).await.unwrap();
         assert_eq!(retrieved.name, role.name);
         assert_eq!(retrieved.disk_layout.partitions.len(), 1);
     }
@@ -286,40 +251,37 @@ mod tests {
     #[tokio::test]
     async fn test_list_roles() {
         let db = setup_db(test_database_path!()).await;
-        let os_store = OperatingSystemsStore::new(db.clone());
-        let role_store = RolesStore::new(db);
 
-        let os = os_store.create("Ubuntu", "24.04", None).await.unwrap();
+        let os = crate::operating_systems::store::create(&db, "Ubuntu", "24.04", None)
+            .await
+            .unwrap();
         let disk_layout = DiskLayout { partitions: vec![] };
 
-        role_store
-            .create("role1", None, os.id.unwrap(), &disk_layout, None)
+        create(&db, "role1", None, os.id.unwrap(), &disk_layout, None)
             .await
             .unwrap();
-        role_store
-            .create("role2", None, os.id.unwrap(), &disk_layout, None)
+        create(&db, "role2", None, os.id.unwrap(), &disk_layout, None)
             .await
             .unwrap();
 
-        let list = role_store.list().await.unwrap();
+        let list = list_with_os(&db).await.unwrap();
         assert_eq!(list.len(), 2);
     }
 
     #[tokio::test]
     async fn test_get_with_os() {
         let db = setup_db(test_database_path!()).await;
-        let os_store = OperatingSystemsStore::new(db.clone());
-        let role_store = RolesStore::new(db);
 
-        let os = os_store.create("Ubuntu", "24.04", None).await.unwrap();
+        let os = crate::operating_systems::store::create(&db, "Ubuntu", "24.04", None)
+            .await
+            .unwrap();
         let disk_layout = DiskLayout { partitions: vec![] };
 
-        let role = role_store
-            .create("web-server", None, os.id.unwrap(), &disk_layout, None)
+        let role = create(&db, "web-server", None, os.id.unwrap(), &disk_layout, None)
             .await
             .unwrap();
 
-        let role_with_os = role_store.get_with_os(role.id.unwrap()).await.unwrap();
+        let role_with_os = get_with_os(&db, role.id.unwrap()).await.unwrap();
         assert_eq!(role_with_os.os_name, "Ubuntu");
         assert_eq!(role_with_os.os_version, "24.04");
     }
@@ -327,28 +289,27 @@ mod tests {
     #[tokio::test]
     async fn test_update_role() {
         let db = setup_db(test_database_path!()).await;
-        let os_store = OperatingSystemsStore::new(db.clone());
-        let role_store = RolesStore::new(db);
 
-        let os = os_store.create("Ubuntu", "24.04", None).await.unwrap();
+        let os = crate::operating_systems::store::create(&db, "Ubuntu", "24.04", None)
+            .await
+            .unwrap();
         let disk_layout = DiskLayout { partitions: vec![] };
 
-        let role = role_store
-            .create("web-server", None, os.id.unwrap(), &disk_layout, None)
+        let role = create(&db, "web-server", None, os.id.unwrap(), &disk_layout, None)
             .await
             .unwrap();
 
-        let updated = role_store
-            .update(
-                role.id.unwrap(),
-                Some("updated-name"),
-                Some("New description"),
-                None,
-                None,
-                None,
-            )
-            .await
-            .unwrap();
+        let updated = update(
+            &db,
+            role.id.unwrap(),
+            Some("updated-name"),
+            Some("New description"),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(updated.name, "updated-name");
         assert_eq!(updated.description, Some("New description".to_string()));
@@ -357,18 +318,17 @@ mod tests {
     #[tokio::test]
     async fn test_delete_role() {
         let db = setup_db(test_database_path!()).await;
-        let os_store = OperatingSystemsStore::new(db.clone());
-        let role_store = RolesStore::new(db);
 
-        let os = os_store.create("Ubuntu", "24.04", None).await.unwrap();
+        let os = crate::operating_systems::store::create(&db, "Ubuntu", "24.04", None)
+            .await
+            .unwrap();
         let disk_layout = DiskLayout { partitions: vec![] };
 
-        let role = role_store
-            .create("web-server", None, os.id.unwrap(), &disk_layout, None)
+        let role = create(&db, "web-server", None, os.id.unwrap(), &disk_layout, None)
             .await
             .unwrap();
 
-        role_store.delete(role.id.unwrap()).await.unwrap();
-        assert!(role_store.get(role.id.unwrap()).await.is_err());
+        delete(&db, role.id.unwrap()).await.unwrap();
+        assert!(get(&db, role.id.unwrap()).await.is_err());
     }
 }

--- a/rack-director/src/roles/store.rs
+++ b/rack-director/src/roles/store.rs
@@ -1,21 +1,21 @@
 use super::{DiskLayout, Role, RoleWithOs};
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use rusqlite::{Connection, params};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+
+use crate::database::{Connection, FromRow};
 
 #[derive(Clone)]
 pub struct RolesStore {
-    db: Arc<Mutex<Connection>>,
+    db: Arc<Connection>,
 }
 
 impl RolesStore {
-    pub fn new(db: Arc<Mutex<Connection>>) -> Self {
+    pub fn new(db: Arc<Connection>) -> Self {
         Self { db }
     }
 
-    /// Create a new role
+    /// Create a new role.
     pub async fn create(
         &self,
         name: &str,
@@ -24,19 +24,20 @@ impl RolesStore {
         disk_layout: &DiskLayout,
         config_template: Option<&serde_json::Value>,
     ) -> Result<Role> {
-        let conn = self.db.lock().await;
         let now = Utc::now();
         let disk_layout_json = serde_json::to_string(disk_layout)?;
         let config_json = config_template.map(serde_json::to_string).transpose()?;
 
-        conn.execute(
-            "INSERT INTO roles (name, description, os_id, disk_layout, config_template, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![name, description, os_id, disk_layout_json, config_json, now, now],
-        )
-        .context("Failed to insert role")?;
+        self.db
+            .execute(
+                "INSERT INTO roles (name, description, os_id, disk_layout, config_template, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                (name.to_string(), description.map(|s| s.to_string()), os_id, disk_layout_json, config_json, now, now),
+            )
+            .await
+            .context("Failed to insert role")?;
 
-        let id = conn.last_insert_rowid();
+        let id = self.db.last_insert_rowid().await;
 
         Ok(Role {
             id: Some(id),
@@ -50,118 +51,116 @@ impl RolesStore {
         })
     }
 
-    /// Get a role by ID
+    /// Get a role by ID.
     pub async fn get(&self, id: i64) -> Result<Role> {
-        let conn = self.db.lock().await;
-
-        let role = crate::database::query_one::<Role>(
-            &conn,
-            "SELECT id, name, description, os_id, disk_layout, config_template, created_at, updated_at
-             FROM roles WHERE id = ?1",
-            &[&id],
-        )
-        .context("Role not found")?;
-
-        Ok(role)
-    }
-
-    /// Get a role with its associated OS information
-    pub async fn get_with_os(&self, id: i64) -> Result<RoleWithOs> {
-        let conn = self.db.lock().await;
-
-        let mut stmt = conn.prepare(
-            "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
-                    r.created_at, r.updated_at, o.name, o.version
-             FROM roles r
-             JOIN operating_systems o ON r.os_id = o.id
-             WHERE r.id = ?1",
-        )?;
-
-        let role = stmt
-            .query_row(params![id], |row| {
-                let disk_layout_json: String = row.get(4)?;
-                let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
-                let config_json: Option<String> = row.get(5)?;
-                let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
-
-                Ok(RoleWithOs {
-                    role: Role {
-                        id: row.get(0)?,
-                        name: row.get(1)?,
-                        description: row.get(2)?,
-                        os_id: row.get(3)?,
-                        disk_layout,
-                        config_template,
-                        created_at: row.get(6)?,
-                        updated_at: row.get(7)?,
-                    },
-                    os_name: row.get(8)?,
-                    os_version: row.get(9)?,
-                })
-            })
+        let role = self
+            .db
+            .query_one(
+                "SELECT id, name, description, os_id, disk_layout, config_template, created_at, updated_at
+                 FROM roles WHERE id = ?1",
+                (id,),
+                Role::from_row,
+            )
+            .await
             .context("Role not found")?;
 
         Ok(role)
     }
 
-    /// List all roles (only used in tests)
+    /// Get a role with its associated OS information.
+    pub async fn get_with_os(&self, id: i64) -> Result<RoleWithOs> {
+        let role = self
+            .db
+            .query_one(
+                "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
+                        r.created_at, r.updated_at, o.name, o.version
+                 FROM roles r
+                 JOIN operating_systems o ON r.os_id = o.id
+                 WHERE r.id = ?1",
+                (id,),
+                |row| {
+                    let disk_layout_json: String = row.get(4)?;
+                    let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
+                    let config_json: Option<String> = row.get(5)?;
+                    let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
+
+                    Ok(RoleWithOs {
+                        role: Role {
+                            id: row.get(0)?,
+                            name: row.get(1)?,
+                            description: row.get(2)?,
+                            os_id: row.get(3)?,
+                            disk_layout,
+                            config_template,
+                            created_at: row.get(6)?,
+                            updated_at: row.get(7)?,
+                        },
+                        os_name: row.get(8)?,
+                        os_version: row.get(9)?,
+                    })
+                },
+            )
+            .await
+            .context("Role not found")?;
+
+        Ok(role)
+    }
+
+    /// List all roles (only used in tests).
     #[cfg(test)]
     pub async fn list(&self) -> Result<Vec<Role>> {
-        let conn = self.db.lock().await;
-
-        let roles = crate::database::query_map_all::<Role>(
-            &conn,
-            "SELECT id, name, description, os_id, disk_layout, config_template, created_at, updated_at
-             FROM roles ORDER BY name",
-            &[],
-        )?;
+        let roles = self
+            .db
+            .query(
+                "SELECT id, name, description, os_id, disk_layout, config_template, created_at, updated_at
+                 FROM roles ORDER BY name",
+                (),
+                Role::from_row,
+            )
+            .await?;
 
         Ok(roles)
     }
 
-    /// List all roles with their OS information
+    /// List all roles with their OS information.
     pub async fn list_with_os(&self) -> Result<Vec<RoleWithOs>> {
-        let conn = self.db.lock().await;
+        let roles = self
+            .db
+            .query(
+                "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
+                        r.created_at, r.updated_at, o.name, o.version
+                 FROM roles r
+                 JOIN operating_systems o ON r.os_id = o.id
+                 ORDER BY r.name",
+                (),
+                |row| {
+                    let disk_layout_json: String = row.get(4)?;
+                    let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
+                    let config_json: Option<String> = row.get(5)?;
+                    let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
 
-        let mut stmt = conn.prepare(
-            "SELECT r.id, r.name, r.description, r.os_id, r.disk_layout, r.config_template,
-                    r.created_at, r.updated_at, o.name, o.version
-             FROM roles r
-             JOIN operating_systems o ON r.os_id = o.id
-             ORDER BY r.name",
-        )?;
-
-        let rows = stmt.query_map(params![], |row| {
-            let disk_layout_json: String = row.get(4)?;
-            let disk_layout: DiskLayout = serde_json::from_str(&disk_layout_json).unwrap();
-            let config_json: Option<String> = row.get(5)?;
-            let config_template = config_json.and_then(|s| serde_json::from_str(&s).ok());
-
-            Ok(RoleWithOs {
-                role: Role {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    description: row.get(2)?,
-                    os_id: row.get(3)?,
-                    disk_layout,
-                    config_template,
-                    created_at: row.get(6)?,
-                    updated_at: row.get(7)?,
+                    Ok(RoleWithOs {
+                        role: Role {
+                            id: row.get(0)?,
+                            name: row.get(1)?,
+                            description: row.get(2)?,
+                            os_id: row.get(3)?,
+                            disk_layout,
+                            config_template,
+                            created_at: row.get(6)?,
+                            updated_at: row.get(7)?,
+                        },
+                        os_name: row.get(8)?,
+                        os_version: row.get(9)?,
+                    })
                 },
-                os_name: row.get(8)?,
-                os_version: row.get(9)?,
-            })
-        })?;
-
-        let mut roles = Vec::new();
-        for row in rows {
-            roles.push(row?);
-        }
+            )
+            .await?;
 
         Ok(roles)
     }
 
-    /// Update a role
+    /// Update a role.
     pub async fn update(
         &self,
         id: i64,
@@ -171,63 +170,59 @@ impl RolesStore {
         disk_layout: Option<&DiskLayout>,
         config_template: Option<&serde_json::Value>,
     ) -> Result<Role> {
-        let needs_update = {
-            let conn = self.db.lock().await;
-            let now = Utc::now();
+        let now = Utc::now();
 
-            let mut updates = Vec::new();
-            let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        let mut updates = Vec::new();
+        // Collect params as rusqlite Values for Send + 'static compatibility
+        let mut values: Vec<rusqlite::types::Value> = Vec::new();
 
-            if let Some(name) = name {
-                updates.push("name = ?");
-                params.push(Box::new(name.to_string()));
-            }
-            if let Some(description) = description {
-                updates.push("description = ?");
-                params.push(Box::new(description.to_string()));
-            }
-            if let Some(os_id) = os_id {
-                updates.push("os_id = ?");
-                params.push(Box::new(os_id));
-            }
-            if let Some(disk_layout) = disk_layout {
-                updates.push("disk_layout = ?");
-                let json = serde_json::to_string(disk_layout)?;
-                params.push(Box::new(json));
-            }
-            if let Some(config_template) = config_template {
-                updates.push("config_template = ?");
-                let json = serde_json::to_string(config_template)?;
-                params.push(Box::new(json));
-            }
+        if let Some(name) = name {
+            updates.push("name = ?");
+            values.push(rusqlite::types::Value::Text(name.to_string()));
+        }
+        if let Some(description) = description {
+            updates.push("description = ?");
+            values.push(rusqlite::types::Value::Text(description.to_string()));
+        }
+        if let Some(os_id) = os_id {
+            updates.push("os_id = ?");
+            values.push(rusqlite::types::Value::Integer(os_id));
+        }
+        if let Some(disk_layout) = disk_layout {
+            updates.push("disk_layout = ?");
+            let json = serde_json::to_string(disk_layout)?;
+            values.push(rusqlite::types::Value::Text(json));
+        }
+        if let Some(config_template) = config_template {
+            updates.push("config_template = ?");
+            let json = serde_json::to_string(config_template)?;
+            values.push(rusqlite::types::Value::Text(json));
+        }
 
-            if updates.is_empty() {
-                false
-            } else {
-                updates.push("updated_at = ?");
-                params.push(Box::new(now));
-                params.push(Box::new(id));
-
-                let query = format!("UPDATE roles SET {} WHERE id = ?", updates.join(", "));
-
-                conn.execute(&query, rusqlite::params_from_iter(params.iter()))?;
-                true
-            }
-        };
-
-        if !needs_update {
+        if updates.is_empty() {
             return self.get(id).await;
         }
+
+        updates.push("updated_at = ?");
+        values.push(rusqlite::types::Value::Text(now.to_rfc3339()));
+        values.push(rusqlite::types::Value::Integer(id));
+
+        let query = format!("UPDATE roles SET {} WHERE id = ?", updates.join(", "));
+
+        // Use execute with params_from_iter for dynamic query
+        self.db
+            .execute(query, rusqlite::params_from_iter(values))
+            .await?;
 
         self.get(id).await
     }
 
-    /// Delete a role
+    /// Delete a role.
     pub async fn delete(&self, id: i64) -> Result<()> {
-        let conn = self.db.lock().await;
-
-        let rows_affected = conn
-            .execute("DELETE FROM roles WHERE id = ?1", params![id])
+        let rows_affected = self
+            .db
+            .execute("DELETE FROM roles WHERE id = ?1", (id,))
+            .await
             .context("Failed to delete role")?;
 
         if rows_affected == 0 {
@@ -241,19 +236,17 @@ impl RolesStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database;
     use crate::operating_systems::OperatingSystemsStore;
     use crate::roles::{DiskLayout, Partition};
+    use crate::test_database_path;
 
-    fn setup_db() -> Arc<Mutex<Connection>> {
-        let conn = Connection::open_in_memory().unwrap();
-        database::run_migrations(&conn).unwrap();
-        Arc::new(Mutex::new(conn))
+    async fn setup_db(path: String) -> Arc<Connection> {
+        Arc::new(crate::database::open(path).await.unwrap())
     }
 
     #[tokio::test]
     async fn test_create_and_get_role() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let os_store = OperatingSystemsStore::new(db.clone());
         let role_store = RolesStore::new(db);
 
@@ -292,7 +285,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_roles() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let os_store = OperatingSystemsStore::new(db.clone());
         let role_store = RolesStore::new(db);
 
@@ -314,7 +307,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_with_os() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let os_store = OperatingSystemsStore::new(db.clone());
         let role_store = RolesStore::new(db);
 
@@ -333,7 +326,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_role() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let os_store = OperatingSystemsStore::new(db.clone());
         let role_store = RolesStore::new(db);
 
@@ -363,7 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_role() {
-        let db = setup_db();
+        let db = setup_db(test_database_path!()).await;
         let os_store = OperatingSystemsStore::new(db.clone());
         let role_store = RolesStore::new(db);
 


### PR DESCRIPTION
Refactor database usage to move from a singleton Connection object guarded by a Mutex to a Connection per task or request. This opens up the ability for tasks to use Transactions and improve concurrency without risking interleaving bugs.