### PR TITLE
Allow omitting filesystem for LVM logical volumes

### DIFF
--- a/common/src/disk_layout.rs
+++ b/common/src/disk_layout.rs
@@ -219,6 +219,13 @@ mod tests {
                     },
                     LogicalVolume {
                         name: "home".to_string(),
+                        size: "50G".to_string(),
+                        filesystem: Some("ext4".to_string()),
+                        mount_point: Some("/home".to_string()),
+                    },
+                    // Raw LV with no filesystem (e.g. consumed by Ceph).
+                    LogicalVolume {
+                        name: "ceph".to_string(),
                         size: "100%FREE".to_string(),
                         filesystem: None,
                         mount_point: None,

--- a/common/src/disk_layout.rs
+++ b/common/src/disk_layout.rs
@@ -51,7 +51,8 @@ pub struct VolumeGroup {
 pub struct LogicalVolume {
     pub name: String,
     pub size: String, // "50G", "100%FREE"
-    pub filesystem: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filesystem: Option<String>, // None for raw LVs (e.g., Ceph OSDs)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mount_point: Option<String>,
 }
@@ -207,20 +208,20 @@ mod tests {
                     LogicalVolume {
                         name: "root".to_string(),
                         size: "50G".to_string(),
-                        filesystem: "ext4".to_string(),
+                        filesystem: Some("ext4".to_string()),
                         mount_point: Some("/".to_string()),
                     },
                     LogicalVolume {
                         name: "swap".to_string(),
                         size: "8G".to_string(),
-                        filesystem: "swap".to_string(),
+                        filesystem: Some("swap".to_string()),
                         mount_point: None,
                     },
                     LogicalVolume {
                         name: "home".to_string(),
                         size: "100%FREE".to_string(),
-                        filesystem: "ext4".to_string(),
-                        mount_point: Some("/home".to_string()),
+                        filesystem: None,
+                        mount_point: None,
                     },
                 ],
             }]),

--- a/rack-agent/src/partition.rs
+++ b/rack-agent/src/partition.rs
@@ -235,9 +235,12 @@ async fn setup_volume_group(vg: &VolumeGroup, disks: &[DiskConfig]) -> Result<()
             .await?;
         }
 
-        // Format the logical volume
-        let lv_path = format!("/dev/{}/{}", vg.name, lv.name);
-        format_filesystem(&lv_path, &lv.filesystem).await?;
+        // Format the logical volume, unless it has no filesystem (e.g. a raw
+        // LV consumed by Ceph or another subsystem).
+        if let Some(ref fs) = lv.filesystem {
+            let lv_path = format!("/dev/{}/{}", vg.name, lv.name);
+            format_filesystem(&lv_path, fs).await?;
+        }
     }
 
     Ok(())

--- a/rack-director-ui/src/components/roles/logical-volume-row.tsx
+++ b/rack-director-ui/src/components/roles/logical-volume-row.tsx
@@ -6,6 +6,14 @@ import { Trash2, ChevronDown, ChevronUp } from "lucide-react";
 import type { LogicalVolume } from "@/lib/client";
 import { selectClassName, BASE_FILESYSTEM_OPTIONS } from "./styles";
 
