### PR TITLE
Add console boot target

### DIFF
--- a/common/src/poll_action.rs
+++ b/common/src/poll_action.rs
@@ -13,6 +13,7 @@ pub enum PollAction {
     PartitionDisks,
     RebootDevice,
     InstallOs,
+    Console,
 }
 
 /// Envelope wrapping a [`PollAction`] sent from rack-director to the agent daemon.

--- a/rack-agent/src/console.rs
+++ b/rack-agent/src/console.rs
@@ -1,0 +1,49 @@
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use common::cnc::CncClient;
+use log::info;
+
+use crate::scan;
+
+// Start the console when the UUID is not known
+pub async fn start_console_command(client: &CncClient) -> Result<()> {
+    let uuid = scan::read_dmi_for_uuid()
+        .await?
+        .ok_or(anyhow!("uuid not found"))?;
+    start_console(&client, &uuid).await
+}
+
+// Start the console when the UUID can be provided. Saves a DMI table scan.
+pub async fn start_console(client: &CncClient, uuid: &str) -> Result<()> {
+    info!("Starting console");
+    let mut process = tokio::process::Command::new("bash")
+        .env("PS0", "#> ")
+        .stdin(open_console_input()?)
+        .stdout(open_console_output()?)
+        .stderr(open_console_output()?)
+        .spawn()
+        .expect("failed to start bash");
+
+    // Set success
+    client.action_success(uuid).await?;
+
+    // Wait for process to exit
+    let exit_code = loop {
+        match process.try_wait()? {
+            None => tokio::time::sleep(Duration::from_secs(2)).await,
+            Some(exit_code) => break exit_code,
+        };
+    };
+
+    info!("User exited console (exit code {})", exit_code);
+    Ok(())
+}
+
+fn open_console_input() -> Result<std::fs::File, std::io::Error> {
+    std::fs::File::options().read(true).open("/dev/console")
+}
+
+fn open_console_output() -> Result<std::fs::File, std::io::Error> {
+    std::fs::File::options().write(true).open("/dev/console")
+}

--- a/rack-agent/src/daemon.rs
+++ b/rack-agent/src/daemon.rs
@@ -3,7 +3,7 @@ use log::{error, info, warn};
 
 use common::cnc::{CncClient, PollAction, PollResponse};
 
-use crate::{bmc, partition, scan};
+use crate::{bmc, console::start_console, partition, scan};
 
 const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
@@ -40,7 +40,7 @@ pub async fn run_daemon(client: &CncClient) -> Result<()> {
             Ok(None) => LoopControl::SleepThenPoll,
             Ok(Some(PollResponse::Action { payload })) => {
                 info!("Received action: {:?}", payload);
-                dispatch_action(client, &payload).await
+                dispatch_action(client, &uuid, &payload).await
             }
         };
 
