### PR TITLE
Fix: Add Device button missing/broken in disk layout editor (#28)

### DIFF
--- a/rack-director-ui/src/components/roles/disk-layout-editor.tsx
+++ b/rack-director-ui/src/components/roles/disk-layout-editor.tsx
@@ -282,36 +282,45 @@ export default function DiskLayoutEditor({
           </button>
         </div>
       ) : (
-        layout.disks.map((disk, diskIndex) => (
-          <DiskSection
-            key={diskIndex}
-            disk={disk}
-            diskIndex={diskIndex}
-            vgNames={vgNames}
-            canRemove={layout.disks.length > 1}
-            onUpdateLabel={(label) =>
-              dispatch({ type: "UPDATE_DISK_LABEL", diskIndex, label })
-            }
-            onUpdateTable={(table) =>
-              dispatch({ type: "UPDATE_DISK_TABLE", diskIndex, table })
-            }
-            onRemove={() => dispatch({ type: "REMOVE_DISK", diskIndex })}
-            onAddPartition={() => dispatch({ type: "ADD_PARTITION", diskIndex })}
-            onRemovePartition={(partIndex) =>
-              dispatch({ type: "REMOVE_PARTITION", diskIndex, partIndex })
-            }
-            onUpdatePartition={(partIndex, partition) =>
-              dispatch({ type: "UPDATE_PARTITION", diskIndex, partIndex, partition })
-            }
-            errors={errors}
-            errorPrefix={`disks.${diskIndex}`}
-            onClearError={onClearError}
-            firmwareMode={firmwareMode}
-            onPrependPartition={(partition) =>
-              dispatch({ type: "PREPEND_PARTITION", diskIndex, partition })
-            }
-          />
-        ))
+        <>
+          {layout.disks.map((disk, diskIndex) => (
+            <DiskSection
+              key={diskIndex}
+              disk={disk}
+              diskIndex={diskIndex}
+              vgNames={vgNames}
+              canRemove={layout.disks.length > 1}
+              onUpdateLabel={(label) =>
+                dispatch({ type: "UPDATE_DISK_LABEL", diskIndex, label })
+              }
+              onUpdateTable={(table) =>
+                dispatch({ type: "UPDATE_DISK_TABLE", diskIndex, table })
+              }
+              onRemove={() => dispatch({ type: "REMOVE_DISK", diskIndex })}
+              onAddPartition={() => dispatch({ type: "ADD_PARTITION", diskIndex })}
+              onRemovePartition={(partIndex) =>
+                dispatch({ type: "REMOVE_PARTITION", diskIndex, partIndex })
+              }
+              onUpdatePartition={(partIndex, partition) =>
+                dispatch({ type: "UPDATE_PARTITION", diskIndex, partIndex, partition })
+              }
+              errors={errors}
+              errorPrefix={`disks.${diskIndex}`}
+              onClearError={onClearError}
+              firmwareMode={firmwareMode}
+              onPrependPartition={(partition) =>
+                dispatch({ type: "PREPEND_PARTITION", diskIndex, partition })
+              }
+            />
+          ))}
+          <button
+            type="button"
+            onClick={() => dispatch({ type: "ADD_DISK" })}
+            className="text-xs text-accent hover:text-accent-hover transition-colors cursor-pointer"
+          >
+            + Add Device
+          </button>
+        </>
       )}
 
       {/* Volume Groups */}

--- a/rack-director-ui/src/pages/RoleNew.tsx
+++ b/rack-director-ui/src/pages/RoleNew.tsx
@@ -344,20 +344,8 @@ function RoleNew() {
 
           {/* Disk Layout card */}
           <div className="border border-border bg-bg-surface">
-            <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+            <div className="px-4 py-3 border-b border-border">
               <span className="text-sm font-semibold text-text-primary">Disk Layout</span>
-              <button
-                type="button"
-                onClick={() => {
-                  // Trigger add disk in the editor via a custom event isn't ideal,
-                  // so we rely on the "+ Add Device" inside the editor empty state.
-                  // This button is shown here for visual consistency per spec.
-                }}
-                className="text-xs text-text-secondary border border-border px-2 py-1 hover:border-accent hover:text-text-primary transition-colors rounded-sm cursor-not-allowed opacity-50"
-                title="Use the '+ Add Device' button below when no disks are defined"
-              >
-                + Add Device
-              </button>
             </div>
             <div className="px-4 py-4">
               <DiskLayoutEditor


### PR DESCRIPTION
## Summary

- The `DiskLayoutEditor` component only rendered the `+ Add Device` button in the empty state (no disks defined). Since `RoleNew` seeds the form with a default disk layout and `RoleEdit` loads existing roles, the empty state was never visible — making it impossible to add additional disks.
- Also removes the non-functional disabled `+ Add Device` button that existed in the `RoleNew` card header with an empty `onClick` handler.

## Changes

- **`disk-layout-editor.tsx`**: Added `+ Add Device` button below the disk list when disks are already present, so it's always accessible.
- **`RoleNew.tsx`**: Removed the broken placeholder button from the Disk Layout card header.

## Test plan

- [ ] Navigate to `/roles/new` and confirm `+ Add Device` appears and successfully adds a second disk
- [ ] Navigate to an existing role's edit page and confirm `+ Add Device` works there too
- [ ] Confirm the broken disabled button no longer appears in the Role create form
- [ ] `npm run build` passes with no errors

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)