+// Sentinel select value representing a raw LV with no filesystem (e.g. Ceph OSD).
+const NO_FILESYSTEM = "__none__";
+
+const FILESYSTEM_OPTIONS = [
+  ...BASE_FILESYSTEM_OPTIONS,
+  { value: NO_FILESYSTEM, label: "— None (raw / Ceph)" },
+];
+
 interface LogicalVolumeRowProps {
   lv: LogicalVolume;
   lvIndex: number;
@@ -34,8 +42,20 @@ export default function LogicalVolumeRow({
   const filesystemError = errors?.[`${errorPrefix}.filesystem`];
   const mountPointError = errors?.[`${errorPrefix}.mount_point`];
 
-  const showMountPoint = lv.filesystem !== "swap";
+  const showMountPoint = lv.filesystem !== "swap" && lv.filesystem !== undefined;
   const sizeDisplay = lv.size || "—";
+
+  function handleFilesystemChange(val: string) {
+    onClearError?.(`${errorPrefix}.filesystem`);
+    if (val === NO_FILESYSTEM) {
+      onUpdate({ filesystem: undefined, mount_point: undefined });
+    } else {
+      onUpdate({
+        filesystem: val,
+        mount_point: val === "swap" ? undefined : lv.mount_point,
+      });
+    }
+  }
 
   return (
     <>
@@ -51,7 +71,7 @@ export default function LogicalVolumeRow({
           {sizeDisplay}
         </td>
         <td className="px-3 py-1.5 text-xs text-text-secondary">
-          {lv.filesystem}
+          {lv.filesystem ?? <span className="text-text-muted">raw</span>}
         </td>
         <td className="px-3 py-1.5 text-xs text-text-secondary font-mono">
           {lv.name || <span className="text-text-muted italic">unnamed</span>}
@@ -146,23 +166,16 @@ export default function LogicalVolumeRow({
                 {/* Filesystem */}
                 <div className="space-y-1">
                   <Label htmlFor={`lv-fs-${errorPrefix}`} className="text-xs text-text-secondary uppercase tracking-[0.5px]">
-                    Filesystem *
+                    Filesystem
                   </Label>
                   <select
                     id={`lv-fs-${errorPrefix}`}
-                    value={lv.filesystem}
-                    onChange={(e) => {
-                      onClearError?.(`${errorPrefix}.filesystem`);
-                      const newFs = e.target.value;
-                      onUpdate({
-                        filesystem: newFs,
-                        mount_point: newFs === "swap" ? undefined : lv.mount_point,
-                      });
-                    }}
+                    value={lv.filesystem ?? NO_FILESYSTEM}
+                    onChange={(e) => handleFilesystemChange(e.target.value)}
                     className={selectClassName}
                     aria-invalid={!!filesystemError}
                   >
-                    {BASE_FILESYSTEM_OPTIONS.map((opt) => (
+                    {FILESYSTEM_OPTIONS.map((opt) => (
                       <option key={opt.value} value={opt.value}>
                         {opt.label}
                       </option>

--- a/rack-director-ui/src/lib/client.ts
+++ b/rack-director-ui/src/lib/client.ts
@@ -261,7 +261,7 @@ export type DiskConfig = {
 export type LogicalVolume = {
   name: string;
   size: string;              // "50G", "100%FREE"
-  filesystem: string;
+  filesystem?: string;       // undefined for raw LVs (e.g. Ceph OSDs)
   mount_point?: string;
 };
 
@@ -493,18 +493,6 @@ export async function cancelDeviceTransition(uuid: string): Promise<void> {
   if (!response.ok) {
     return handleApiError(response, 'Failed to cancel transition');
   }
-}
-
-export async function cancelDeviceTransition(uuid: string): Promise<void> {
-  return fetch(`/ui/devices/${uuid}/lifecycle/cancel`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-  }).then((response) => {
-    if (!response.ok) {
-      console.error('Error cancelling device transition:', response.statusText);
-      throw new Error('Failed to cancel transition');
-    }
-  });
 }
 
 export async function getDeviceTransitions(uuid: string, includeCompleted: boolean = false): Promise<LifecycleTransition[]> {

--- a/rack-director/src/director/mod.rs
+++ b/rack-director/src/director/mod.rs
@@ -299,8 +299,8 @@ impl<'a> Director<'a> {
         };
 
         // If the agent included a plan_id, verify it matches the active plan
-        if let Some(rid) = reported_plan_id {
-            if plan.id != Some(rid) {
+        if let Some(rid) = reported_plan_id
+            && plan.id != Some(rid) {
                 log::warn!(
                     "action_success for device {} reported plan_id={} but active plan is {:?} — ignoring stale report",
                     device_uuid,
@@ -309,7 +309,6 @@ impl<'a> Director<'a> {
                 );
                 return Ok(());
             }
-        }
 
         // Start the plan if it's pending
         if plan.status == PlanStatus::Pending {
@@ -367,8 +366,8 @@ impl<'a> Director<'a> {
         };
 
         // If the agent included a plan_id, verify it matches the active plan
-        if let Some(rid) = reported_plan_id {
-            if plan.id != Some(rid) {
+        if let Some(rid) = reported_plan_id
+            && plan.id != Some(rid) {
                 log::warn!(
                     "action_failed for device {} reported plan_id={} but active plan is {:?} — ignoring stale report",
                     device_uuid,
@@ -377,7 +376,6 @@ impl<'a> Director<'a> {
                 );
                 return Ok(());
             }
-        }
 
         // Mark current action as failed
         let _result = plan.mark_action_failed(error_message.to_string());

--- a/rack-director/src/director/mod.rs
+++ b/rack-director/src/director/mod.rs
@@ -300,15 +300,16 @@ impl<'a> Director<'a> {
 
         // If the agent included a plan_id, verify it matches the active plan
         if let Some(rid) = reported_plan_id
-            && plan.id != Some(rid) {
-                log::warn!(
-                    "action_success for device {} reported plan_id={} but active plan is {:?} — ignoring stale report",
-                    device_uuid,
-                    rid,
-                    plan.id
-                );
-                return Ok(());
-            }
+            && plan.id != Some(rid)
+        {
+            log::warn!(
+                "action_success for device {} reported plan_id={} but active plan is {:?} — ignoring stale report",
+                device_uuid,
+                rid,
+                plan.id
+            );
+            return Ok(());
+        }
 
         // Start the plan if it's pending
         if plan.status == PlanStatus::Pending {
@@ -367,15 +368,16 @@ impl<'a> Director<'a> {
 
         // If the agent included a plan_id, verify it matches the active plan
         if let Some(rid) = reported_plan_id
-            && plan.id != Some(rid) {
-                log::warn!(
-                    "action_failed for device {} reported plan_id={} but active plan is {:?} — ignoring stale report",
-                    device_uuid,
-                    rid,
-                    plan.id
-                );
-                return Ok(());
-            }
+            && plan.id != Some(rid)
+        {
+            log::warn!(
+                "action_failed for device {} reported plan_id={} but active plan is {:?} — ignoring stale report",
+                device_uuid,
+                rid,
+                plan.id
+            );
+            return Ok(());
+        }
 
         // Mark current action as failed
         let _result = plan.mark_action_failed(error_message.to_string());

--- a/rack-director/src/disk_layout/validate.rs
+++ b/rack-director/src/disk_layout/validate.rs
@@ -251,7 +251,11 @@ fn validate_logical_volume_filesystems(
     errors: &mut HashMap<String, String>,
 ) {
     for (j, lv) in vg.logical_volumes.iter().enumerate() {
-        if !VALID_FILESYSTEMS.contains(&lv.filesystem.as_str()) {
+        // A logical volume may omit its filesystem (e.g. a raw LV consumed by
+        // Ceph). Only validate the value when one is specified.
+        if let Some(fs) = lv.filesystem.as_deref()
+            && !VALID_FILESYSTEMS.contains(&fs)
+        {
             errors.insert(
                 format!(
                     "volume_groups.{}.logical_volumes.{}.filesystem",
@@ -259,7 +263,7 @@ fn validate_logical_volume_filesystems(
                 ),
                 format!(
                     "Invalid filesystem '{}'. Valid options: ext4, xfs, btrfs, vfat, swap",
-                    lv.filesystem
+                    fs
                 ),
             );
         }
@@ -674,7 +678,7 @@ mod tests {
                 logical_volumes: vec![LogicalVolume {
                     name: "root".to_string(),
                     size: "rest".to_string(),
-                    filesystem: "ext4".to_string(),
+                    filesystem: Some("ext4".to_string()),
                     mount_point: Some("/".to_string()),
                 }],
             }]),
@@ -757,7 +761,7 @@ mod tests {
                 logical_volumes: vec![LogicalVolume {
                     name: "root".to_string(),
                     size: "rest".to_string(),
-                    filesystem: "ext4".to_string(),
+                    filesystem: Some("ext4".to_string()),
                     mount_point: Some("/".to_string()),
                 }],
             }]),
@@ -796,7 +800,7 @@ mod tests {
                 logical_volumes: vec![LogicalVolume {
                     name: "root".to_string(),
                     size: "rest".to_string(),
-                    filesystem: "fat32".to_string(), // invalid
+                    filesystem: Some("fat32".to_string()), // invalid
                     mount_point: Some("/".to_string()),
                 }],
             }]),
@@ -807,6 +811,36 @@ mod tests {
         let errors = result.unwrap_err();
         assert!(errors.contains_key("volume_groups.0.logical_volumes.0.filesystem"));
         assert!(errors["volume_groups.0.logical_volumes.0.filesystem"].contains("fat32"));
+    }
+
+    #[test]
+    fn test_lv_without_filesystem_is_ok() {
+        // A raw LV (e.g. consumed by Ceph) omits its filesystem.
+        let layout = DiskLayout {
+            disks: vec![DiskConfig {
+                device: "/dev/sda".to_string(),
+                partition_table: "gpt".to_string(),
+                partitions: vec![PartitionConfig {
+                    label: "lvm".to_string(),
+                    size: "rest".to_string(),
+                    filesystem: None,
+                    mount_point: None,
+                    flags: Some(vec!["lvm".to_string()]),
+                    volume_group: Some("vg0".to_string()),
+                }],
+            }],
+            volume_groups: Some(vec![VolumeGroup {
+                name: "vg0".to_string(),
+                logical_volumes: vec![LogicalVolume {
+                    name: "osd0".to_string(),
+                    size: "100%FREE".to_string(),
+                    filesystem: None,
+                    mount_point: None,
+                }],
+            }]),
+            zfs_pools: None,
+        };
+        assert!(validate_disk_layout(&layout, None).is_ok());
     }
 
     #[test]
@@ -840,13 +874,13 @@ mod tests {
                     LogicalVolume {
                         name: "root".to_string(),
                         size: "50G".to_string(),
-                        filesystem: "ext4".to_string(),
+                        filesystem: Some("ext4".to_string()),
                         mount_point: Some("/".to_string()),
                     },
                     LogicalVolume {
                         name: "swap".to_string(),
                         size: "8G".to_string(),
-                        filesystem: "swap".to_string(),
+                        filesystem: Some("swap".to_string()),
                         mount_point: None,
                     },
                 ],

--- a/rack-director/src/disk_layout/validate.rs
+++ b/rack-director/src/disk_layout/validate.rs
@@ -108,7 +108,31 @@ fn validate_disk_partitions(
 
     for (j, partition) in partitions.iter().enumerate() {
         validate_partition_filesystem(disk_index, j, partition.filesystem.as_deref(), errors);
+        validate_mount_point_requires_filesystem(
+            format!("disks.{}.partitions.{}.mount_point", disk_index, j),
+            partition.filesystem.as_deref(),
+            partition.mount_point.as_deref(),
+            errors,
+        );
         validate_lvm_partition(disk_index, j, partition, defined_vg_names, errors);
+    }
+}
+
+/// A mount point is only meaningful when there is a filesystem to mount. Reject a
+/// `mount_point` that is set while `filesystem` is absent — install-script templates
+/// would otherwise emit a broken entry with an empty filesystem type.
+fn validate_mount_point_requires_filesystem(
+    field: String,
+    filesystem: Option<&str>,
+    mount_point: Option<&str>,
+    errors: &mut HashMap<String, String>,
+) {
+    if filesystem.is_none() && mount_point.is_some() {
+        errors.insert(
+            field,
+            "A mount point requires a filesystem; clear the mount point or choose a filesystem"
+                .to_string(),
+        );
     }
 }
 
@@ -267,6 +291,16 @@ fn validate_logical_volume_filesystems(
                 ),
             );
         }
+
+        validate_mount_point_requires_filesystem(
+            format!(
+                "volume_groups.{}.logical_volumes.{}.mount_point",
+                vg_index, j
+            ),
+            lv.filesystem.as_deref(),
+            lv.mount_point.as_deref(),
+            errors,
+        );
     }
 }
 
@@ -841,6 +875,62 @@ mod tests {
             zfs_pools: None,
         };
         assert!(validate_disk_layout(&layout, None).is_ok());
+    }
+
+    #[test]
+    fn test_lv_mount_point_without_filesystem_returns_error() {
+        let layout = DiskLayout {
+            disks: vec![DiskConfig {
+                device: "/dev/sda".to_string(),
+                partition_table: "gpt".to_string(),
+                partitions: vec![PartitionConfig {
+                    label: "lvm".to_string(),
+                    size: "rest".to_string(),
+                    filesystem: None,
+                    mount_point: None,
+                    flags: Some(vec!["lvm".to_string()]),
+                    volume_group: Some("vg0".to_string()),
+                }],
+            }],
+            volume_groups: Some(vec![VolumeGroup {
+                name: "vg0".to_string(),
+                logical_volumes: vec![LogicalVolume {
+                    name: "data".to_string(),
+                    size: "100%FREE".to_string(),
+                    filesystem: None,
+                    mount_point: Some("/data".to_string()), // nonsensical: no fs to mount
+                }],
+            }]),
+            zfs_pools: None,
+        };
+        let result = validate_disk_layout(&layout, None);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.contains_key("volume_groups.0.logical_volumes.0.mount_point"));
+    }
+
+    #[test]
+    fn test_partition_mount_point_without_filesystem_returns_error() {
+        let layout = DiskLayout {
+            disks: vec![DiskConfig {
+                device: "/dev/sda".to_string(),
+                partition_table: "gpt".to_string(),
+                partitions: vec![PartitionConfig {
+                    label: "data".to_string(),
+                    size: "rest".to_string(),
+                    filesystem: None,
+                    mount_point: Some("/data".to_string()), // nonsensical: no fs to mount
+                    flags: None,
+                    volume_group: None,
+                }],
+            }],
+            volume_groups: None,
+            zfs_pools: None,
+        };
+        let result = validate_disk_layout(&layout, None);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.contains_key("disks.0.partitions.0.mount_point"));
     }
 
     #[test]

--- a/rack-director/src/templates/mod.rs
+++ b/rack-director/src/templates/mod.rs
@@ -78,7 +78,7 @@ pub struct LogicalVolumeContext {
     pub vg_name: String,
     pub lv_name: String,
     pub size: String,
-    pub filesystem: String,
+    pub filesystem: Option<String>,
     pub mount_point: Option<String>,
 }
 
@@ -430,13 +430,13 @@ mod tests {
                     LogicalVolume {
                         name: "root".to_string(),
                         size: "50G".to_string(),
-                        filesystem: "ext4".to_string(),
+                        filesystem: Some("ext4".to_string()),
                         mount_point: Some("/".to_string()),
                     },
                     LogicalVolume {
                         name: "swap".to_string(),
                         size: "8G".to_string(),
-                        filesystem: "swap".to_string(),
+                        filesystem: Some("swap".to_string()),
                         mount_point: None,
                     },
                 ],
@@ -467,7 +467,7 @@ mod tests {
         assert_eq!(logical_volumes[0].vg_name, "vg0");
         assert_eq!(logical_volumes[0].lv_name, "root");
         assert_eq!(logical_volumes[0].size, "50G");
-        assert_eq!(logical_volumes[0].filesystem, "ext4");
+        assert_eq!(logical_volumes[0].filesystem, Some("ext4".to_string()));
         assert_eq!(logical_volumes[0].mount_point, Some("/".to_string()));
 
         assert_eq!(logical_volumes[1].device, "/dev/vg0/swap");
@@ -541,7 +541,7 @@ mod tests {
                 logical_volumes: vec![LogicalVolume {
                     name: "home".to_string(),
                     size: "100%FREE".to_string(),
-                    filesystem: "xfs".to_string(),
+                    filesystem: Some("xfs".to_string()),
                     mount_point: Some("/home".to_string()),
                 }],
             }]),
@@ -651,13 +651,13 @@ mod tests {
                     LogicalVolume {
                         name: "root".to_string(),
                         size: "14G".to_string(),
-                        filesystem: "xfs".to_string(),
+                        filesystem: Some("xfs".to_string()),
                         mount_point: Some("/".to_string()),
                     },
                     LogicalVolume {
                         name: "swap".to_string(),
                         size: "2G".to_string(),
-                        filesystem: "swap".to_string(),
+                        filesystem: Some("swap".to_string()),
                         mount_point: None,
                     },
                 ],

--- a/rack-director/src/templates/mod.rs
+++ b/rack-director/src/templates/mod.rs
@@ -69,7 +69,7 @@ pub struct PartitionContext {
 /// - `{{ this.vg_name }}` - Volume group name
 /// - `{{ this.lv_name }}` - Logical volume name
 /// - `{{ this.size }}` - LV size string
-/// - `{{ this.filesystem }}` - Filesystem type
+/// - `{{ this.filesystem }}` - Filesystem type, or null for raw LVs (e.g. Ceph)
 /// - `{{ this.mount_point }}` - Mount point, or null
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct LogicalVolumeContext {


### PR DESCRIPTION
## Summary

Resolves #22 — allows declaring an LVM logical volume **without** a filesystem. This supports raw LVs consumed by other subsystems (e.g. Ceph OSDs) that must not be formatted with a traditional filesystem.

Partitions already supported an optional filesystem (`Option<String>`); this brings logical volumes to parity.

## Changes

- **common**: `LogicalVolume.filesystem` is now `Option<String>` (serialized only when present).
- **rack-agent**: `setup_volume_group` skips `mkfs` for LVs with no filesystem.
- **rack-director**:
  - `validate_logical_volume_filesystems` only validates when a filesystem is specified.
  - `LogicalVolumeContext.filesystem` is now nullable so install-script templates render `null` for raw LVs.
- **rack-director-ui**: the logical-volume editor adds a "None (raw / Ceph)" filesystem option and hides the mount point when no filesystem is set.

### Incidental fix
While verifying the UI build, I found a pre-existing **duplicate `cancelDeviceTransition` declaration** in `client.ts` (introduced on `main` by the cancel-lifecycle work) that broke the production build entirely. Removed the stray duplicate, keeping the idiomatic `handleApiError`-based version.

## Testing

- `cargo test -p common -p rack-director -p rack-agent` — all pass (added a validation test for a filesystem-less LV; updated existing LVM roundtrip/context tests).
- `npx vite build` — succeeds (was previously broken by the duplicate above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
