### PR TITLE
Remove no-op "Mark As Fixed" button for Broken devices

### DIFF
--- a/rack-director-ui/src/pages/DeviceDetail.tsx
+++ b/rack-director-ui/src/pages/DeviceDetail.tsx
@@ -39,7 +39,7 @@ import {
   type Platform,
   type DeviceWarning,
 } from "@/lib/client";
-import { AlertCircle, Pin, Trash2, Zap, XCircle, WrenchIcon, CheckCircle2 } from "lucide-react";
+import { AlertCircle, Pin, Trash2, Zap, XCircle, WrenchIcon } from "lucide-react";
 import { EditableHostname } from "@/components/devices/editable-hostname";
 import { MakeStaticDialog } from "@/components/networks/make-static-dialog";
 import { TransitionDialog } from "@/components/devices/transition-dialog";
@@ -868,7 +868,7 @@ function DeviceDetail() {
         </Button>
       )}
 
-      {/* Broken: Deprovision + Provision (asks role) + Mark As Fixed + Decommission */}
+      {/* Broken: Deprovision + Provision (asks role) + Decommission */}
       {isBroken && (
         <>
           <Button
@@ -888,15 +888,6 @@ function DeviceDetail() {
           >
             <Zap className="size-3.5" />
             Provision
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => openTransitionDialog("unprovisioned")}
-            disabled={transitioning}
-          >
-            <CheckCircle2 className="size-3.5" />
-            Mark As Fixed
           </Button>
           <Button
             variant="danger"


### PR DESCRIPTION
## Summary

Fixes #15.

For `Broken` devices, the device detail page showed a **"Mark As Fixed"** button. It was originally meant to let a repaired machine return to service without a reinstall flow, but it was never wired to anything special — its `onClick` was `openTransitionDialog("unprovisioned")`, **identical** to the "Deprovision" button directly above it. Since devices only enter `Broken` via a failed transition (which must be retried in full), the one-click "fixed" shortcut was misleading.

## Changes

- Remove the "Mark As Fixed" `<Button>` from the Broken-state action group in `rack-director-ui/src/pages/DeviceDetail.tsx`.
- Drop the now-unused `CheckCircle2` lucide-react import.
- Update the section comment.

Broken-state actions are now **Deprovision / Provision / Decommission** (plus the shared Cancel Transition / Console controls). UI-only change — no backend, API, or route changes.

## Verification

- `npm run build` (tsc + vite) passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)