### PR TITLE
Use IP-bound sockets for DHCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1457,6 +1457,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-interface"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddcb8865ad3d9950f22f42ffa0ef0aecbfbf191867b3122413602b0a360b2a6"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror 2.0.17",
+ "winapi",
+]
+
+[[package]]
 name = "num-modular"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,7 +1778,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1803,7 +1815,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1859,16 +1871,19 @@ dependencies = [
  "futures",
  "handlebars",
  "log",
+ "network-interface",
  "object_store",
  "rand 0.8.5",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "stdext",
  "tempfile",
  "tftp_client",
  "tokio",
+ "tokio-recvmsg",
  "tokio-test",
  "tower 0.4.13",
  "uuid",
@@ -2348,6 +2363,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2552,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -2551,6 +2576,17 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-recvmsg"
+version = "0.1.0"
+source = "git+https://github.com/nik-johnson-net/tokio-recvmsg#8fcd596713a4b001be0859ec79b3f1653c2a631f"
+dependencies = [
+ "libc",
+ "socket2 0.6.2",
+ "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2951,6 +2987,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,6 +3010,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ clap = { version = "4.5.40", features = ["derive"] }
 dhcproto = "0.14"
 handlebars = "6.2"
 log = { version = "0.4.27", features = ["kv"] }
+network-interface = "2"
 reqwest = { version = "0.12", features = ["json"] }
 rusqlite = { version = "0.36.0", features = ["bundled", "chrono"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
+socket2 = "0.5"
 env_logger = "0.11"
 tempfile = "3.12"
 tokio = { version = "1.45.1", features = ["rt-multi-thread", "net", "macros", "sync", "signal", "fs", "time", "io-util", "process"] }
+tokio-recvmsg = { git = "https://github.com/nik-johnson-net/tokio-recvmsg" }
 tokio-test = "0.4"
 tower = { version = "0.4", features = ["util"] }

--- a/rack-director/Cargo.toml
+++ b/rack-director/Cargo.toml
@@ -16,12 +16,15 @@ dhcproto = { workspace = true }
 futures = "0.3"
 handlebars = { workspace = true }
 log = { workspace = true }
+network-interface = { workspace = true }
 rand = "0.8"
 rusqlite = { workspace = true, features = ["uuid"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+socket2 = { workspace = true }
 env_logger = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
+tokio-recvmsg = { workspace = true }
 uuid = { version = "1.20.0", features = ["serde"] }
 object_store = { version = "0.13.1", features = ["aws"] }
 

--- a/rack-director/src/boot_files/filesystem.rs
+++ b/rack-director/src/boot_files/filesystem.rs
@@ -17,26 +17,6 @@ use crate::tftp::{Handler, TftpReader};
 /// Path validation is performed using canonicalization to prevent directory traversal
 /// attacks. The canonicalized requested path must be within the canonicalized base path.
 /// Any attempt to access files outside the base directory will be rejected.
-///
-/// # Example
-///
-/// ```no_run
-/// use rack_director::boot_files::{FilesystemBootFileProvider, BootFileProvider};
-/// use std::path::PathBuf;
-///
-/// # async fn example() -> anyhow::Result<()> {
-/// let provider = FilesystemBootFileProvider::new(
-///     PathBuf::from("/var/lib/tftpboot"),
-/// )?;
-///
-/// // This will succeed if the file exists
-/// let reader = provider.get_file("snponly.efi").await?;
-///
-/// // This will fail due to path traversal attempt
-/// assert!(provider.get_file("../etc/passwd").await.is_err());
-/// # Ok(())
-/// # }
-/// ```
 #[derive(Debug)]
 pub struct FilesystemBootFileProvider {
     base_path: PathBuf,

--- a/rack-director/src/dhcp/handler.rs
+++ b/rack-director/src/dhcp/handler.rs
@@ -8,15 +8,30 @@ use dhcproto::{
 use log::{debug, info, trace, warn};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use tokio::net::UdpSocket;
+use tokio_recvmsg::PktInfo;
 
 use super::allocator;
 use super::boot_config::BootConfigProvider;
 use super::device_resolution::{DeviceContext, DeviceResolver};
+use super::interface;
 use super::message_builder;
 use super::request::{RequestContext, extract_server_identifier};
 use super::store::{self, DhcpNetwork, LeaseState, format_mac};
 use crate::database::{Connection, ConnectionFactory};
+
+/// Reply to send after processing a DHCP packet.
+pub enum DhcpReply {
+    /// L2 client response. `local_ip` selects which per-network socket to send from.
+    /// `peer_addr` is the source address of the received packet — used to decide
+    /// whether to broadcast (peer IP is unspecified) or unicast (peer IP is set, e.g. test/renewal).
+    L2 {
+        data: Vec<u8>,
+        local_ip: Ipv4Addr,
+        peer_addr: SocketAddr,
+    },
+    /// Relay agent response — unicast to the relay agent on port 67.
+    Relay { data: Vec<u8>, dest: SocketAddr },
+}
 
 /// Determines the appropriate vendor class identifier (Option 60) based on client architecture.
 ///
@@ -76,101 +91,154 @@ impl DhcpHandler {
         }
     }
 
+    /// Handle a DHCP packet received on the wildcard broadcast socket.
+    ///
+    /// Uses the `PktInfo` (interface index and destination address) from recvmsg to identify
+    /// which L2 network the packet belongs to. For relay-agent packets (giaddr != 0), falls
+    /// back to relay-based network selection.
     pub async fn handle_packet(
         &self,
         data: &[u8],
-        peer_addr: SocketAddr,
-        socket: Arc<UdpSocket>,
-    ) -> Result<()> {
-        // Decode DHCP message using dhcproto
+        pkt_info: &PktInfo,
+    ) -> Result<Option<DhcpReply>> {
         let msg = match Message::decode(&mut Decoder::new(data)) {
             Ok(msg) => msg,
             Err(e) => {
                 log::warn!("Failed to decode DHCP message: {}", e);
-                return Ok(());
+                return Ok(None);
             }
         };
 
         trace!("DHCP: Received packet {:?}", msg);
-
-        // Open one connection per packet to avoid shared-connection contention
         let conn = self.db.open().await?;
 
-        // Extract relay agent address (giaddr)
-        let relay_agent = if msg.giaddr() != Ipv4Addr::UNSPECIFIED {
-            Some(msg.giaddr())
-        } else {
-            None
-        };
+        // If relay agent (giaddr != 0), use relay-based network selection
+        if msg.giaddr() != Ipv4Addr::UNSPECIFIED {
+            let relay_agent = msg.giaddr();
+            let network = match store::get_network_by_relay(&conn, Some(relay_agent)).await? {
+                Some(n) => n,
+                None => {
+                    log::warn!("No network found for relay agent {}", relay_agent);
+                    return Ok(None);
+                }
+            };
+            debug!(
+                "Using network '{}' (id={}) for relay {}",
+                network.name, network.id, relay_agent
+            );
+            let dest = SocketAddr::new(relay_agent.into(), 67);
+            return self
+                .process_and_reply(&conn, &msg, &network, self.server_identifier, move |data| {
+                    DhcpReply::Relay { data, dest }
+                })
+                .await;
+        }
 
-        // Match to network based on relay agent
-        let network = match store::get_network_by_relay(&conn, relay_agent).await? {
-            Some(network) => network,
-            None => {
-                log::warn!("No network found for relay agent {:?}", relay_agent);
-                return Ok(());
+        // L2 path: use interface index to find matching network
+        let l2_networks = store::get_l2_networks(&conn).await?;
+        let Some((network, local_ip)) =
+            interface::find_matching_l2_network(pkt_info.if_index, &l2_networks)?
+        else {
+            debug!(
+                "No L2 network matches interface {}, dropping",
+                pkt_info.if_index
+            );
+            return Ok(None);
+        };
+        debug!(
+            "Using network '{}' (id={}) for interface index {} (local_ip={})",
+            network.name, network.id, pkt_info.if_index, local_ip
+        );
+        let peer_addr = pkt_info.addr_src;
+        self.process_and_reply(&conn, &msg, network, local_ip, move |data| DhcpReply::L2 {
+            data,
+            local_ip,
+            peer_addr,
+        })
+        .await
+    }
+
+    /// Handle a DHCP packet received on a per-network socket (unicast renewals).
+    ///
+    /// The `local_ip` is the address the per-network socket is bound to, which identifies
+    /// which L2 network this packet belongs to.
+    pub async fn handle_l2_unicast_packet(
+        &self,
+        data: &[u8],
+        peer_addr: SocketAddr,
+        local_ip: Ipv4Addr,
+    ) -> Result<Option<DhcpReply>> {
+        let msg = match Message::decode(&mut Decoder::new(data)) {
+            Ok(msg) => msg,
+            Err(e) => {
+                log::warn!("Failed to decode DHCP message: {}", e);
+                return Ok(None);
             }
         };
 
-        debug!(
-            "Using network '{}' (id={}) for relay {:?}",
-            network.name, network.id, relay_agent
-        );
+        trace!("DHCP unicast: Received packet {:?}", msg);
+        let conn = self.db.open().await?;
 
+        let l2_networks = store::get_l2_networks(&conn).await?;
+        let Some(network) = interface::find_l2_network_for_ip(local_ip, &l2_networks)? else {
+            debug!("No L2 network matches local IP {}, dropping", local_ip);
+            return Ok(None);
+        };
+        debug!(
+            "Unicast: Using network '{}' (id={}) for local_ip={}",
+            network.name, network.id, local_ip
+        );
+        self.process_and_reply(&conn, &msg, network, local_ip, move |data| DhcpReply::L2 {
+            data,
+            local_ip,
+            peer_addr,
+        })
+        .await
+    }
+
+    /// Shared logic for processing a DHCP message against a selected network and producing a reply.
+    async fn process_and_reply<F>(
+        &self,
+        conn: &Connection,
+        msg: &Message,
+        network: &DhcpNetwork,
+        server_identifier: Ipv4Addr,
+        make_reply: F,
+    ) -> Result<Option<DhcpReply>>
+    where
+        F: FnOnce(Vec<u8>) -> DhcpReply,
+    {
         let response = match msg.opts().msg_type() {
-            Some(MessageType::Discover) => self.handle_discover(&conn, &msg, &network).await?,
-            Some(MessageType::Request) => self.handle_request(&conn, &msg, &network).await?,
+            Some(MessageType::Discover) => {
+                self.handle_discover(conn, msg, network, server_identifier)
+                    .await?
+            }
+            Some(MessageType::Request) => {
+                self.handle_request(conn, msg, network, server_identifier)
+                    .await?
+            }
             Some(MessageType::Release) => {
-                self.handle_release(&conn, &msg).await?;
+                self.handle_release(conn, msg).await?;
                 None
             }
             Some(MessageType::Decline) => {
-                self.handle_decline(&conn, &msg).await?;
+                self.handle_decline(conn, msg).await?;
                 None
             }
             _ => {
                 log::debug!("Ignoring unsupported DHCP message type");
-                return Ok(());
+                return Ok(None);
             }
         };
 
         if let Some(resp) = response {
             trace!("DHCP: Sending response {:?}", resp);
-            self.send_response(resp, &msg, peer_addr, socket).await?;
-        }
-
-        Ok(())
-    }
-
-    /// Send DHCP response following RFC 3046 relay agent rules
-    async fn send_response(
-        &self,
-        resp: Message,
-        req: &Message,
-        peer_addr: SocketAddr,
-        socket: Arc<UdpSocket>,
-    ) -> Result<()> {
-        let mut buf = Vec::new();
-        resp.encode(&mut Encoder::new(&mut buf))?;
-
-        // RFC 3046: If giaddr is set, send to relay agent on port 67
-        // Otherwise, send to peer (broadcast or unicast)
-        let dest = if req.giaddr() != Ipv4Addr::UNSPECIFIED {
-            SocketAddr::new(req.giaddr().into(), 67)
+            let mut buf = Vec::new();
+            resp.encode(&mut Encoder::new(&mut buf))?;
+            Ok(Some(make_reply(buf)))
         } else {
-            // For localhost testing, we send unicast to the peer address
-            // In production, this would be broadcast to 255.255.255.255:68
-            if peer_addr.ip().is_unspecified() {
-                SocketAddr::new(Ipv4Addr::BROADCAST.into(), 68)
-            } else {
-                peer_addr
-            }
-        };
-
-        debug!("Sending DHCP response to {}", dest);
-        socket.send_to(&buf, dest).await?;
-
-        Ok(())
+            Ok(None)
+        }
     }
 
     async fn handle_discover(
@@ -178,6 +246,7 @@ impl DhcpHandler {
         conn: &Connection,
         msg: &Message,
         network: &DhcpNetwork,
+        server_identifier: Ipv4Addr,
     ) -> Result<Option<Message>> {
         let req_ctx = RequestContext::from_message(msg);
 
@@ -203,7 +272,7 @@ impl DhcpHandler {
                 dev_ctx
                     .device_uuid
                     .as_ref()
-                    .map(|u| u.to_string())
+                    .map(|u: &uuid::Uuid| u.to_string())
                     .unwrap_or_default(),
                 dev_ctx.disable_reason.as_deref().unwrap_or("unknown")
             );
@@ -235,7 +304,7 @@ impl DhcpHandler {
         .await?;
 
         let offer = self
-            .build_offer(msg, ip, network, &req_ctx, &dev_ctx)
+            .build_offer(msg, ip, network, &req_ctx, &dev_ctx, server_identifier)
             .await?;
         info!(
             "DHCP OFFER {} to MAC {} on network '{}'",
@@ -250,18 +319,19 @@ impl DhcpHandler {
         conn: &Connection,
         msg: &Message,
         network: &DhcpNetwork,
+        server_identifier: Ipv4Addr,
     ) -> Result<Option<Message>> {
         let req_ctx = RequestContext::from_message(msg);
 
         // Check Server Identifier option (Option 54) per RFC 2131 Section 4.3.2
         // If present, only respond if it matches our server identifier
         if let Some(server_id) = extract_server_identifier(msg)
-            && server_id != self.server_identifier
+            && server_id != server_identifier
         {
             // This request is for a different DHCP server - ignore it
             debug!(
                 "Ignoring DHCPREQUEST from {} - server identifier {} doesn't match ours {}",
-                req_ctx.mac, server_id, self.server_identifier
+                req_ctx.mac, server_id, server_identifier
             );
             return Ok(None);
         }
@@ -290,7 +360,7 @@ impl DhcpHandler {
                 dev_ctx
                     .device_uuid
                     .as_ref()
-                    .map(|u| u.to_string())
+                    .map(|u: &uuid::Uuid| u.to_string())
                     .unwrap_or_default(),
                 dev_ctx.disable_reason.as_deref().unwrap_or("unknown")
             );
@@ -304,7 +374,7 @@ impl DhcpHandler {
             req_ctx.ciaddr
         } else {
             warn!("DHCP REQUEST without requested IP or ciaddr");
-            return Ok(Some(self.build_nak(msg)?));
+            return Ok(Some(self.build_nak(msg, server_identifier)?));
         };
 
         debug!("Requested IP: {}", requested_ip);
@@ -322,7 +392,7 @@ impl DhcpHandler {
                     "NAKing DHCPREQUEST from {} - requested {} but static reservation is {}",
                     req_ctx.mac, requested_ip, reserved_ip
                 );
-                return Ok(Some(self.build_nak(msg)?));
+                return Ok(Some(self.build_nak(msg, server_identifier)?));
             }
 
             // Static reservation matches requested IP - update or create lease
@@ -344,7 +414,14 @@ impl DhcpHandler {
             }
 
             let ack = self
-                .build_ack(msg, reserved_ip, network, &req_ctx, &dev_ctx)
+                .build_ack(
+                    msg,
+                    reserved_ip,
+                    network,
+                    &req_ctx,
+                    &dev_ctx,
+                    server_identifier,
+                )
                 .await?;
             info!(
                 "DHCP ACK {} to MAC {} on network '{}' (static reservation)",
@@ -363,7 +440,7 @@ impl DhcpHandler {
                     "DHCP REQUEST IP mismatch: requested {}, expected {}",
                     requested_ip, lease_ip
                 );
-                return Ok(Some(self.build_nak(msg)?));
+                return Ok(Some(self.build_nak(msg, server_identifier)?));
             }
 
             // Update lease to 'active'
@@ -375,7 +452,14 @@ impl DhcpHandler {
             }
 
             let ack = self
-                .build_ack(msg, lease_ip, network, &req_ctx, &dev_ctx)
+                .build_ack(
+                    msg,
+                    lease_ip,
+                    network,
+                    &req_ctx,
+                    &dev_ctx,
+                    server_identifier,
+                )
                 .await?;
             info!(
                 "DHCP ACK {} to MAC {} on network '{}'",
@@ -385,7 +469,7 @@ impl DhcpHandler {
             Ok(Some(ack))
         } else {
             warn!("No lease found for MAC {}", req_ctx.mac);
-            Ok(Some(self.build_nak(msg)?))
+            Ok(Some(self.build_nak(msg, server_identifier)?))
         }
     }
 
@@ -419,14 +503,15 @@ impl DhcpHandler {
         network: &DhcpNetwork,
         req_ctx: &RequestContext,
         _dev_ctx: &DeviceContext,
+        server_identifier: Ipv4Addr,
     ) -> Result<Message> {
-        let mut msg = message_builder::create_base_reply(req, &self.server_identifier);
+        let mut msg = message_builder::create_base_reply(req, &server_identifier);
         msg.set_yiaddr(ip);
 
         msg.opts_mut()
             .insert(v4::DhcpOption::MessageType(MessageType::Offer));
         msg.opts_mut()
-            .insert(v4::DhcpOption::ServerIdentifier(self.server_identifier));
+            .insert(v4::DhcpOption::ServerIdentifier(server_identifier));
         msg.opts_mut()
             .insert(v4::DhcpOption::AddressLeaseTime(network.lease_duration));
 
@@ -451,16 +536,19 @@ impl DhcpHandler {
         network: &DhcpNetwork,
         req_ctx: &RequestContext,
         dev_ctx: &DeviceContext,
+        server_identifier: Ipv4Addr,
     ) -> Result<Message> {
-        let mut msg = self.build_offer(req, ip, network, req_ctx, dev_ctx).await?;
+        let mut msg = self
+            .build_offer(req, ip, network, req_ctx, dev_ctx, server_identifier)
+            .await?;
         msg.opts_mut()
             .insert(v4::DhcpOption::MessageType(MessageType::Ack));
 
         Ok(msg)
     }
 
-    fn build_nak(&self, req: &Message) -> Result<Message> {
-        Ok(message_builder::build_nak(req, self.server_identifier))
+    fn build_nak(&self, req: &Message, server_identifier: Ipv4Addr) -> Result<Message> {
+        Ok(message_builder::build_nak(req, server_identifier))
     }
 }
 
@@ -505,6 +593,7 @@ mod tests {
                 &network,
                 &req_ctx,
                 &dev_ctx,
+                handler.server_identifier,
             )
             .await
             .unwrap();
@@ -542,7 +631,9 @@ mod tests {
             .insert(v4::DhcpOption::MessageType(MessageType::Request));
 
         // Build a NAK response
-        let nak = handler.build_nak(&request).unwrap();
+        let nak = handler
+            .build_nak(&request, handler.server_identifier)
+            .unwrap();
 
         // Verify the server identifier matches the handler's configured value
         let server_id = nak
@@ -649,6 +740,7 @@ mod tests {
                 &network,
                 &req_ctx,
                 &dev_ctx,
+                custom_server_id,
             )
             .await
             .unwrap();
@@ -774,6 +866,7 @@ mod tests {
                 &network,
                 &req_context,
                 &device_context,
+                handler.server_identifier,
             )
             .await
             .unwrap();
@@ -906,6 +999,7 @@ mod tests {
                 &network,
                 &req_ctx,
                 &dev_ctx,
+                handler.server_identifier,
             )
             .await
             .unwrap();
@@ -967,6 +1061,7 @@ mod tests {
                 &network,
                 &req_ctx,
                 &dev_ctx,
+                handler.server_identifier,
             )
             .await
             .unwrap();
@@ -1028,6 +1123,7 @@ mod tests {
                 &network,
                 &req_ctx,
                 &dev_ctx,
+                handler.server_identifier,
             )
             .await
             .unwrap();
@@ -1093,7 +1189,7 @@ mod tests {
 
         // Handle the request
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1165,7 +1261,7 @@ mod tests {
 
         // Handle the request
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1214,7 +1310,7 @@ mod tests {
 
         // Handle the request
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1279,7 +1375,7 @@ mod tests {
 
         // Handle the request
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1339,7 +1435,7 @@ mod tests {
 
         let network = store::get_network(&conn, network_id).await.unwrap();
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1392,7 +1488,7 @@ mod tests {
 
         let network = store::get_network(&conn, network_id).await.unwrap();
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1446,7 +1542,7 @@ mod tests {
 
         let network = store::get_network(&conn, network_id).await.unwrap();
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1519,7 +1615,7 @@ mod tests {
 
         let network = store::get_network(&conn, network_id).await.unwrap();
         let response = handler
-            .handle_request(&conn, &request, &network)
+            .handle_request(&conn, &request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1585,7 +1681,7 @@ mod tests {
 
         let network = store::get_network(&conn, network_id).await.unwrap();
         let response = handler
-            .handle_request(&conn, &renew_request, &network)
+            .handle_request(&conn, &renew_request, &network, handler.server_identifier)
             .await
             .unwrap();
 
@@ -1610,7 +1706,7 @@ mod tests {
             .insert(v4::DhcpOption::RequestedIpAddress(reserved_ip));
 
         let response = handler
-            .handle_request(&conn, &new_request, &network)
+            .handle_request(&conn, &new_request, &network, handler.server_identifier)
             .await
             .unwrap();
 

--- a/rack-director/src/dhcp/interface.rs
+++ b/rack-director/src/dhcp/interface.rs
@@ -23,10 +23,10 @@ pub fn get_ipv4_addresses_for_interface(if_index: u32) -> anyhow::Result<Vec<Ipv
 ///
 /// The local IP is used as the source IP for sending (so replies egress on the correct interface)
 /// and as the DHCP Server Identifier (Option 54) in the reply.
-pub fn find_matching_l2_network<'a>(
+pub fn find_matching_l2_network(
     if_index: u32,
-    networks: &'a [DhcpNetwork],
-) -> anyhow::Result<Option<(&'a DhcpNetwork, Ipv4Addr)>> {
+    networks: &[DhcpNetwork],
+) -> anyhow::Result<Option<(&DhcpNetwork, Ipv4Addr)>> {
     let local_ips = get_ipv4_addresses_for_interface(if_index)?;
     for network in networks {
         let subnet: Ipv4Subnet = network
@@ -45,10 +45,10 @@ pub fn find_matching_l2_network<'a>(
 /// Given a local IP, find which L2 network's subnet contains it.
 ///
 /// Used by per-network receive loops where the local IP is known from the socket bind address.
-pub fn find_l2_network_for_ip<'a>(
+pub fn find_l2_network_for_ip(
     local_ip: Ipv4Addr,
-    networks: &'a [DhcpNetwork],
-) -> anyhow::Result<Option<&'a DhcpNetwork>> {
+    networks: &[DhcpNetwork],
+) -> anyhow::Result<Option<&DhcpNetwork>> {
     for network in networks {
         let subnet: Ipv4Subnet = network
             .subnet
@@ -59,6 +59,28 @@ pub fn find_l2_network_for_ip<'a>(
         }
     }
     Ok(None)
+}
+
+/// Find the local interface IP that belongs to `subnet`.
+///
+/// Returns `Ok(None)` when no local interface has an address within the
+/// subnet (e.g. relay-only network). Returns `Err` on OS-level failures.
+pub fn find_local_ip_for_subnet(subnet: &str) -> anyhow::Result<Option<Ipv4Addr>> {
+    let subnet: common::Ipv4Subnet = subnet
+        .parse()
+        .map_err(|e: common::Ipv4SubnetError| anyhow::anyhow!("{}", e))?;
+
+    let all_ifaces = NetworkInterface::show()?;
+    let local_ip = all_ifaces
+        .iter()
+        .flat_map(|iface| &iface.addr)
+        .filter_map(|addr| match addr {
+            Addr::V4(v4) => Some(v4.ip),
+            _ => None,
+        })
+        .find(|&ip| subnet.ip_in_range(ip));
+
+    Ok(local_ip)
 }
 
 #[cfg(test)]

--- a/rack-director/src/dhcp/interface.rs
+++ b/rack-director/src/dhcp/interface.rs
@@ -1,0 +1,145 @@
+use super::store::DhcpNetwork;
+use common::Ipv4Subnet;
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
+use std::net::Ipv4Addr;
+
+/// Returns all IPv4 addresses assigned to the interface with the given index.
+pub fn get_ipv4_addresses_for_interface(if_index: u32) -> anyhow::Result<Vec<Ipv4Addr>> {
+    let interfaces = NetworkInterface::show()?;
+    let addrs = interfaces
+        .into_iter()
+        .filter(|iface| iface.index == if_index)
+        .flat_map(|iface| iface.addr)
+        .filter_map(|addr| match addr {
+            Addr::V4(v4) => Some(v4.ip),
+            _ => None,
+        })
+        .collect();
+    Ok(addrs)
+}
+
+/// Given a list of L2 networks, find which one's subnet contains any IPv4 address on the
+/// given interface. Returns the matched network and the local IP that matched.
+///
+/// The local IP is used as the source IP for sending (so replies egress on the correct interface)
+/// and as the DHCP Server Identifier (Option 54) in the reply.
+pub fn find_matching_l2_network<'a>(
+    if_index: u32,
+    networks: &'a [DhcpNetwork],
+) -> anyhow::Result<Option<(&'a DhcpNetwork, Ipv4Addr)>> {
+    let local_ips = get_ipv4_addresses_for_interface(if_index)?;
+    for network in networks {
+        let subnet: Ipv4Subnet = network
+            .subnet
+            .parse()
+            .map_err(|e: common::Ipv4SubnetError| anyhow::anyhow!("{}", e))?;
+        for &ip in &local_ips {
+            if subnet.ip_in_range(ip) {
+                return Ok(Some((network, ip)));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Given a local IP, find which L2 network's subnet contains it.
+///
+/// Used by per-network receive loops where the local IP is known from the socket bind address.
+pub fn find_l2_network_for_ip<'a>(
+    local_ip: Ipv4Addr,
+    networks: &'a [DhcpNetwork],
+) -> anyhow::Result<Option<&'a DhcpNetwork>> {
+    for network in networks {
+        let subnet: Ipv4Subnet = network
+            .subnet
+            .parse()
+            .map_err(|e: common::Ipv4SubnetError| anyhow::anyhow!("{}", e))?;
+        if subnet.ip_in_range(local_ip) {
+            return Ok(Some(network));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loopback_index() -> u32 {
+        // Find the loopback interface index
+        NetworkInterface::show()
+            .unwrap()
+            .into_iter()
+            .find(|iface| {
+                iface
+                    .addr
+                    .iter()
+                    .any(|addr| matches!(addr, Addr::V4(v4) if v4.ip == Ipv4Addr::LOCALHOST))
+            })
+            .map(|iface| iface.index)
+            .expect("loopback interface not found")
+    }
+
+    fn make_l2_network(subnet: &str) -> DhcpNetwork {
+        use chrono::Utc;
+        DhcpNetwork {
+            id: 1,
+            name: "test".to_string(),
+            subnet: subnet.to_string(),
+            gateway: "127.0.0.1".to_string(),
+            dns_servers: vec![],
+            lease_duration: 3600,
+            relay_agent_address: None,
+            enable_autodiscovery: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_get_ipv4_for_loopback() {
+        let idx = loopback_index();
+        let addrs = get_ipv4_addresses_for_interface(idx).unwrap();
+        assert!(
+            addrs.contains(&Ipv4Addr::LOCALHOST),
+            "loopback must have 127.0.0.1"
+        );
+    }
+
+    #[test]
+    fn test_find_matching_l2_network_match() {
+        let idx = loopback_index();
+        let network = make_l2_network("127.0.0.0/8");
+        let networks = vec![network];
+        let result = find_matching_l2_network(idx, &networks).unwrap();
+        assert!(result.is_some());
+        let (_, local_ip) = result.unwrap();
+        assert_eq!(local_ip, Ipv4Addr::LOCALHOST);
+    }
+
+    #[test]
+    fn test_find_matching_l2_network_no_match() {
+        let idx = loopback_index();
+        let network = make_l2_network("192.168.100.0/24");
+        let networks = vec![network];
+        let result = find_matching_l2_network(idx, &networks).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_find_l2_network_for_ip() {
+        let network = make_l2_network("127.0.0.0/8");
+        let networks = vec![network];
+        let result = find_l2_network_for_ip(Ipv4Addr::LOCALHOST, &networks).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().subnet, "127.0.0.0/8");
+    }
+
+    #[test]
+    fn test_find_l2_network_for_ip_no_match() {
+        let network = make_l2_network("192.168.100.0/24");
+        let networks = vec![network];
+        let result = find_l2_network_for_ip(Ipv4Addr::LOCALHOST, &networks).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/rack-director/src/dhcp/mod.rs
+++ b/rack-director/src/dhcp/mod.rs
@@ -6,40 +6,95 @@ mod interface;
 mod ip_discovery;
 pub mod message_builder;
 mod request;
+pub mod socket_manager;
 pub mod store;
 
 use anyhow::Result;
+use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;
-use tokio::{net::UdpSocket, task::JoinHandle};
+use tokio::{net::UdpSocket, sync::mpsc, sync::oneshot, sync::watch, task::JoinHandle};
 use tokio_recvmsg::UdpSocketRecvMsg;
 
 use crate::database::ConnectionFactory;
 
 pub use ip_discovery::discover_server_identifier;
+pub use socket_manager::SocketCmd;
 pub use store::{DhcpNetwork, DhcpPool, Lease, LeaseState, StaticReservation};
 
 use boot_config::BootConfigProvider;
 use device_resolution::DirectorDeviceResolver;
-use handler::{DhcpHandler, DhcpReply};
-
-use crate::boot_files::BootFileProvider;
-
-/// A UDP socket bound to a specific local IP for one L2 network.
-struct L2Socket {
-    local_ip: Ipv4Addr,
-    socket: Arc<UdpSocket>,
-}
+use handler::DhcpHandler;
+use socket_manager::{DhcpSocketManager, SocketTable};
 
 pub struct DhcpServer {
     handler: DhcpHandler,
     address: SocketAddr,
     conn: Arc<dyn ConnectionFactory>,
+    server_identifier: Ipv4Addr,
 }
 
 pub struct StartResult {
-    pub join_handle: JoinHandle<Result<()>>,
+    pub join_handle: JoinHandle<()>,
     pub port: u16,
+    pub control: DhcpControl,
+}
+
+/// A cheaply-clonable handle for notifying the DHCP socket manager of
+/// network lifecycle events. Obtained from `StartResult::control`.
+#[derive(Clone)]
+pub struct DhcpControl {
+    cmd_tx: mpsc::Sender<SocketCmd>,
+}
+
+impl DhcpControl {
+    /// Create a no-op control handle whose commands are immediately discarded.
+    ///
+    /// Useful in unit tests that construct `AppState` directly but do not
+    /// exercise DHCP socket management.
+    #[cfg(test)]
+    pub fn noop() -> Self {
+        // Capacity 1; the receiver is immediately dropped so the manager never
+        // runs. Commands sent via DhcpControl are silently discarded.
+        let (cmd_tx, _cmd_rx) = mpsc::channel(1);
+        Self { cmd_tx }
+    }
+
+    /// Notify the socket manager that a new DHCP network was created.
+    ///
+    /// Returns once the manager has processed the command (socket bound or
+    /// warning logged if no matching interface was found).
+    pub async fn network_created(&self, id: i64, subnet: String) {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SocketCmd::AddNetwork {
+                id,
+                subnet,
+                resp: resp_tx,
+            })
+            .await
+            .is_ok()
+        {
+            resp_rx.await.ok();
+        }
+    }
+
+    /// Notify the socket manager that a DHCP network was deleted.
+    ///
+    /// Returns once the manager has processed the command (socket closed if
+    /// one was bound for this network).
+    pub async fn network_deleted(&self, id: i64) {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SocketCmd::RemoveNetwork { id, resp: resp_tx })
+            .await
+            .is_ok()
+        {
+            resp_rx.await.ok();
+        }
+    }
 }
 
 impl DhcpServer {
@@ -47,7 +102,7 @@ impl DhcpServer {
         conn: Arc<dyn ConnectionFactory>,
         tftp_server: String,
         http_server: String,
-        boot_file_provider: Arc<dyn BootFileProvider>,
+        boot_file_provider: Arc<dyn crate::boot_files::BootFileProvider>,
         server_identifier: Ipv4Addr,
         address: Option<SocketAddr>,
     ) -> Result<Self> {
@@ -82,47 +137,221 @@ impl DhcpServer {
             handler,
             address: address.unwrap_or_else(|| SocketAddr::new(server_identifier.into(), 67)),
             conn,
+            server_identifier,
         })
     }
 
-    /// Start the DHCP server (long-running task).
-    pub async fn serve(self) -> Result<StartResult> {
-        // Bind wildcard socket first to obtain the ephemeral port, then bind
-        // per-network sockets to the SAME port on specific IPs. All sockets use
-        // SO_REUSEADDR so they can coexist on the same port.
-        let wildcard = make_wildcard_socket(&self.address).await?;
-        wildcard.set_broadcast(true)?;
-        wildcard.enable_pktinfo()?;
+    /// Start the DHCP server.
+    ///
+    /// When `no_broadcast` is `true` (used in tests), no wildcard socket is
+    /// created. The server-id socket binds to `server_identifier:port` and is
+    /// the only receive path. This avoids privilege issues and port conflicts
+    /// during testing.
+    ///
+    /// When `no_broadcast` is `false` (production), a wildcard socket binds
+    /// `0.0.0.0:PORT` first to obtain the OS-assigned port, and all subsequent
+    /// sockets reuse that same port via `SO_REUSEADDR`.
+    pub async fn serve(self, no_broadcast: bool) -> Result<StartResult> {
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
 
-        let local_addr = wildcard.local_addr()?;
-        log::info!("DHCP server listening on {}", local_addr);
-        let port = local_addr.port();
+        let (port, table_rx, join_handle) = if no_broadcast {
+            start_no_broadcast(
+                self.server_identifier,
+                self.address.port(),
+                cmd_rx,
+                self.handler.clone(),
+            )
+            .await?
+        } else {
+            start_with_broadcast(
+                self.server_identifier,
+                &self.address,
+                cmd_rx,
+                self.handler.clone(),
+            )
+            .await?
+        };
 
-        let startup_conn = self.conn.open().await?;
-        let l2_sockets: Arc<Vec<L2Socket>> = Arc::new(build_l2_sockets(&startup_conn, port).await?);
-        drop(startup_conn);
+        // Bind sockets for networks that already existed at startup.
+        bootstrap_existing_networks(&self.conn, &cmd_tx, &table_rx).await;
 
-        // Spawn per-network unicast receive loops.
-        for l2 in l2_sockets.iter() {
-            let sock = l2.socket.clone();
-            let local_ip = l2.local_ip;
-            let handler = self.handler.clone();
-            let l2_ref = l2_sockets.clone();
-            tokio::spawn(async move {
-                per_network_recv_loop(sock, local_ip, handler, l2_ref).await;
-            });
-        }
+        log::info!(
+            "DHCP server started on port {} (no_broadcast={})",
+            port,
+            no_broadcast
+        );
 
-        // Spawn wildcard broadcast receive loop
-        let join_handle = tokio::spawn(wildcard_recv_loop(wildcard, self.handler, l2_sockets));
-
-        Ok(StartResult { join_handle, port })
+        Ok(StartResult {
+            join_handle,
+            port,
+            control: DhcpControl { cmd_tx },
+        })
     }
 }
 
-/// Build the wildcard 0.0.0.0 socket with SO_REUSEADDR so per-network sockets can
-/// coexist on the same port. tokio's `UdpSocket::bind` does not expose SO_REUSEADDR
-/// before binding, so socket2 is used directly.
+// ---------------------------------------------------------------------------
+// Start helpers
+// ---------------------------------------------------------------------------
+
+/// Start in no-broadcast mode: server-id socket only, no wildcard socket.
+///
+/// Returns `(port, table_rx, join_handle)` where `join_handle` is the socket
+/// manager's run loop.
+async fn start_no_broadcast(
+    server_identifier: Ipv4Addr,
+    requested_port: u16,
+    cmd_rx: mpsc::Receiver<SocketCmd>,
+    handler: DhcpHandler,
+) -> Result<(u16, watch::Receiver<Arc<SocketTable>>, JoinHandle<()>)> {
+    // Bind server-id socket; port 0 yields an ephemeral port.
+    let server_id_socket =
+        Arc::new(make_server_id_socket(server_identifier, requested_port).await?);
+    let port = server_id_socket.local_addr()?.port();
+
+    log::info!(
+        "DHCP server (no-broadcast) listening on {}:{}",
+        server_identifier,
+        port
+    );
+
+    let initial_table = Arc::new(SocketTable {
+        server_id_socket: server_id_socket.clone(),
+        network_sockets: HashMap::new(),
+    });
+    let (table_tx, table_rx) = watch::channel(initial_table);
+
+    // Spawn the server-id receive loop.
+    let recv_handle = tokio::spawn(socket_manager::server_id_recv_loop(
+        server_id_socket.clone(),
+        handler.clone(),
+        table_rx.clone(),
+    ));
+    let recv_abort = recv_handle.abort_handle();
+
+    let manager = DhcpSocketManager::new(
+        port,
+        server_identifier,
+        server_id_socket.clone(),
+        recv_abort,
+        table_tx.clone(),
+        cmd_rx,
+        handler,
+    );
+    let join_handle = tokio::spawn(manager.run());
+
+    Ok((port, table_rx, join_handle))
+}
+
+/// Start in broadcast mode: wildcard socket + server-id socket.
+///
+/// Returns `(port, table_rx, join_handle)` where `join_handle` is the socket
+/// manager's run loop.
+async fn start_with_broadcast(
+    server_identifier: Ipv4Addr,
+    address: &SocketAddr,
+    cmd_rx: mpsc::Receiver<SocketCmd>,
+    handler: DhcpHandler,
+) -> Result<(u16, watch::Receiver<Arc<SocketTable>>, JoinHandle<()>)> {
+    // Bind the wildcard socket first so the OS assigns the port.
+    let wildcard = make_wildcard_socket(address).await?;
+    wildcard.enable_pktinfo()?;
+    let port = wildcard.local_addr()?.port();
+
+    log::info!("DHCP server listening on 0.0.0.0:{}", port);
+
+    // Bind server-id socket to the same port with SO_REUSEADDR.
+    let server_id_socket = Arc::new(make_server_id_socket(server_identifier, port).await?);
+
+    let initial_table = Arc::new(SocketTable {
+        server_id_socket: server_id_socket.clone(),
+        network_sockets: HashMap::new(),
+    });
+    let (table_tx, table_rx) = watch::channel(initial_table);
+
+    // Spawn server-id receive loop (detached — managed by socket manager).
+    let recv_handle = tokio::spawn(socket_manager::server_id_recv_loop(
+        server_id_socket.clone(),
+        handler.clone(),
+        table_rx.clone(),
+    ));
+    let recv_abort = recv_handle.abort_handle();
+
+    // Spawn wildcard receive loop (detached — runs for the server's lifetime).
+    tokio::spawn(socket_manager::wildcard_recv_loop(
+        wildcard,
+        handler.clone(),
+        table_rx.clone(),
+    ));
+
+    let manager = DhcpSocketManager::new(
+        port,
+        server_identifier,
+        server_id_socket.clone(),
+        recv_abort,
+        table_tx.clone(),
+        cmd_rx,
+        handler,
+    );
+    let join_handle = tokio::spawn(manager.run());
+
+    Ok((port, table_rx, join_handle))
+}
+
+/// Replay all pre-existing networks through the socket manager so that
+/// sockets are bound for networks created before this server started.
+///
+/// This mirrors the behaviour of the old `build_l2_sockets` function but
+/// goes through the same `SocketCmd` path as the live API, ensuring the
+/// socket table is always the authoritative source.
+async fn bootstrap_existing_networks(
+    conn: &Arc<dyn ConnectionFactory>,
+    cmd_tx: &mpsc::Sender<SocketCmd>,
+    table_rx: &watch::Receiver<Arc<SocketTable>>,
+) {
+    let startup_conn = match conn.open().await {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("DHCP bootstrap: failed to open DB connection: {}", e);
+            return;
+        }
+    };
+
+    let networks = match store::get_l2_networks(&startup_conn).await {
+        Ok(n) => n,
+        Err(e) => {
+            log::error!("DHCP bootstrap: failed to list networks: {}", e);
+            return;
+        }
+    };
+
+    for network in networks {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        if cmd_tx
+            .send(SocketCmd::AddNetwork {
+                id: network.id,
+                subnet: network.subnet.clone(),
+                resp: resp_tx,
+            })
+            .await
+            .is_ok()
+        {
+            resp_rx.await.ok();
+        }
+    }
+
+    log::debug!(
+        "DHCP bootstrap: socket table has {} network socket(s)",
+        table_rx.borrow().network_sockets.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Socket constructors
+// ---------------------------------------------------------------------------
+
+/// Build a wildcard 0.0.0.0 socket with SO_REUSEADDR and SO_BROADCAST so
+/// per-network sockets can coexist on the same port. `tokio`'s `UdpSocket::bind`
+/// does not expose SO_REUSEADDR before binding, so `socket2` is used directly.
 async fn make_wildcard_socket(address: &SocketAddr) -> anyhow::Result<UdpSocket> {
     use socket2::{Domain, Protocol, Socket, Type};
     let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
@@ -133,179 +362,25 @@ async fn make_wildcard_socket(address: &SocketAddr) -> anyhow::Result<UdpSocket>
     Ok(UdpSocket::from_std(sock.into())?)
 }
 
-/// Build a UDP socket bound to `local_ip:port` with SO_REUSEADDR and SO_BROADCAST.
+/// Build a socket bound to `local_ip:port` with SO_REUSEADDR, SO_BROADCAST,
+/// and IP_PKTINFO enabled.
 ///
-/// The port must match the wildcard socket's port so all sockets share the same
-/// source port (required by dhclient's BPF filter: `udp src port 67 and dst port 68`).
-async fn make_l2_socket(local_ip: Ipv4Addr, port: u16) -> anyhow::Result<UdpSocket> {
+/// This socket serves as the server-identifier socket. Pktinfo is required
+/// because the server-id receive loop calls `handle_packet` which uses the
+/// destination IP from pktinfo to identify the DHCP network.
+pub(crate) async fn make_server_id_socket(
+    local_ip: Ipv4Addr,
+    port: u16,
+) -> anyhow::Result<UdpSocket> {
     use socket2::{Domain, Protocol, Socket, Type};
     let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
     sock.set_reuse_address(true)?;
     sock.set_broadcast(true)?;
     sock.bind(&SocketAddrV4::new(local_ip, port).into())?;
     sock.set_nonblocking(true)?;
-    Ok(UdpSocket::from_std(sock.into())?)
-}
-
-/// Enumerate all local interfaces and create one L2Socket per L2 network that has
-/// a matching local interface IP. All sockets bind to `local_ip:port` where `port`
-/// matches the wildcard socket so replies egress with the correct source port.
-async fn build_l2_sockets(
-    conn: &crate::database::Connection,
-    port: u16,
-) -> anyhow::Result<Vec<L2Socket>> {
-    use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
-
-    let networks = store::get_l2_networks(conn).await?;
-    let all_ifaces = NetworkInterface::show()?;
-    let mut sockets = Vec::new();
-
-    for network in &networks {
-        let subnet: common::Ipv4Subnet = network
-            .subnet
-            .parse()
-            .map_err(|e: common::Ipv4SubnetError| anyhow::anyhow!("{}", e))?;
-
-        let local_ip = all_ifaces
-            .iter()
-            .flat_map(|iface| &iface.addr)
-            .filter_map(|addr| match addr {
-                Addr::V4(v4) => Some(v4.ip),
-                _ => None,
-            })
-            .find(|&ip| subnet.ip_in_range(ip));
-
-        let Some(local_ip) = local_ip else {
-            log::warn!(
-                "No local interface found for L2 network '{}' ({}), skipping socket",
-                network.name,
-                network.subnet
-            );
-            continue;
-        };
-
-        match make_l2_socket(local_ip, port).await {
-            Ok(sock) => {
-                log::info!(
-                    "L2 socket bound to {}:{} for network '{}'",
-                    local_ip,
-                    port,
-                    network.name
-                );
-                sockets.push(L2Socket {
-                    local_ip,
-                    socket: Arc::new(sock),
-                });
-            }
-            Err(e) => {
-                log::warn!(
-                    "Failed to bind L2 socket for network '{}' ({}): {}",
-                    network.name,
-                    local_ip,
-                    e
-                );
-            }
-        }
-    }
-
-    Ok(sockets)
-}
-
-/// Receive loop for the wildcard 0.0.0.0:67 socket. Uses recvmsg to capture
-/// the incoming interface index so we can select the correct L2 network.
-async fn wildcard_recv_loop(
-    socket: UdpSocket,
-    handler: DhcpHandler,
-    l2_sockets: Arc<Vec<L2Socket>>,
-) -> Result<()> {
-    let mut buf = vec![0u8; 1500];
-    loop {
-        match socket.recv_msg(&mut buf).await {
-            Ok((len, pkt_info)) => {
-                let data = buf[..len].to_vec();
-                let h = handler.clone();
-                let l2 = l2_sockets.clone();
-                tokio::spawn(async move {
-                    match h.handle_packet(&data, &pkt_info).await {
-                        Ok(Some(reply)) => dispatch_reply(reply, &l2).await,
-                        Ok(None) => {}
-                        Err(e) => log::error!("DHCP handler error: {}", e),
-                    }
-                });
-            }
-            Err(e) => log::error!("DHCP wildcard socket error: {}", e),
-        }
-    }
-}
-
-/// Receive loop for a per-network socket bound to `local_ip:67`. Handles unicast
-/// DHCP renewals and rebinding from clients that already have a lease.
-async fn per_network_recv_loop(
-    socket: Arc<UdpSocket>,
-    local_ip: Ipv4Addr,
-    handler: DhcpHandler,
-    l2_sockets: Arc<Vec<L2Socket>>,
-) {
-    let mut buf = vec![0u8; 1500];
-    loop {
-        match socket.recv_from(&mut buf).await {
-            Ok((len, peer_addr)) => {
-                let data = buf[..len].to_vec();
-                let h = handler.clone();
-                let l2 = l2_sockets.clone();
-                tokio::spawn(async move {
-                    match h.handle_l2_unicast_packet(&data, peer_addr, local_ip).await {
-                        Ok(Some(reply)) => dispatch_reply(reply, &l2).await,
-                        Ok(None) => {}
-                        Err(e) => log::error!("DHCP unicast handler error: {}", e),
-                    }
-                });
-            }
-            Err(e) => log::error!("DHCP per-network socket error: {}", e),
-        }
-    }
-}
-
-/// Send a DHCP reply using the appropriate socket.
-///
-/// For L2 replies: use the per-network socket bound to `local_ip:port` so that
-/// replies egress on the correct interface and carry the same source port as the
-/// server (required by `dhclient`'s BPF filter).
-async fn dispatch_reply(reply: DhcpReply, l2_sockets: &[L2Socket]) {
-    match reply {
-        DhcpReply::L2 {
-            data,
-            local_ip,
-            peer_addr,
-        } => {
-            // RFC 2131: if the client has no IP yet (INIT/SELECTING), broadcast the reply.
-            // Otherwise (RENEWING/REBINDING), reply directly to peer_addr.
-            let dest: SocketAddr = if peer_addr.ip().is_unspecified() {
-                SocketAddr::new(Ipv4Addr::BROADCAST.into(), 68)
-            } else {
-                peer_addr
-            };
-
-            if let Some(l2) = l2_sockets.iter().find(|s| s.local_ip == local_ip) {
-                if let Err(e) = l2.socket.send_to(&data, dest).await {
-                    log::error!("DHCP L2 send error to {}: {}", dest, e);
-                }
-            } else {
-                log::error!("No L2 socket for {} — dropping reply to {}", local_ip, dest);
-            }
-        }
-        DhcpReply::Relay { data, dest } => {
-            // Relay reply — source IP doesn't matter, bind ephemerally
-            match UdpSocket::bind("0.0.0.0:0").await {
-                Ok(s) => {
-                    if let Err(e) = s.send_to(&data, dest).await {
-                        log::error!("DHCP relay send error: {}", e);
-                    }
-                }
-                Err(e) => log::error!("DHCP relay socket bind error: {}", e),
-            }
-        }
-    }
+    let udp = UdpSocket::from_std(sock.into())?;
+    udp.enable_pktinfo()?;
+    Ok(udp)
 }
 
 /// Spawn a background task that periodically deletes expired DHCP leases.

--- a/rack-director/src/dhcp/mod.rs
+++ b/rack-director/src/dhcp/mod.rs
@@ -2,15 +2,17 @@ mod allocator;
 mod boot_config;
 mod device_resolution;
 mod handler;
+mod interface;
 mod ip_discovery;
 pub mod message_builder;
 mod request;
 pub mod store;
 
 use anyhow::Result;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;
 use tokio::{net::UdpSocket, task::JoinHandle};
+use tokio_recvmsg::UdpSocketRecvMsg;
 
 use crate::database::ConnectionFactory;
 
@@ -19,13 +21,20 @@ pub use store::{DhcpNetwork, DhcpPool, Lease, LeaseState, StaticReservation};
 
 use boot_config::BootConfigProvider;
 use device_resolution::DirectorDeviceResolver;
-use handler::DhcpHandler;
+use handler::{DhcpHandler, DhcpReply};
 
 use crate::boot_files::BootFileProvider;
+
+/// A UDP socket bound to a specific local IP for one L2 network.
+struct L2Socket {
+    local_ip: Ipv4Addr,
+    socket: Arc<UdpSocket>,
+}
 
 pub struct DhcpServer {
     handler: DhcpHandler,
     address: SocketAddr,
+    conn: Arc<dyn ConnectionFactory>,
 }
 
 pub struct StartResult {
@@ -47,7 +56,6 @@ impl DhcpServer {
         log::info!("  HTTP Server: {}", http_server);
         log::info!("  Server Identifier: {}", server_identifier);
 
-        // List networks at startup for diagnostic purposes
         let startup_db = conn.open().await?;
         let networks = store::list_networks(&startup_db).await?;
         log::info!("  Configured networks: {}", networks.len());
@@ -63,49 +71,238 @@ impl DhcpServer {
 
         let boot_config = BootConfigProvider::new(tftp_server, http_server, boot_file_provider);
         let device_resolver = Arc::new(DirectorDeviceResolver::new());
-        let handler = DhcpHandler::new(conn, device_resolver, boot_config, server_identifier);
+        let handler = DhcpHandler::new(
+            conn.clone(),
+            device_resolver,
+            boot_config,
+            server_identifier,
+        );
 
         Ok(Self {
             handler,
             address: address.unwrap_or_else(|| SocketAddr::new(server_identifier.into(), 67)),
+            conn,
         })
     }
 
-    /// Start the DHCP server (long-running task)
+    /// Start the DHCP server (long-running task).
     pub async fn serve(self) -> Result<StartResult> {
-        let socket = Arc::new(UdpSocket::bind(&self.address).await?);
-        log::debug!("Enabling broadcast on DHCP socket");
-        socket.set_broadcast(true)?;
+        // Bind wildcard socket first to obtain the ephemeral port, then bind
+        // per-network sockets to the SAME port on specific IPs. All sockets use
+        // SO_REUSEADDR so they can coexist on the same port.
+        let wildcard = make_wildcard_socket(&self.address).await?;
+        wildcard.set_broadcast(true)?;
+        wildcard.enable_pktinfo()?;
 
-        let local_addr = socket.local_addr()?;
+        let local_addr = wildcard.local_addr()?;
         log::info!("DHCP server listening on {}", local_addr);
-
-        let join_handle = tokio::spawn(self.serve_task(socket));
         let port = local_addr.port();
+
+        let startup_conn = self.conn.open().await?;
+        let l2_sockets: Arc<Vec<L2Socket>> = Arc::new(build_l2_sockets(&startup_conn, port).await?);
+        drop(startup_conn);
+
+        // Spawn per-network unicast receive loops.
+        for l2 in l2_sockets.iter() {
+            let sock = l2.socket.clone();
+            let local_ip = l2.local_ip;
+            let handler = self.handler.clone();
+            let l2_ref = l2_sockets.clone();
+            tokio::spawn(async move {
+                per_network_recv_loop(sock, local_ip, handler, l2_ref).await;
+            });
+        }
+
+        // Spawn wildcard broadcast receive loop
+        let join_handle = tokio::spawn(wildcard_recv_loop(wildcard, self.handler, l2_sockets));
+
         Ok(StartResult { join_handle, port })
     }
+}
 
-    pub async fn serve_task(self, socket: Arc<UdpSocket>) -> Result<()> {
-        let mut buf = vec![0u8; 1500]; // MTU size
+/// Build the wildcard 0.0.0.0 socket with SO_REUSEADDR so per-network sockets can
+/// coexist on the same port. tokio's `UdpSocket::bind` does not expose SO_REUSEADDR
+/// before binding, so socket2 is used directly.
+async fn make_wildcard_socket(address: &SocketAddr) -> anyhow::Result<UdpSocket> {
+    use socket2::{Domain, Protocol, Socket, Type};
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+    sock.set_reuse_address(true)?;
+    sock.set_broadcast(true)?;
+    sock.bind(&(*address).into())?;
+    sock.set_nonblocking(true)?;
+    Ok(UdpSocket::from_std(sock.into())?)
+}
 
-        loop {
-            match socket.recv_from(&mut buf).await {
-                Ok((len, peer_addr)) => {
-                    let data = buf[..len].to_vec();
-                    let handler = self.handler.clone();
-                    let socket_clone = socket.clone();
+/// Build a UDP socket bound to `local_ip:port` with SO_REUSEADDR and SO_BROADCAST.
+///
+/// The port must match the wildcard socket's port so all sockets share the same
+/// source port (required by dhclient's BPF filter: `udp src port 67 and dst port 68`).
+async fn make_l2_socket(local_ip: Ipv4Addr, port: u16) -> anyhow::Result<UdpSocket> {
+    use socket2::{Domain, Protocol, Socket, Type};
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+    sock.set_reuse_address(true)?;
+    sock.set_broadcast(true)?;
+    sock.bind(&SocketAddrV4::new(local_ip, port).into())?;
+    sock.set_nonblocking(true)?;
+    Ok(UdpSocket::from_std(sock.into())?)
+}
 
-                    // Spawn task per request (like TFTP server pattern)
-                    tokio::spawn(async move {
-                        if let Err(e) = handler.handle_packet(&data, peer_addr, socket_clone).await
-                        {
-                            log::error!("DHCP handler error: {}", e);
-                        }
-                    });
+/// Enumerate all local interfaces and create one L2Socket per L2 network that has
+/// a matching local interface IP. All sockets bind to `local_ip:port` where `port`
+/// matches the wildcard socket so replies egress with the correct source port.
+async fn build_l2_sockets(
+    conn: &crate::database::Connection,
+    port: u16,
+) -> anyhow::Result<Vec<L2Socket>> {
+    use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
+
+    let networks = store::get_l2_networks(conn).await?;
+    let all_ifaces = NetworkInterface::show()?;
+    let mut sockets = Vec::new();
+
+    for network in &networks {
+        let subnet: common::Ipv4Subnet = network
+            .subnet
+            .parse()
+            .map_err(|e: common::Ipv4SubnetError| anyhow::anyhow!("{}", e))?;
+
+        let local_ip = all_ifaces
+            .iter()
+            .flat_map(|iface| &iface.addr)
+            .filter_map(|addr| match addr {
+                Addr::V4(v4) => Some(v4.ip),
+                _ => None,
+            })
+            .find(|&ip| subnet.ip_in_range(ip));
+
+        let Some(local_ip) = local_ip else {
+            log::warn!(
+                "No local interface found for L2 network '{}' ({}), skipping socket",
+                network.name,
+                network.subnet
+            );
+            continue;
+        };
+
+        match make_l2_socket(local_ip, port).await {
+            Ok(sock) => {
+                log::info!(
+                    "L2 socket bound to {}:{} for network '{}'",
+                    local_ip,
+                    port,
+                    network.name
+                );
+                sockets.push(L2Socket {
+                    local_ip,
+                    socket: Arc::new(sock),
+                });
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to bind L2 socket for network '{}' ({}): {}",
+                    network.name,
+                    local_ip,
+                    e
+                );
+            }
+        }
+    }
+
+    Ok(sockets)
+}
+
+/// Receive loop for the wildcard 0.0.0.0:67 socket. Uses recvmsg to capture
+/// the incoming interface index so we can select the correct L2 network.
+async fn wildcard_recv_loop(
+    socket: UdpSocket,
+    handler: DhcpHandler,
+    l2_sockets: Arc<Vec<L2Socket>>,
+) -> Result<()> {
+    let mut buf = vec![0u8; 1500];
+    loop {
+        match socket.recv_msg(&mut buf).await {
+            Ok((len, pkt_info)) => {
+                let data = buf[..len].to_vec();
+                let h = handler.clone();
+                let l2 = l2_sockets.clone();
+                tokio::spawn(async move {
+                    match h.handle_packet(&data, &pkt_info).await {
+                        Ok(Some(reply)) => dispatch_reply(reply, &l2).await,
+                        Ok(None) => {}
+                        Err(e) => log::error!("DHCP handler error: {}", e),
+                    }
+                });
+            }
+            Err(e) => log::error!("DHCP wildcard socket error: {}", e),
+        }
+    }
+}
+
+/// Receive loop for a per-network socket bound to `local_ip:67`. Handles unicast
+/// DHCP renewals and rebinding from clients that already have a lease.
+async fn per_network_recv_loop(
+    socket: Arc<UdpSocket>,
+    local_ip: Ipv4Addr,
+    handler: DhcpHandler,
+    l2_sockets: Arc<Vec<L2Socket>>,
+) {
+    let mut buf = vec![0u8; 1500];
+    loop {
+        match socket.recv_from(&mut buf).await {
+            Ok((len, peer_addr)) => {
+                let data = buf[..len].to_vec();
+                let h = handler.clone();
+                let l2 = l2_sockets.clone();
+                tokio::spawn(async move {
+                    match h.handle_l2_unicast_packet(&data, peer_addr, local_ip).await {
+                        Ok(Some(reply)) => dispatch_reply(reply, &l2).await,
+                        Ok(None) => {}
+                        Err(e) => log::error!("DHCP unicast handler error: {}", e),
+                    }
+                });
+            }
+            Err(e) => log::error!("DHCP per-network socket error: {}", e),
+        }
+    }
+}
+
+/// Send a DHCP reply using the appropriate socket.
+///
+/// For L2 replies: use the per-network socket bound to `local_ip:port` so that
+/// replies egress on the correct interface and carry the same source port as the
+/// server (required by `dhclient`'s BPF filter).
+async fn dispatch_reply(reply: DhcpReply, l2_sockets: &[L2Socket]) {
+    match reply {
+        DhcpReply::L2 {
+            data,
+            local_ip,
+            peer_addr,
+        } => {
+            // RFC 2131: if the client has no IP yet (INIT/SELECTING), broadcast the reply.
+            // Otherwise (RENEWING/REBINDING), reply directly to peer_addr.
+            let dest: SocketAddr = if peer_addr.ip().is_unspecified() {
+                SocketAddr::new(Ipv4Addr::BROADCAST.into(), 68)
+            } else {
+                peer_addr
+            };
+
+            if let Some(l2) = l2_sockets.iter().find(|s| s.local_ip == local_ip) {
+                if let Err(e) = l2.socket.send_to(&data, dest).await {
+                    log::error!("DHCP L2 send error to {}: {}", dest, e);
                 }
-                Err(e) => {
-                    log::error!("DHCP socket error: {}", e);
+            } else {
+                log::error!("No L2 socket for {} — dropping reply to {}", local_ip, dest);
+            }
+        }
+        DhcpReply::Relay { data, dest } => {
+            // Relay reply — source IP doesn't matter, bind ephemerally
+            match UdpSocket::bind("0.0.0.0:0").await {
+                Ok(s) => {
+                    if let Err(e) = s.send_to(&data, dest).await {
+                        log::error!("DHCP relay send error: {}", e);
+                    }
                 }
+                Err(e) => log::error!("DHCP relay socket bind error: {}", e),
             }
         }
     }
@@ -132,7 +329,6 @@ pub fn spawn_lease_cleanup_task(connection_factory: Arc<dyn ConnectionFactory>) 
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[tokio::test]

--- a/rack-director/src/dhcp/socket_manager.rs
+++ b/rack-director/src/dhcp/socket_manager.rs
@@ -1,0 +1,413 @@
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use tokio::net::UdpSocket;
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::AbortHandle;
+use tokio_recvmsg::UdpSocketRecvMsg;
+
+use super::handler::{DhcpHandler, DhcpReply};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// The read-hot socket table, shared via `watch::Receiver`.
+///
+/// All DHCP receive loops borrow this table when dispatching replies so they
+/// always use the most-recently-bound socket for each network.
+pub struct SocketTable {
+    /// The socket bound to `server_identifier:port` — used for relay-agent
+    /// replies and as the send socket for networks whose local IP equals the
+    /// server identifier.
+    pub server_id_socket: Arc<UdpSocket>,
+    /// Per-network sockets keyed by the local interface IP for that network.
+    pub network_sockets: HashMap<Ipv4Addr, Arc<UdpSocket>>,
+}
+
+/// Commands sent from the HTTP layer to the `DhcpSocketManager`.
+pub enum SocketCmd {
+    /// A new DHCP network was created via the HTTP API. The manager should
+    /// bind a socket for the network's local interface IP (if one exists).
+    AddNetwork {
+        id: i64,
+        subnet: String,
+        resp: oneshot::Sender<()>,
+    },
+    /// A DHCP network was deleted via the HTTP API. The manager should close
+    /// the associated socket (if any).
+    RemoveNetwork { id: i64, resp: oneshot::Sender<()> },
+}
+
+// ---------------------------------------------------------------------------
+// Private implementation types
+// ---------------------------------------------------------------------------
+
+/// Bookkeeping for a single managed network socket entry.
+struct NetworkEntry {
+    /// The local interface IP that was bound for this network.
+    local_ip: Ipv4Addr,
+    /// The bound socket (may alias `server_id_socket` when
+    /// `local_ip == server_identifier`).
+    socket: Arc<UdpSocket>,
+    /// Abort handle for the per-network receive loop. `None` when this
+    /// entry reuses the server-id receive loop (i.e. `local_ip == server_identifier`).
+    recv_abort: Option<AbortHandle>,
+}
+
+/// Owns all DHCP socket lifecycle and reacts to `SocketCmd` events.
+///
+/// The manager is intentionally free of locks. Callers communicate via
+/// `mpsc` commands; readers get the current socket table via `watch`.
+pub struct DhcpSocketManager {
+    port: u16,
+    server_identifier: Ipv4Addr,
+    server_id_socket: Arc<UdpSocket>,
+    /// Abort handle kept so callers can cancel the server-id loop on shutdown.
+    server_id_recv: AbortHandle,
+    network_entries: HashMap<i64, NetworkEntry>,
+    table_tx: watch::Sender<Arc<SocketTable>>,
+    cmd_rx: mpsc::Receiver<SocketCmd>,
+    handler: DhcpHandler,
+}
+
+impl DhcpSocketManager {
+    /// Create a new manager from pre-built components.
+    ///
+    /// Callers must:
+    /// 1. Bind `server_id_socket` and enable pktinfo on it.
+    /// 2. Spawn the server-id receive loop and pass its `AbortHandle`.
+    /// 3. Build an initial (empty) `SocketTable` and create a `watch` pair.
+    /// 4. Create an `mpsc` pair and pass `cmd_rx` here, keeping `cmd_tx` for
+    ///    `DhcpControl`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        port: u16,
+        server_identifier: Ipv4Addr,
+        server_id_socket: Arc<UdpSocket>,
+        server_id_recv: AbortHandle,
+        table_tx: watch::Sender<Arc<SocketTable>>,
+        cmd_rx: mpsc::Receiver<SocketCmd>,
+        handler: DhcpHandler,
+    ) -> Self {
+        Self {
+            port,
+            server_identifier,
+            server_id_socket,
+            server_id_recv,
+            network_entries: HashMap::new(),
+            table_tx,
+            cmd_rx,
+            handler,
+        }
+    }
+
+    /// Run the command loop. Returns when the command channel is closed.
+    pub async fn run(mut self) {
+        while let Some(cmd) = self.cmd_rx.recv().await {
+            match cmd {
+                SocketCmd::AddNetwork { id, subnet, resp } => {
+                    self.handle_add_network(id, subnet);
+                    let _ = resp.send(());
+                }
+                SocketCmd::RemoveNetwork { id, resp } => {
+                    self.handle_remove_network(id);
+                    let _ = resp.send(());
+                }
+            }
+        }
+        // Channel closed — abort server-id recv loop on the way out.
+        self.server_id_recv.abort();
+    }
+
+    // -----------------------------------------------------------------------
+    // Command handlers
+    // -----------------------------------------------------------------------
+
+    /// Handle `AddNetwork`: resolve local IP, bind socket (or reuse server-id
+    /// socket), spawn per-network recv loop if needed, rebuild table.
+    fn handle_add_network(&mut self, id: i64, subnet: String) {
+        let local_ip = match super::interface::find_local_ip_for_subnet(&subnet) {
+            Ok(Some(ip)) => ip,
+            Ok(None) => {
+                log::warn!(
+                    "DHCP socket manager: no local interface found for subnet {} (network id={}), skipping",
+                    subnet,
+                    id
+                );
+                return;
+            }
+            Err(e) => {
+                log::warn!(
+                    "DHCP socket manager: failed to resolve subnet {} (network id={}): {}",
+                    subnet,
+                    id,
+                    e
+                );
+                return;
+            }
+        };
+
+        let entry = if local_ip == self.server_identifier {
+            // The network's local IP is the same as the server identifier —
+            // the server-id socket already handles packets on this IP.
+            log::info!(
+                "DHCP socket manager: network {} ({}) reuses server-id socket ({}:{})",
+                id,
+                subnet,
+                local_ip,
+                self.port
+            );
+            NetworkEntry {
+                local_ip,
+                socket: self.server_id_socket.clone(),
+                recv_abort: None,
+            }
+        } else {
+            // Bind a dedicated socket for this network.
+            let socket = match bind_l2_socket(local_ip, self.port) {
+                Ok(s) => Arc::new(s),
+                Err(e) => {
+                    log::warn!(
+                        "DHCP socket manager: failed to bind socket for network {} ({}:{}): {}",
+                        id,
+                        local_ip,
+                        self.port,
+                        e
+                    );
+                    return;
+                }
+            };
+
+            log::info!(
+                "DHCP socket manager: bound socket {}:{} for network {} ({})",
+                local_ip,
+                self.port,
+                id,
+                subnet
+            );
+
+            let abort = spawn_per_network_recv_loop(
+                socket.clone(),
+                local_ip,
+                self.handler.clone(),
+                self.table_tx.subscribe(),
+            );
+
+            NetworkEntry {
+                local_ip,
+                socket,
+                recv_abort: Some(abort),
+            }
+        };
+
+        self.network_entries.insert(id, entry);
+        self.publish_table();
+    }
+
+    /// Handle `RemoveNetwork`: remove entry, abort recv loop if dedicated,
+    /// rebuild table.
+    fn handle_remove_network(&mut self, id: i64) {
+        if let Some(entry) = self.network_entries.remove(&id) {
+            if let Some(abort) = entry.recv_abort {
+                abort.abort();
+            }
+            log::info!(
+                "DHCP socket manager: removed socket for network {} ({}:{})",
+                id,
+                entry.local_ip,
+                self.port
+            );
+            self.publish_table();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Table management
+    // -----------------------------------------------------------------------
+
+    /// Rebuild `SocketTable` from current entries and publish it.
+    fn publish_table(&self) {
+        let table = Arc::new(SocketTable {
+            server_id_socket: self.server_id_socket.clone(),
+            network_sockets: self
+                .network_entries
+                .values()
+                .map(|e| (e.local_ip, e.socket.clone()))
+                .collect(),
+        });
+        // `send` only fails if all receivers have been dropped (i.e. shutdown),
+        // which is benign.
+        let _ = self.table_tx.send(table);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Receive loops (pub so mod.rs can spawn them)
+// ---------------------------------------------------------------------------
+
+/// Receive loop for the server-identifier socket. Handles both relay-agent
+/// unicast (giaddr-directed) and direct unicast from clients.
+///
+/// Uses `recvmsg` so that pktinfo identifies the local destination IP, which
+/// the handler uses for network-lookup and `server_identifier` insertion.
+pub async fn server_id_recv_loop(
+    socket: Arc<UdpSocket>,
+    handler: DhcpHandler,
+    table_rx: watch::Receiver<Arc<SocketTable>>,
+) {
+    pktinfo_recv_loop(socket, "server-id socket", handler, table_rx).await
+}
+
+/// Receive loop for the wildcard 0.0.0.0 socket (broadcast / relay-agent
+/// packets). Only started when `--no-dhcp-broadcast` is **not** set.
+pub async fn wildcard_recv_loop(
+    socket: UdpSocket,
+    handler: DhcpHandler,
+    table_rx: watch::Receiver<Arc<SocketTable>>,
+) {
+    pktinfo_recv_loop(Arc::new(socket), "wildcard socket", handler, table_rx).await
+}
+
+/// Inner recv loop used by both `server_id_recv_loop` and `wildcard_recv_loop`.
+async fn pktinfo_recv_loop(
+    socket: Arc<UdpSocket>,
+    label: &'static str,
+    handler: DhcpHandler,
+    table_rx: watch::Receiver<Arc<SocketTable>>,
+) {
+    let mut buf = vec![0u8; 1500];
+    loop {
+        match socket.recv_msg(&mut buf).await {
+            Ok((len, pkt_info)) => {
+                let data = buf[..len].to_vec();
+                let h = handler.clone();
+                let rx = table_rx.clone();
+                tokio::spawn(async move {
+                    match h.handle_packet(&data, &pkt_info).await {
+                        Ok(Some(reply)) => dispatch_reply(reply, &rx).await,
+                        Ok(None) => {}
+                        Err(e) => log::error!("DHCP {} handler error: {}", label, e),
+                    }
+                });
+            }
+            Err(e) => log::error!("DHCP {} recv error: {}", label, e),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Receive loop for a socket bound to a specific local interface IP. Handles
+/// unicast DHCP renewals from clients that already have a lease.
+///
+/// Uses plain `recv_from` (no pktinfo needed) because the local IP is already
+/// known from the socket's bound address.
+async fn per_network_recv_loop(
+    socket: Arc<UdpSocket>,
+    local_ip: Ipv4Addr,
+    handler: DhcpHandler,
+    table_rx: watch::Receiver<Arc<SocketTable>>,
+) {
+    let mut buf = vec![0u8; 1500];
+    loop {
+        match socket.recv_from(&mut buf).await {
+            Ok((len, peer_addr)) => {
+                let data = buf[..len].to_vec();
+                let h = handler.clone();
+                let rx = table_rx.clone();
+                tokio::spawn(async move {
+                    match h.handle_l2_unicast_packet(&data, peer_addr, local_ip).await {
+                        Ok(Some(reply)) => dispatch_reply(reply, &rx).await,
+                        Ok(None) => {}
+                        Err(e) => log::error!("DHCP per-network socket handler error: {}", e),
+                    }
+                });
+            }
+            Err(e) => log::error!("DHCP per-network socket recv error: {}", e),
+        }
+    }
+}
+
+/// Send a DHCP reply using the appropriate socket from the current table.
+///
+/// For `L2` replies the socket bound to `local_ip` is used so replies egress
+/// on the correct interface and carry the server's source port (required by
+/// `dhclient`'s BPF filter: `udp src port 67 and dst port 68`).
+///
+/// For `Relay` replies the server-id socket is used.
+async fn dispatch_reply(reply: DhcpReply, table_rx: &watch::Receiver<Arc<SocketTable>>) {
+    use std::net::{IpAddr, SocketAddr};
+
+    match reply {
+        DhcpReply::L2 {
+            data,
+            local_ip,
+            peer_addr,
+        } => {
+            // RFC 2131: broadcast when the client has no IP yet (INIT/SELECTING),
+            // unicast when the client already has an IP (RENEWING/REBINDING).
+            let dest: SocketAddr = if peer_addr.ip() == IpAddr::V4(Ipv4Addr::UNSPECIFIED) {
+                SocketAddr::new(Ipv4Addr::BROADCAST.into(), 68)
+            } else {
+                peer_addr
+            };
+
+            let socket = {
+                let table = table_rx.borrow();
+                table.network_sockets.get(&local_ip).cloned()
+            };
+
+            if let Some(sock) = socket {
+                if let Err(e) = sock.send_to(&data, dest).await {
+                    log::error!("DHCP L2 send error to {}: {}", dest, e);
+                }
+            } else {
+                log::error!(
+                    "DHCP dispatch: no L2 socket for {} — dropping reply to {}",
+                    local_ip,
+                    dest
+                );
+            }
+        }
+        DhcpReply::Relay { data, dest } => {
+            let socket = {
+                let table = table_rx.borrow();
+                table.server_id_socket.clone()
+            };
+            if let Err(e) = socket.send_to(&data, dest).await {
+                log::error!("DHCP relay send error to {}: {}", dest, e);
+            }
+        }
+    }
+}
+
+/// Spawn `per_network_recv_loop` and return an `AbortHandle` so the caller
+/// can cancel the loop when the network is removed.
+fn spawn_per_network_recv_loop(
+    socket: Arc<UdpSocket>,
+    local_ip: Ipv4Addr,
+    handler: DhcpHandler,
+    table_rx: watch::Receiver<Arc<SocketTable>>,
+) -> AbortHandle {
+    tokio::spawn(per_network_recv_loop(socket, local_ip, handler, table_rx)).abort_handle()
+}
+
+/// Bind a UDP socket to `local_ip:port` using SO_REUSEADDR and SO_BROADCAST.
+///
+/// This is a synchronous wrapper around `socket2` so it can be called from
+/// within `handle_add_network` without async friction.
+fn bind_l2_socket(local_ip: Ipv4Addr, port: u16) -> anyhow::Result<UdpSocket> {
+    use socket2::{Domain, Protocol, Socket, Type};
+    use std::net::SocketAddrV4;
+
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+    sock.set_reuse_address(true)?;
+    sock.set_broadcast(true)?;
+    sock.bind(&SocketAddrV4::new(local_ip, port).into())?;
+    sock.set_nonblocking(true)?;
+    Ok(UdpSocket::from_std(sock.into())?)
+}

--- a/rack-director/src/dhcp/store.rs
+++ b/rack-director/src/dhcp/store.rs
@@ -402,6 +402,20 @@ pub async fn list_networks(conn: &Connection) -> Result<Vec<DhcpNetwork>> {
     Ok(networks)
 }
 
+/// Returns all DHCP networks configured for L2 (relay_agent_address IS NULL).
+pub async fn get_l2_networks(conn: &Connection) -> Result<Vec<DhcpNetwork>> {
+    let networks = conn
+        .query(
+            "SELECT id, name, subnet, gateway, dns_servers, lease_duration, \
+             relay_agent_address, enable_autodiscovery, created_at, updated_at \
+             FROM dhcp_networks WHERE relay_agent_address IS NULL",
+            (),
+            DhcpNetwork::from_row,
+        )
+        .await?;
+    Ok(networks)
+}
+
 /// Create a new network.
 #[allow(clippy::too_many_arguments)]
 pub async fn create_network(
@@ -813,6 +827,31 @@ mod tests {
         assert_eq!(network.name, "Test Network");
         assert_eq!(network.subnet, "10.0.0.0/24");
         assert_eq!(network.gateway, "10.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn test_get_l2_networks() {
+        let (db, _) = setup_db_with_network(test_database_path!()).await;
+
+        // Create a relay network (relay_agent_address IS NOT NULL)
+        create_network(
+            &db,
+            "Relay Network",
+            "192.168.1.0/24",
+            "192.168.1.1",
+            &["8.8.8.8".to_string()],
+            86400,
+            Some("10.0.0.2"),
+            false,
+        )
+        .await
+        .unwrap();
+
+        let l2 = get_l2_networks(&db).await.unwrap();
+        // Only the L2 network (no relay_agent_address) should be returned
+        assert_eq!(l2.len(), 1);
+        assert_eq!(l2[0].name, "Test Network");
+        assert!(l2[0].relay_agent_address.is_none());
     }
 
     #[tokio::test]

--- a/rack-director/src/http/cnc/boot_files.rs
+++ b/rack-director/src/http/cnc/boot_files.rs
@@ -147,6 +147,7 @@ mod tests {
             image_store: Arc::new(image_store),
             agent_images_path,
             boot_file_provider,
+            dhcp: crate::dhcp::DhcpControl::noop(),
         });
 
         (state, temp_dir)

--- a/rack-director/src/http/cnc/install_script.rs
+++ b/rack-director/src/http/cnc/install_script.rs
@@ -191,6 +191,7 @@ mod tests {
             image_store: Arc::new(image_store),
             agent_images_path,
             boot_file_provider,
+            dhcp: crate::dhcp::DhcpControl::noop(),
         });
 
         (state, temp_dir, migration_conn)

--- a/rack-director/src/http/cnc/mod.rs
+++ b/rack-director/src/http/cnc/mod.rs
@@ -617,6 +617,7 @@ mod tests {
             image_store: Arc::new(image_store),
             agent_images_path,
             boot_file_provider,
+            dhcp: crate::dhcp::DhcpControl::noop(),
         });
         (state, temp_dir)
     }

--- a/rack-director/src/http/mod.rs
+++ b/rack-director/src/http/mod.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinHandle;
 
 use crate::boot_files::BootFileProvider;
 use crate::database::ConnectionFactory;
+use crate::dhcp::DhcpControl;
 use crate::storage::ImageStore;
 
 /// Shared application state for all HTTP handlers.
@@ -25,6 +26,9 @@ pub struct AppState {
     pub image_store: Arc<ImageStore>,
     pub agent_images_path: PathBuf,
     pub boot_file_provider: Arc<dyn BootFileProvider>,
+    /// Handle to the DHCP socket manager, used by network create/delete
+    /// handlers to bind or release per-network sockets in real time.
+    pub dhcp: DhcpControl,
 }
 
 pub struct StartResult {
@@ -38,12 +42,14 @@ pub async fn start<T: Into<SocketAddr>>(
     bind: T,
     agent_images_path: PathBuf,
     boot_file_provider: Arc<dyn BootFileProvider>,
+    dhcp: DhcpControl,
 ) -> Result<StartResult> {
     let state = Arc::new(AppState {
         connection_factory,
         image_store,
         agent_images_path,
         boot_file_provider,
+        dhcp,
     });
 
     let app = Router::new()

--- a/rack-director/src/http/ui/devices.rs
+++ b/rack-director/src/http/ui/devices.rs
@@ -810,6 +810,7 @@ mod tests {
             image_store: store.into(),
             agent_images_path,
             boot_file_provider,
+            dhcp: crate::dhcp::DhcpControl::noop(),
         });
         (state, temp_dir, migration_conn)
     }

--- a/rack-director/src/http/ui/networks.rs
+++ b/rack-director/src/http/ui/networks.rs
@@ -145,6 +145,14 @@ async fn create_network(
     )
     .await?;
 
+    // Notify the DHCP socket manager so it can bind a socket for this network
+    // before we return 201. This ensures the socket is ready when the caller
+    // starts sending DHCP packets.
+    state
+        .dhcp
+        .network_created(network.id, network.subnet.clone())
+        .await;
+
     Ok((StatusCode::CREATED, Json(network)))
 }
 
@@ -189,6 +197,8 @@ async fn delete_network(
 ) -> Result<StatusCode, HttpError> {
     let conn = state.connection_factory.open().await?;
     crate::dhcp::store::delete_network(&conn, id).await?;
+    // Notify the DHCP socket manager to close the socket for this network.
+    state.dhcp.network_deleted(id).await;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/rack-director/src/lib.rs
+++ b/rack-director/src/lib.rs
@@ -114,6 +114,14 @@ pub struct Args {
         help = "Path to agent image files (vmlinuz, initramfs.img)"
     )]
     agent_images_path: String,
+
+    /// Disable the wildcard broadcast socket.
+    ///
+    /// When set, no `0.0.0.0:PORT` socket is created. The server-identifier
+    /// socket handles all traffic. Intended for integration tests where
+    /// broadcast sockets are undesirable.
+    #[arg(long, default_value_t = false)]
+    no_dhcp_broadcast: bool,
 }
 
 pub struct RackDirectorHandle {
@@ -125,8 +133,8 @@ pub struct RackDirectorHandle {
     tftp_handle: JoinHandle<Result<(), anyhow::Error>>,
     pub tftp_port: u16,
 
-    // Information for the dhcp service
-    dhcp_handle: JoinHandle<Result<(), anyhow::Error>>,
+    // Information for the dhcp service (socket manager run loop, returns ())
+    dhcp_handle: JoinHandle<()>,
     pub dhcp_port: u16,
 
     // Background task for cleaning up expired DHCP leases
@@ -137,7 +145,9 @@ impl RackDirectorHandle {
     // Wait for the services to stop.
     // TODO: Currently just waiting for any one to abort. Need a proper abort signal / shutdown architecture.
     pub async fn wait(self) {
-        let _ = tokio::try_join!(self.http_handle, self.tftp_handle, self.dhcp_handle);
+        // dhcp_handle returns () so it cannot be joined with try_join!; abort it on exit.
+        let _ = tokio::try_join!(self.http_handle, self.tftp_handle);
+        self.dhcp_handle.abort();
         self.lease_cleanup_handle.abort();
     }
 }
@@ -202,6 +212,9 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
     let mut tftp_server = tftp::Server::new(boot_file_provider.clone());
     tftp_server.address(args.tftp_address);
 
+    // Start DHCP Service first so the DhcpControl handle is available for HTTP.
+    let dhcp_start_result = dhcp_server.serve(args.no_dhcp_broadcast).await?;
+
     // Start HTTP Service — each HTTP handler opens its own connection via the
     // shared factory, keeping it independent of DHCP and Director connections.
     let http_start_result = http::start(
@@ -210,14 +223,12 @@ pub async fn rack_director_start(args: crate::Args) -> Result<RackDirectorHandle
         args.http_address,
         std::path::PathBuf::from(&args.agent_images_path),
         boot_file_provider,
+        dhcp_start_result.control.clone(),
     )
     .await?;
 
     // Start TFTP Service
     let tftp_start_result = tftp_server.serve().await?;
-
-    // Start DHCP Service
-    let dhcp_start_result = dhcp_server.serve().await?;
 
     Ok(RackDirectorHandle {
         http_handle: http_start_result.join_handle,

--- a/rack-director/tests/common/mod.rs
+++ b/rack-director/tests/common/mod.rs
@@ -104,6 +104,8 @@ pub async fn start_rack_director() -> Result<TestRackDirectorHandle, anyhow::Err
         &format!("--tftp-path={}", tftp_path.display()),
         &format!("--storage-path={}", storage_path),
         "--dhcp-address=0.0.0.0:0",
+        "--dhcp-server-identifier=127.0.0.1",
+        "--no-dhcp-broadcast",
         "--http-address=127.0.0.1:0",
         "--tftp-address=127.0.0.1:0",
         "--tftp-public-address=10.0.0.1",

--- a/rack-director/tests/common/mod.rs
+++ b/rack-director/tests/common/mod.rs
@@ -47,8 +47,8 @@ pub async fn create_test_network(http_port: u16) -> Result<u64, anyhow::Error> {
         .post(format!("http://127.0.0.1:{}/ui/dhcp/networks", http_port))
         .json(&json!({
             "name": "Test",
-            "subnet": "10.0.0.0/24",
-            "gateway": "10.0.0.1",
+            "subnet": "127.0.0.0/8",
+            "gateway": "127.0.0.1",
             "dns_servers": ["8.8.8.8"],
             "lease_duration": 3600,
             "enable_autodiscovery": false
@@ -70,8 +70,8 @@ pub async fn create_test_pool(http_port: u16, network_id: u64) -> Result<(), any
         ))
         .json(&json!({
             "name": "Test Pool",
-            "range_start": "10.0.0.100",
-            "range_end": "10.0.0.200"
+            "range_start": "127.0.0.100",
+            "range_end": "127.0.0.200"
         }))
         .send()
         .await?
@@ -103,7 +103,7 @@ pub async fn start_rack_director() -> Result<TestRackDirectorHandle, anyhow::Err
         &format!("--db-path={}", db_path),
         &format!("--tftp-path={}", tftp_path.display()),
         &format!("--storage-path={}", storage_path),
-        "--dhcp-address=127.0.0.1:0",
+        "--dhcp-address=0.0.0.0:0",
         "--http-address=127.0.0.1:0",
         "--tftp-address=127.0.0.1:0",
         "--tftp-public-address=10.0.0.1",


### PR DESCRIPTION
Split the DHCP Socket into a broadcast-listener socket and multiple IP-bound sockets used for sending and receiving. Packets received on the broadcast socket are received using system calls that return the packet and the interface ID that received it. The interface ID is matched to a DHCP Network by looking at the assigned local IP addresses on that interface. Replies are never sent from the broadcast socket, since Operating Systems may route broadcast sockets out different interfaces.

An IP-Bound socket is created for each DHCP Network corresponding to a IP Address assigned to a local interface. These handle unicast packets as well as sending broadcast replies from the broadcast socket, to ensure they go out the proper interface. This makes the Relay Agent Address of a network redundant, and it can be removed in a future change.