### PR TITLE
Show seen MAC addresses in Add Pending Device form

### DIFF
--- a/rack-director-ui/src/components/devices/seen-mac-input.tsx
+++ b/rack-director-ui/src/components/devices/seen-mac-input.tsx
@@ -1,0 +1,148 @@
+/**
+ * SeenMacInput — a controlled MAC address combobox that proactively shows
+ * unregistered MAC addresses seen on the selected network (sourced from DHCP
+ * leases), so operators can pick one instead of typing it from memory.
+ *
+ * Fetches its own data (leases + pending devices) on mount, non-fatally.
+ * Filters by networkId, freshness (active/offered), and text prefix.
+ * Shows all candidates immediately on focus — even when the field is empty.
+ */
+
+import { useState, useEffect, useMemo } from "react";
+import { FormFieldError } from "@/components/ui/form-field-error";
+import {
+  getDhcpLeases,
+  getPendingDevices,
+  type DhcpLease,
+  type PendingDevice,
+} from "@/lib/client";
+
+const inputClassName =
+  "w-full bg-bg-base border border-border text-xs text-text-primary px-3 py-2 rounded-sm focus:outline-none focus:border-accent focus:shadow-[0_0_0_1px_var(--color-accent)] placeholder:text-text-muted";
+
+interface SeenMacInputProps {
+  value: string;
+  onChange: (mac: string) => void;
+  networkId: number | null;
+  error?: string;
+  id?: string;
+}
+
+export function SeenMacInput({
+  value,
+  onChange,
+  networkId,
+  error,
+  id = "macAddress",
+}: SeenMacInputProps) {
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [leases, setLeases] = useState<DhcpLease[]>([]);
+  const [existingPending, setExistingPending] = useState<PendingDevice[]>([]);
+
+  useEffect(() => {
+    Promise.all([getDhcpLeases(), getPendingDevices()])
+      .then(([ls, pending]) => {
+        setLeases(ls);
+        setExistingPending(pending);
+      })
+      .catch(() => {
+        // Non-fatal: manual entry still works without suggestions
+      });
+  }, []);
+
+  const pendingMacs = useMemo(
+    () => new Set(existingPending.map((p) => p.mac_address.toLowerCase())),
+    [existingPending]
+  );
+
+  const candidates = useMemo(() => {
+    const query = value.toLowerCase();
+
+    return leases
+      .filter((lease) => {
+        // Skip leases already tied to a device
+        if (lease.device_uuid) return false;
+        // Skip MACs already registered as pending devices
+        if (pendingMacs.has(lease.mac_address.toLowerCase())) return false;
+        // Filter by selected network when one is chosen
+        if (networkId !== null && lease.network_id !== networkId) return false;
+        // Only keep fresh leases; treat missing state as included
+        if (
+          lease.state !== undefined &&
+          lease.state !== "active" &&
+          lease.state !== "offered"
+        ) {
+          return false;
+        }
+        // Text filter: if the user has typed something, require prefix match
+        if (query && !lease.mac_address.toLowerCase().startsWith(query)) {
+          return false;
+        }
+        return true;
+      })
+      .sort((a, b) => {
+        // Sort most-recently-seen first using lease_start, falling back to lease_end
+        const aTime =
+          a.lease_start
+            ? new Date(a.lease_start).getTime()
+            : a.lease_end
+            ? new Date(a.lease_end).getTime()
+            : 0;
+        const bTime =
+          b.lease_start
+            ? new Date(b.lease_start).getTime()
+            : b.lease_end
+            ? new Date(b.lease_end).getTime()
+            : 0;
+        return bTime - aTime;
+      })
+      .slice(0, 10);
+  }, [value, networkId, leases, pendingMacs]);
+
+  return (
+    <div className="relative">
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+        onFocus={() => setShowSuggestions(true)}
+        onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+        placeholder="e.g., aa:bb:cc:dd:ee:ff"
+        required
+        aria-invalid={!!error}
+        autoComplete="off"
+        className={inputClassName}
+      />
+
+      {showSuggestions && (
+        <div className="absolute z-10 w-full bg-bg-surface border border-border mt-1 max-h-48 overflow-y-auto">
+          {candidates.length > 0 ? (
+            candidates.map((lease) => (
+              <div
+                key={lease.id}
+                className="px-3 py-2 text-xs text-text-primary hover:bg-bg-raised cursor-pointer"
+                onMouseDown={() => {
+                  onChange(lease.mac_address);
+                  setShowSuggestions(false);
+                }}
+              >
+                {lease.mac_address} &mdash; {lease.ip_address}
+              </div>
+            ))
+          ) : (
+            <div className="px-3 py-2 text-xs text-text-muted">
+              {networkId === null
+                ? "Select a network to see MACs seen on it"
+                : "No unregistered MACs seen on this network yet"}
+            </div>
+          )}
+        </div>
+      )}
+
+      <FormFieldError error={error} />
+    </div>
+  );
+}

--- a/rack-director-ui/src/pages/PendingDeviceNew.tsx
+++ b/rack-director-ui/src/pages/PendingDeviceNew.tsx
@@ -1,22 +1,16 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
 import { FormFieldError } from "@/components/ui/form-field-error";
 import { useFieldErrors } from "@/hooks/useFieldErrors";
+import { SeenMacInput } from "@/components/devices/seen-mac-input";
 import {
   createPendingDevice,
   getNetworks,
-  getDhcpLeases,
-  getPendingDevices,
   ValidationError,
   type DhcpNetwork,
-  type DhcpLease,
-  type PendingDevice,
 } from "@/lib/client";