@@ -61,7 +61,7 @@ pub async fn run_daemon(client: &CncClient) -> Result<()> {
 /// rack-director via [`RackDirector::action_success`] /
 /// [`RackDirector::action_failed`]. The daemon only observes the outcome to
 /// decide whether to poll again immediately or stop.
-async fn dispatch_action(client: &CncClient, action: &PollAction) -> LoopControl {
+async fn dispatch_action(client: &CncClient, uuid: &str, action: &PollAction) -> LoopControl {
     match action {
         PollAction::DiscoverHardware => {
             let args = scan::DeviceScanArgs::new(false);
@@ -112,6 +112,12 @@ async fn dispatch_action(client: &CncClient, action: &PollAction) -> LoopControl
             // no timeout. This requires manual intervention to reset the plan.
             LoopControl::Exit
         }
+        PollAction::Console => {
+            if let Err(e) = start_console(client, uuid).await {
+                error!("Console failed: {e}");
+            }
+            LoopControl::PollImmediately
+        }
     }
 }
 
@@ -134,7 +140,7 @@ mod tests {
             .await;
 
         let client = CncClient::new(&server.url());
-        let control = dispatch_action(&client, &PollAction::RebootDevice).await;
+        let control = dispatch_action(&client, "", &PollAction::RebootDevice).await;
 
         assert!(matches!(control, LoopControl::Exit));
     }
@@ -149,7 +155,7 @@ mod tests {
             .await;
 
         let client = CncClient::new(&server.url());
-        let control = dispatch_action(&client, &PollAction::InstallOs).await;
+        let control = dispatch_action(&client, "", &PollAction::InstallOs).await;
 
         assert!(matches!(control, LoopControl::Exit));
     }
@@ -170,7 +176,7 @@ mod tests {
             .await;
 
         let client = CncClient::new(&server.url());
-        let control = dispatch_action(&client, &PollAction::DiscoverHardware).await;
+        let control = dispatch_action(&client, "", &PollAction::DiscoverHardware).await;
 
         assert!(matches!(control, LoopControl::SleepThenPoll));
     }
@@ -186,7 +192,7 @@ mod tests {
             .await;
 
         let client = CncClient::new(&server.url());
-        let control = dispatch_action(&client, &PollAction::PartitionDisks).await;
+        let control = dispatch_action(&client, "", &PollAction::PartitionDisks).await;
 
         assert!(matches!(control, LoopControl::SleepThenPoll));
     }
@@ -202,7 +208,7 @@ mod tests {
             .await;
 
         let client = CncClient::new(&server.url());
-        let control = dispatch_action(&client, &PollAction::ConfigureBmc).await;
+        let control = dispatch_action(&client, "", &PollAction::ConfigureBmc).await;
 
         assert!(matches!(control, LoopControl::SleepThenPoll));
     }

--- a/rack-agent/src/main.rs
+++ b/rack-agent/src/main.rs
@@ -4,7 +4,10 @@ use clap::Parser;
 use clap::Subcommand;
 use log::{error, info, warn};
 
+use crate::console::start_console_command;
+
 mod bmc;
+mod console;
 mod daemon;
 mod partition;
 mod scan;
@@ -19,6 +22,8 @@ enum Command {
     PartitionDisks,
     /// Continuously polls rack-director for actions and executes them without rebooting between actions.
     Daemon,
+    /// Give a shell
+    Console,
 }
 
 #[derive(Parser, Debug)]
@@ -59,6 +64,7 @@ async fn main() {
             Command::ConfigureBmc => bmc::bmc_configure(&client).await,
             Command::PartitionDisks => partition::partition_disks(&client).await,
             Command::Daemon => daemon::run_daemon(&client).await,
+            Command::Console => start_console_command(&client).await,
         }
     } else {
         // Read action from --action flag or /proc/cmdline
@@ -76,6 +82,7 @@ async fn main() {
             "configure-bmc" => bmc::bmc_configure(&client).await,
             "partition-disks" => partition::partition_disks(&client).await,
             "daemon" => daemon::run_daemon(&client).await,
+            "console" => start_console_command(&client).await,
             _ => {
                 error!("Unknown action: {}", action);
                 std::process::exit(1);

--- a/rack-director/src/director/mod.rs
+++ b/rack-director/src/director/mod.rs
@@ -1033,7 +1033,7 @@ mod tests {
         // Verify the device gets BMC config boot target for second action
         let boot_target = director.next_boot_target(&test_uuid, 600).await.unwrap();
         assert!(
-            matches!(boot_target, BootTarget::AgentImage { action, cmdline } if action == "daemon")
+            matches!(boot_target, BootTarget::AgentImage { action, cmdline: _ } if action == "daemon")
         );
 
         // Simulate BMC configuration completion

--- a/rack-director/src/http/cnc/poll.rs
+++ b/rack-director/src/http/cnc/poll.rs
@@ -30,6 +30,7 @@ impl From<&Action> for PollAction {
             Action::PartitionDisks => PollAction::PartitionDisks,
             Action::RebootDevice => PollAction::RebootDevice,
             Action::InstallOs => PollAction::InstallOs,
+            Action::Console => PollAction::Console,
         }
     }
 }
@@ -244,5 +245,6 @@ mod tests {
             PollAction::RebootDevice
         );
         assert_eq!(PollAction::from(&Action::InstallOs), PollAction::InstallOs);
+        assert_eq!(PollAction::from(&Action::Console), PollAction::Console);
     }
 }

--- a/rack-director/src/plans/actions/mod.rs
+++ b/rack-director/src/plans/actions/mod.rs
@@ -20,6 +20,7 @@ pub enum Action {
     InstallOs,
     PartitionDisks,
     RebootDevice,
+    Console,
 }
 
 /// Context required for converting Actions to BootTargets
@@ -41,6 +42,7 @@ impl Action {
                 generate_agent_boot_target("daemon")
             }
             Action::InstallOs => generate_os_install_boot_target(ctx).await,
+            Action::Console => generate_agent_boot_target("console"),
             // All other actions default to local disk boot
             _ => Ok(BootTarget::LocalDisk),
         }


### PR DESCRIPTION
## Summary

- Adds a `Console` action that PXE-boots the device into an interactive bash shell via `/dev/console`
- Useful for debugging devices mid-provisioning without needing out-of-band access (IPMI/iDRAC)
- When dispatched, the agent starts bash on `/dev/console`, reports success, and waits for exit

## Changes

- `common`: add `Console` variant to `PollAction`
- `rack-agent/main`: add `console` CLI subcommand; implement `start_console` (opens bash on `/dev/console`)
- `rack-agent/daemon`: pass device UUID to `dispatch_action`; handle `PollAction::Console`
- `rack-director/plans/actions`: add `Console` to `Action` enum, maps to `AgentBoot("console")`
- `rack-director/poll`: map `Action::Console → PollAction::Console`

## Test plan

- [ ] Assign a device to a Console action in rack-director and verify it PXE-boots and spawns a shell
- [ ] Verify `action_success` is called before the shell starts (so the plan can advance)
- [ ] Verify daemon polls again after the shell exits
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)