-
-const inputClassName =
-  "w-full bg-bg-base border border-border text-xs text-text-primary px-3 py-2 rounded-sm focus:outline-none focus:border-accent focus:shadow-[0_0_0_1px_var(--color-accent)] placeholder:text-text-muted";
 
 const selectClassName =
   "w-full bg-bg-base border border-border text-xs text-text-primary px-3 py-2 rounded-sm focus:outline-none focus:border-accent focus:shadow-[0_0_0_1px_var(--color-accent)]";
@@ -30,46 +24,20 @@ export default function PendingDeviceNew() {
 
   const [networkId, setNetworkId] = useState("");
   const [macAddress, setMacAddress] = useState("");
-  const [showSuggestions, setShowSuggestions] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [networks, setNetworks] = useState<DhcpNetwork[]>([]);
-  const [leases, setLeases] = useState<DhcpLease[]>([]);
-  const [existingPending, setExistingPending] = useState<PendingDevice[]>([]);
 
   useEffect(() => {
-    Promise.all([getNetworks(), getDhcpLeases(), getPendingDevices()])
-      .then(([nets, ls, pending]) => {
+    getNetworks()
+      .then((nets) => {
         setNetworks(nets);
-        setLeases(ls);
-        setExistingPending(pending);
       })
       .catch(() => {
-        // Non-fatal: form is still usable without suggestions
+        // Non-fatal: network select will remain empty
       });
   }, []);
-
-  const existingMacs = useMemo(
-    () => new Set(existingPending.map((p) => p.mac_address.toLowerCase())),
-    [existingPending]
-  );
-
-  const filteredSuggestions = useMemo(() => {
-    if (!macAddress) return [];
-    const query = macAddress.toLowerCase();
-    const selectedNetworkId = networkId ? parseInt(networkId) : null;
-
-    return leases
-      .filter((lease) => {
-        if (lease.device_uuid) return false;
-        if (existingMacs.has(lease.mac_address.toLowerCase())) return false;
-        if (selectedNetworkId !== null && lease.network_id !== selectedNetworkId) return false;
-        if (!lease.mac_address.toLowerCase().startsWith(query)) return false;
-        return true;
-      })
-      .slice(0, 10);
-  }, [macAddress, networkId, leases, existingMacs]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -146,43 +114,19 @@ export default function PendingDeviceNew() {
             </div>
 
             {/* MAC Address */}
-            <div className="relative">
+            <div>
               <label
                 htmlFor="macAddress"
                 className={labelClassName}
               >
                 MAC Address <span className="text-status-broken">*</span>
               </label>
-              <input
-                id="macAddress"
-                type="text"
+              <SeenMacInput
                 value={macAddress}
-                onChange={(e) => { setMacAddress(e.target.value); clearFieldError("mac_address"); }}
-                onFocus={() => { if (macAddress) setShowSuggestions(true); }}
-                onBlur={() => { setTimeout(() => setShowSuggestions(false), 150); }}
-                placeholder="e.g., aa:bb:cc:dd:ee:ff"
-                required
-                aria-invalid={!!getError("mac_address")}
-                autoComplete="off"
-                className={inputClassName}
+                onChange={(m) => { setMacAddress(m); clearFieldError("mac_address"); }}
+                networkId={networkId ? parseInt(networkId) : null}
+                error={getError("mac_address")}
               />
-              <FormFieldError error={getError("mac_address")} />
-              {showSuggestions && filteredSuggestions.length > 0 && (
-                <div className="absolute z-10 w-full bg-bg-surface border border-border mt-1 max-h-48 overflow-y-auto">
-                  {filteredSuggestions.map((lease) => (
-                    <div
-                      key={lease.id}
-                      className="px-3 py-2 text-xs text-text-primary hover:bg-bg-raised cursor-pointer"
-                      onMouseDown={() => {
-                        setMacAddress(lease.mac_address);
-                        setShowSuggestions(false);
-                      }}
-                    >
-                      {lease.mac_address} &mdash; {lease.ip_address}
-                    </div>
-                  ))}
-                </div>
-              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fixes #17 — the "Add Pending Device" form now proactively shows MAC addresses that rack-director has **seen** on the selected network (via DHCP leases) but which aren't yet registered as devices, so operators can pick one instead of memorizing or copy/pasting it.

Previously, candidate MACs only appeared as a *type-to-filter* autocomplete (the list returned nothing until you started typing), so an operator who didn't already know the MAC saw nothing.

## Changes

- **New component** `rack-director-ui/src/components/devices/seen-mac-input.tsx` — a self-contained, controlled MAC combobox that:
  - fetches its own DHCP leases + pending devices on mount (non-fatal on error → manual entry still works)
  - excludes MACs already tied to a device or already registered as pending
  - filters by the selected network and lease **freshness** (only `active`/`offered`, sorted most-recently-seen first)
  - **opens the candidate list on focus even when the field is empty** — the key fix — while typing still narrows the list by prefix
  - shows a contextual empty state ("Select a network…" / "No unregistered MACs seen on this network yet")
- **`PendingDeviceNew.tsx`** — drops the inline suggestion state/logic/markup and renders `<SeenMacInput>`; network loading, validation, submit, and navigation are unchanged.

No backend, API-client, or DB changes: `dhcp_leases` already captures every seen MAC, and `getDhcpLeases()` / `getPendingDevices()` already return what's needed.

## Verification

- `npm run build` (TypeScript + Vite) passes cleanly.
- Manual/e2e browser verification against a running stack (devserver + rack-simulator-seeded leases) has **not** been run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)